### PR TITLE
data: add Modula-2 .def sample

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -4,8 +4,8 @@
 | Metric | Value |
 | ------ | ----- |
 | **Languages** | 215 |
-| **Total samples** | 3335 |
-| **Samples labeled by humans** | 278 |
+| **Total samples** | 3336 |
+| **Samples labeled by humans** | 279 |
 
 ## Per Language
 For each language, the table reports total number of samples (_Samples_) and how many of them have been labeled by a human (_Human_).
@@ -133,7 +133,7 @@ For each language, the table reports total number of samples (_Samples_) and how
 | Markdown | 15 | 7 |
 | Mercury | 9 | 0 |
 | Mirah | 15 | 1 |
-| Modula-2 | 20 | 0 |
+| Modula-2 | 21 | 1 |
 | Modula-3 | 9 | 1 |
 | Monkey | 20 | 0 |
 | NSIS | 20 | 0 |

--- a/data/dataset.yml
+++ b/data/dataset.yml
@@ -6835,6 +6835,11 @@ files:
     annotations:
       linguist: PicoLisp
       vote: PicoLisp
+  github.com/gitGNU/gnu_gm2/e743eb0703328c4f0a1500a9898d7e30deda8147/gcc-versionno/gcc/gm2/gm2-compiler/P1SymBuild.def:
+    annotations:
+      human-smola: Modula-2
+      linguist: Text
+      vote: Modula-2
   github.com/gitbucket/gitbucket/f35ecce3c7b08e9579408252f80674b5b4ae7c43/src/main/scala/gitbucket/core/controller/api/ApiGitReferenceControllerBase.scala:
     annotations:
       linguist: Scala

--- a/data/github.com/gitGNU/gnu_gm2/e743eb0703328c4f0a1500a9898d7e30deda8147/gcc-versionno/gcc/gm2/gm2-compiler/P1SymBuild.def
+++ b/data/github.com/gitGNU/gnu_gm2/e743eb0703328c4f0a1500a9898d7e30deda8147/gcc-versionno/gcc/gm2/gm2-compiler/P1SymBuild.def
@@ -1,0 +1,528 @@
+(* Copyright (C) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009,
+                 2010
+                 Free Software Foundation, Inc. *)
+(* This file is part of GNU Modula-2.
+
+GNU Modula-2 is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+GNU Modula-2 is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License along
+with gm2; see the file COPYING.  If not, write to the Free Software
+Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA. *)
+
+DEFINITION MODULE P1SymBuild ;
+
+(*
+   Title      : P1SymBuild
+   Author     : Gaius Mulley
+   Date       : 24/6/87
+   LastEdit   : Sat Dec  9 11:34:34 EST 1989
+   System     : UNIX (GNU Modula-2)
+   Description: Builds symbol entities, types, constants, variables,
+                procedures, modules and scopes.
+                All procedures are only called during Pass 1.
+*)
+
+EXPORT QUALIFIED P1StartBuildDefinitionModule,
+                 P1EndBuildDefinitionModule,
+                 P1StartBuildImplementationModule,
+                 P1EndBuildImplementationModule,
+                 P1StartBuildProgramModule,
+                 P1EndBuildProgramModule,
+                 StartBuildInnerModule,
+                 EndBuildInnerModule,
+                 BuildImportOuterModule,
+                 BuildExportOuterModule,
+                 BuildImportInnerModule,
+                 BuildExportInnerModule,
+                 StartBuildEnumeration,
+                 EndBuildEnumeration,
+                 BuildHiddenType,
+                 StartBuildProcedure,
+                 EndBuildProcedure,
+                 BuildProcedureHeading,
+                 BuildNulName,
+                 BuildTypeEnd,
+                 CheckExplicitExported ;
+
+
+(*
+   StartBuildDefinitionModule - Creates a definition module and starts
+                                a new scope.
+
+                                The Stack is expected:
+
+                                Entry                 Exit
+
+                         Ptr ->
+                                +------------+
+                                | NameStart  |                       <- Ptr
+                                |------------|        +------------+
+                                | NulName/"C"|        | NameStart  |
+                                |------------|        |------------|
+*)
+
+PROCEDURE P1StartBuildDefinitionModule ;
+
+
+(*
+   EndBuildDefinitionModule - Destroys the definition module scope and
+                              checks for correct name.
+
+                              The Stack is expected:
+
+                              Entry                 Exit
+
+                       Ptr ->
+                              +------------+        +-----------+
+                              | NameEnd    |        |           |
+                              |------------|        |-----------|
+                              | NameStart  |        |           | <- Ptr
+                              |------------|        |-----------|
+*)
+
+PROCEDURE P1EndBuildDefinitionModule ;
+
+
+(*
+   StartBuildImplementationModule - Creates an implementation module and starts
+                                    a new scope.
+
+                                    The Stack is expected:
+
+                                    Entry                 Exit
+
+                             Ptr ->                                     <- Ptr
+                                    +------------+        +-----------+
+                                    | NameStart  |        | NameStart |
+                                    |------------|        |-----------|
+
+*)
+
+PROCEDURE P1StartBuildImplementationModule ;
+
+
+(*
+   EndBuildImplementationModule - Destroys the implementation module scope and
+                                  checks for correct name.
+
+                                  The Stack is expected:
+
+                                  Entry                 Exit
+
+                           Ptr ->
+                                  +------------+        +-----------+
+                                  | NameEnd    |        |           |
+                                  |------------|        |-----------|
+                                  | NameStart  |        |           | <- Ptr
+                                  |------------|        |-----------|
+*)
+
+PROCEDURE P1EndBuildImplementationModule ;
+
+
+(*
+   StartBuildProgramModule - Creates a program module and starts
+                             a new scope.
+
+                             The Stack is expected:
+
+                             Entry                 Exit
+
+                      Ptr ->                                     <- Ptr
+                             +------------+        +-----------+
+                             | NameStart  |        | NameStart |
+                             |------------|        |-----------|
+
+*)
+
+PROCEDURE P1StartBuildProgramModule ;
+
+
+(*
+   EndBuildProgramModule - Destroys the program module scope and
+                           checks for correct name.
+
+                           The Stack is expected:
+
+                           Entry                 Exit
+
+                    Ptr ->
+                           +------------+        +-----------+
+                           | NameEnd    |        |           |
+                           |------------|        |-----------|
+                           | NameStart  |        |           | <- Ptr
+                           |------------|        |-----------|
+*)
+
+PROCEDURE P1EndBuildProgramModule ;
+
+
+(*
+   StartBuildInnerModule - Creates an Inner module and starts
+                           a new scope.
+
+                           The Stack is expected:
+
+                           Entry                 Exit
+
+                    Ptr ->                                     <- Ptr
+                           +------------+        +-----------+
+                           | NameStart  |        | NameStart |
+                           |------------|        |-----------|
+
+*)
+
+PROCEDURE StartBuildInnerModule ;
+
+
+(*
+   EndBuildInnermModule - Destroys the Inner module scope and
+                          checks for correct name.
+
+                          The Stack is expected:
+
+                          Entry                 Exit
+
+                   Ptr ->
+                          +------------+        +-----------+
+                          | NameEnd    |        |           |
+                          |------------|        |-----------|
+                          | NameStart  |        |           | <- Ptr
+                          |------------|        |-----------|
+*)
+
+PROCEDURE EndBuildInnerModule ;
+
+
+(*
+   BuildImportOuterModule - Builds imported identifiers into an outer module
+                            from a definition module.
+
+                            The Stack is expected:
+
+                            Entry           OR    Entry
+
+                     Ptr ->                Ptr ->
+                            +------------+        +-----------+
+                            | #          |        | #         |
+                            |------------|        |-----------|
+                            | Id1        |        | Id1       |
+                            |------------|        |-----------|
+                            .            .        .           .
+                            .            .        .           .
+                            .            .        .           .
+                            |------------|        |-----------|
+                            | Id#        |        | Id#       |
+                            |------------|        |-----------|
+                            | ImportTok  |        | Ident     |
+                            |------------|        |-----------|
+
+                            IMPORT Id1, .. Id# ;  FROM Ident IMPORT Id1 .. Id# ;
+
+
+                                                  Error Condition
+                            Exit
+
+                            All above stack discarded
+*)
+
+PROCEDURE BuildImportOuterModule (definition: BOOLEAN) ;
+
+
+(*
+   BuildExportOuterModule - Builds exported identifiers from an outer module
+                            to the outside world of library modules.
+
+                            The Stack is expected:
+
+                            Entry           OR    Entry
+
+                     Ptr ->                Ptr ->
+                            +------------+        +--------------+
+                            | #          |        | #            |
+                            |------------|        |--------------|
+                            | Id1        |        | Id1          |
+                            |------------|        |--------------|
+                            .            .        .              .
+                            .            .        .              .
+                            .            .        .              .
+                            |------------|        |--------------|
+                            | Id#        |        | Id#          |
+                            |------------|        |--------------|
+                            | ExportTok  |        | QualifiedTok |
+                            |------------|        |--------------|
+
+                            EXPORT Id1, .. Id# ;  EXPORT QUALIFIED Id1 .. Id# ;
+
+                            Error Condition
+
+
+                            Exit
+
+                            All above stack discarded
+*)
+
+PROCEDURE BuildExportOuterModule ;
+
+
+(*
+   CheckExplicitExported - checks to see whether we are compiling
+                           a definition module and whether the ident
+                           is implicitly export qualified or unqualified.
+
+
+                           The Stack is expected:
+
+                           Entry                 Exit
+
+                    Ptr ->                Ptr ->
+                           +------------+        +-----------+
+                           | Identname  |        | Identname |
+                           |------------|        |-----------|
+ 
+*)
+
+PROCEDURE CheckExplicitExported ;
+
+
+(*
+   BuildImportInnerModule - Builds imported identifiers into an inner module
+                            from the last level of module.
+
+                            The Stack is expected:
+
+                            Entry           OR    Entry
+
+                     Ptr ->                Ptr ->
+                            +------------+        +-----------+
+                            | #          |        | #         |
+                            |------------|        |-----------|
+                            | Id1        |        | Id1       |
+                            |------------|        |-----------|
+                            .            .        .           .
+                            .            .        .           .
+                            .            .        .           .
+                            |------------|        |-----------|
+                            | Id#        |        | Id#       |
+                            |------------|        |-----------|
+                            | ImportTok  |        | Ident     |
+                            |------------|        |-----------|
+
+                            IMPORT Id1, .. Id# ;  FROM Ident IMPORT Id1 .. Id# ;
+
+
+                                                  Error Condition
+                            Exit
+
+                            All above stack discarded
+*)
+
+PROCEDURE BuildImportInnerModule ;
+
+
+(*
+   BuildExportInnerModule - Builds exported identifiers from an inner module
+                            to the next layer module.
+
+                            The Stack is expected:
+
+                            Entry           OR    Entry
+
+                     Ptr ->                Ptr ->
+                            +------------+        +--------------+
+                            | #          |        | #            |
+                            |------------|        |--------------|
+                            | Id1        |        | Id1          |
+                            |------------|        |--------------|
+                            .            .        .              .
+                            .            .        .              .
+                            .            .        .              .
+                            |------------|        |--------------|
+                            | Id#        |        | Id#          |
+                            |------------|        |--------------|
+                            | ExportTok  |        | QualifiedTok |
+                            |------------|        |--------------|
+
+                            EXPORT Id1, .. Id# ;  EXPORT QUALIFIED Id1 .. Id# ;
+
+
+                            Exit
+
+                            All above stack discarded
+*)
+
+PROCEDURE BuildExportInnerModule ;
+
+
+(*
+   StartBuildEnumeration - Builds an Enumeration type Type.
+
+
+                           Stack
+
+                           Entry                 Exit
+
+                    Ptr ->
+                           +------------+
+                           | #          |
+                           |------------|
+                           | en 1       |
+                           |------------|
+                           | en 2       |
+                           |------------|
+                           .            .
+                           .            .
+                           .            .                       <- Ptr
+                           |------------|        +------------+
+                           | en #       |        | Type       |
+                           |------------|        |------------|
+                           | Name       |        | Name       |
+                           |------------|        |------------|
+*)
+
+PROCEDURE StartBuildEnumeration ;
+
+
+(*
+   EndBuildEnumeration - completes the construction of the enumeration type.
+
+
+                         Stack
+
+                         Entry                 Exit
+
+                  Ptr ->
+                         +------------+
+                         | Type       |                          <- Ptr
+                         |------------|        +---------------+
+                         | Name       |        | Type  | Name  |
+                         |------------|        |---------------|
+          
+                                               Empty
+*)
+
+PROCEDURE EndBuildEnumeration ;
+
+
+(*
+   BuildHiddenType - Builds a Hidden Type.
+
+
+                     Stack
+
+                     Entry                 Exit
+
+              Ptr ->
+                     +------------+
+                     | Name       |                          <- Ptr
+                     |------------|        Empty
+*)
+
+PROCEDURE BuildHiddenType ;
+
+
+(*
+   StartBuildProcedure - Builds a Procedure.
+
+                         The Stack:
+
+                         Entry                 Exit
+
+                                                              <- Ptr
+                                               +------------+
+                  Ptr ->                       | ProcSym    |
+                         +------------+        |------------|
+                         | Name       |        | Name       |
+                         |------------|        |------------|
+*)
+
+PROCEDURE StartBuildProcedure ;
+
+
+(*
+   EndBuildProcedure - Ends building a Procedure.
+                       It checks the start procedure name matches the end
+                       procedure name.
+
+                       The Stack:
+
+
+                       Entry                 Exit
+
+                Ptr ->
+                       +------------+
+                       | NameEnd    |
+                       |------------|
+                       | ProcSym    |
+                       |------------|
+                       | NameStart  |
+                       |------------|
+                                             Empty
+*)
+
+PROCEDURE EndBuildProcedure ;
+
+
+(*
+   BuildProcedureHeading - Builds a procedure heading for the definition
+                           module procedures.
+
+                           Operation only performed if compiling a
+                           definition module.
+
+                           The Stack:
+
+                           Entry                       Exit
+
+                    Ptr ->
+                           +------------+
+                           | ProcSym    |              Empty
+                           |------------|
+
+*)
+
+PROCEDURE BuildProcedureHeading ;
+
+
+(*
+   BuildNulName - Pushes a NulKey onto the top of the stack.
+                  The Stack:
+
+
+                  Entry                    Exit
+
+                                                          <- Ptr
+                  Empty                    +------------+
+                                           | NulKey     |
+                                           |------------|
+*)
+
+PROCEDURE BuildNulName ;
+
+
+(*
+   BuildTypeEnd - Pops the type Type and Name.
+                  The Stack:
+
+
+                  Entry                    Exit
+
+
+           Ptr ->
+                  +-------------+
+                  | Type | Name |          Empty
+                  |-------------|
+*)
+
+PROCEDURE BuildTypeEnd ;
+
+
+END P1SymBuild.


### PR DESCRIPTION
* No Modula-2 definition module was present, since linguist does not
recognize .def extension.
* From https://github.com/gitGNU/gnu_gm2/blob/master/gcc-versionno/gcc/gm2/gm2-compiler/P1SymBuild.def
* Found with GitHub query: extension:def "definition module"

Identified from https://github.com/github/linguist/pull/4629