### PR TITLE
tools: use git:// protocol to fetch repos

### DIFF
--- a/tools/common.py
+++ b/tools/common.py
@@ -125,7 +125,7 @@ def clone_tmp_repo(repo, commit=None):
     if os.path.exists(os.path.join(tmp_dir, ".git")):
         return tmp_dir
     os.makedirs(tmp_dir, exist_ok=True)
-    url = "https://github.com/%s.git" % repo
+    url = "git://github.com/%s.git" % repo
     if commit:
         subprocess.run(
             "git clone --no-progress --single-branch %s %s" % (url, tmp_dir),


### PR DESCRIPTION
git:// won't bother with auth requests when a repo does not exist.