### PR TITLE
Refine labels with linguist strategies

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -3,9 +3,9 @@
 
 | Metric | Value |
 | ------ | ----- |
-| **Languages** | 247 |
-| **Total samples** | 3825 |
-| **Samples labeled by humans** | 486 |
+| **Languages** | 250 |
+| **Total samples** | 3792 |
+| **Samples labeled by humans** | 505 |
 
 ## Per Language
 For each language, the table reports total number of samples (_Samples_) and how many of them have been labeled by a human (_Human_).
@@ -22,7 +22,7 @@ For each language, the table reports total number of samples (_Samples_) and how
 | ATS | 20 | 2 |
 | ActionScript | 20 | 0 |
 | Ada | 20 | 20 |
-| Agda | 20 | 0 |
+| Agda | 18 | 0 |
 | Alloy | 19 | 0 |
 | AngelScript | 3 | 0 |
 | Apex | 20 | 1 |
@@ -62,8 +62,8 @@ For each language, the table reports total number of samples (_Samples_) and how
 | Clean | 9 | 9 |
 | Clojure | 19 | 2 |
 | CoffeeScript | 19 | 3 |
-| ColdFusion | 13 | 2 |
-| ColdFusion CFC | 7 | 7 |
+| ColdFusion | 12 | 2 |
+| ColdFusion CFC | 8 | 8 |
 | Common Lisp | 14 | 10 |
 | Common Workflow Language | 16 | 0 |
 | Component Pascal | 1 | 0 |
@@ -90,8 +90,8 @@ For each language, the table reports total number of samples (_Samples_) and how
 | Factor | 19 | 0 |
 | Fancy | 16 | 1 |
 | Fantom | 20 | 0 |
-| Forth | 19 | 1 |
-| Fortran | 20 | 3 |
+| Forth | 19 | 2 |
+| Fortran | 20 | 5 |
 | FreeMarker | 18 | 2 |
 | Frege | 17 | 1 |
 | G-code | 1 | 1 |
@@ -103,7 +103,7 @@ For each language, the table reports total number of samples (_Samples_) and how
 | Gnuplot | 9 | 1 |
 | Go | 22 | 4 |
 | Golo | 20 | 0 |
-| Gosu | 8 | 0 |
+| Gosu | 6 | 0 |
 | Grace | 20 | 1 |
 | Groovy | 20 | 1 |
 | HTML | 4 | 4 |
@@ -127,6 +127,7 @@ For each language, the table reports total number of samples (_Samples_) and how
 | JavaScript | 20 | 5 |
 | Jsonnet | 20 | 0 |
 | Julia | 18 | 0 |
+| Jupyter Notebook | 1 | 1 |
 | KiCad Layout | 2 | 2 |
 | Kit | 19 | 1 |
 | Kotlin | 20 | 1 |
@@ -139,11 +140,12 @@ For each language, the table reports total number of samples (_Samples_) and how
 | Lasso | 9 | 2 |
 | Limbo | 17 | 0 |
 | Liquid | 20 | 3 |
+| Literate Agda | 1 | 1 |
 | Literate CoffeeScript | 1 | 1 |
 | LiveScript | 20 | 2 |
 | Logtalk | 20 | 1 |
 | Lua | 20 | 2 |
-| M4 | 16 | 3 |
+| M4 | 13 | 3 |
 | MATLAB | 23 | 16 |
 | MAXScript | 17 | 0 |
 | Makefile | 17 | 1 |
@@ -162,7 +164,7 @@ For each language, the table reports total number of samples (_Samples_) and how
 | Nim | 20 | 0 |
 | Nit | 19 | 0 |
 | Nix | 18 | 0 |
-| OCaml | 17 | 2 |
+| OCaml | 14 | 2 |
 | Objective-C | 20 | 2 |
 | Opa | 19 | 0 |
 | Opal | 3 | 0 |
@@ -171,8 +173,8 @@ For each language, the table reports total number of samples (_Samples_) and how
 | Oxygene | 1 | 0 |
 | Oz | 20 | 1 |
 | PHP | 21 | 3 |
-| PL/SQL | 15 | 10 |
-| PL/pgSQL | 15 | 5 |
+| PL/SQL | 13 | 11 |
+| PL/pgSQL | 13 | 5 |
 | POV-Ray SDL | 2 | 0 |
 | Pascal | 20 | 1 |
 | Perl | 20 | 3 |
@@ -184,9 +186,9 @@ For each language, the table reports total number of samples (_Samples_) and how
 | PowerShell | 17 | 2 |
 | Processing | 20 | 2 |
 | Prolog | 17 | 4 |
-| PureBasic | 9 | 0 |
+| PureBasic | 8 | 0 |
 | PureScript | 20 | 0 |
-| Python | 22 | 3 |
+| Python | 21 | 3 |
 | QML | 19 | 2 |
 | QMake | 20 | 1 |
 | R | 21 | 2 |
@@ -196,17 +198,17 @@ For each language, the table reports total number of samples (_Samples_) and how
 | Ragel | 17 | 0 |
 | Raku | 11 | 9 |
 | Rascal | 20 | 0 |
-| Reason | 2 | 2 |
+| Reason | 3 | 3 |
 | Rebol | 18 | 7 |
 | Red | 18 | 1 |
-| RenderScript | 15 | 1 |
+| RenderScript | 4 | 1 |
 | Ring | 20 | 0 |
 | Roff | 1 | 1 |
 | Ruby | 20 | 3 |
 | Rust | 23 | 4 |
 | SAS | 20 | 4 |
-| SQL | 10 | 8 |
-| SQLPL | 15 | 0 |
+| SQL | 12 | 11 |
+| SQLPL | 1 | 1 |
 | SVG | 2 | 0 |
 | Scala | 20 | 3 |
 | Scheme | 21 | 21 |
@@ -222,13 +224,14 @@ For each language, the table reports total number of samples (_Samples_) and how
 | Swift | 19 | 1 |
 | SystemVerilog | 19 | 9 |
 | TLA | 20 | 0 |
-| TSQL | 3 | 3 |
+| TSQL | 5 | 5 |
+| TSX | 1 | 1 |
 | TXL | 18 | 0 |
 | Tcl | 18 | 3 |
 | Terra | 7 | 0 |
 | Text | 1 | 1 |
 | Turing | 8 | 0 |
-| TypeScript | 20 | 4 |
+| TypeScript | 18 | 4 |
 | Unix Assembly | 4 | 4 |
 | V | 18 | 2 |
 | VHDL | 16 | 2 |
@@ -242,7 +245,7 @@ For each language, the table reports total number of samples (_Samples_) and how
 | Wolfram Language | 10 | 2 |
 | Wollok | 20 | 0 |
 | XC | 20 | 0 |
-| XML | 12 | 12 |
+| XML | 16 | 16 |
 | XProc | 17 | 0 |
 | XQuery | 20 | 3 |
 | XS | 14 | 1 |
@@ -257,5 +260,5 @@ For each language, the table reports total number of samples (_Samples_) and how
 | ooc | 19 | 1 |
 | q | 15 | 2 |
 | reStructuredText | 1 | 1 |
-| sed | 11 | 1 |
+| sed | 9 | 1 |
 | xBase | 14 | 9 |

--- a/data/dataset.yml
+++ b/data/dataset.yml
@@ -2,48 +2,59 @@ files:
   github.com/0sara0/tests/6ae9de579f662df2c6bb32d972d23f789f4d0cbb/cutomers-tests/login.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/0sara0/webDevelop/b669729e92ea9c7ea31c6d5b9bfbb9b56c2cdcba/quran-project/CRUD_MVC.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/0xd4d/dnSpy/af178fba50fb224e682c637f1aacdcf03083ddcc/dnSpy/dnSpy/Output/OutputBufferVM.cs:
     annotations:
       linguist: C#
+      linguist-heuristics: C#
       vote: C#
   github.com/0xxon/perl-nss/acb817194a17e02894b726077dcbea35a83531be/X509.xs:
     annotations:
       linguist: XS
+      linguist-extension: XS
       vote: XS
   github.com/1DSAG/ATC-Best-Practice-Guide/ef9526c5f2e503576675195aa35fe99404bee142/src/zcl_ci_test_comp_procs.clas.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/2d-inc/developer_quest/26ab6ddbc2463e570267bc6a820938e700577e6d/lib/src/shared_state/game/task_tree/backend_infrastructure.dart:
     annotations:
       human-smola: Dart
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/3dgen/cppwasm-book/f22f25b627a8eadfb62f9d80958b545415bc23c0/server.go:
     annotations:
       human-smola: Go
       linguist: WebAssembly
+      linguist-extension: Go
       vote: Go
   github.com/3r1k0n/LOLCODEshenanigans/0c3bb1435f937ed7db539dd5f2b3adf92a99fa69/ROCKPAPERMEOW.lol:
     annotations:
       linguist: LOLCODE
+      linguist-extension: LOLCODE
       vote: LOLCODE
   github.com/411Hall/JAWS/73f968da77c2dae3613854ec3f03f53e95982629/jaws-enum.ps1:
     annotations:
       linguist: PowerShell
+      linguist-extension: PowerShell
       vote: PowerShell
   github.com/4dn-dcic/pipelines-cwl/46dbd4c38119ef8a2d00b44678e45dafd430f5fa/cwl_awsem_v1/addfragtopairs.cwl:
     annotations:
       linguist: Common Workflow Language
+      linguist-extension: Common Workflow Language
       vote: Common Workflow Language
   github.com/6dreams/stream-reader/e5757aa4ed54923aecbb94d7a57322246d92f94c/sixdreams/StreamReader/XmlStreamReader.zep:
     annotations:
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/8l/bcpl/bad6eec7682368ca7ded866005cc4a47e8a67569/cintcode/com/type.b:
     annotations:
@@ -53,158 +64,197 @@ files:
   github.com/8l/pilos/61708530eb721d918944050663f59c6050de333b/lib/init.l:
     annotations:
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
       vote: PicoLisp
   github.com/996icu/996.ICU/19c6d18efb52b6bf12c34f2893c9bafad9e66ebb/archived/licenses[WIP]/tools/test-gen-license/src/lib.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/99fk/Bat-To-Exe-Converter-Downloader/a3b00ae1b0c822bdaa72b58d92c25f7d1d3dcaad/Bat_To_Exe_Converter_Downloader.pb:
     annotations:
       linguist: PureBasic
+      linguist-extension: PureBasic
       vote: PureBasic
   github.com/ADN-DevTech/3dsMax-MCG-Samples/820d8a32badf916849282081ca42416a88d2f6b7/Tools/Sample Deformers/Stretch MCG.ms:
     annotations:
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: MAXScript
   github.com/AFNetworking/AFNetworking/5cf601ce0cbdd758da4b31d85a49514219a1faf8/UIKit+AFNetworking/UIRefreshControl+AFNetworking.h:
     annotations:
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/AJMartel/IRTriage/edfc35dde062c32bd4e03deb821c88ed6fc65d83/Compile/Tools/Updater/My_Github_Updates_Calculator.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/ALaDyn/gnuplots/66a3b1d0be6272c0d86d21cc75d68f3f956e1735/multi-density.gnuplot:
     annotations:
       linguist: Gnuplot
+      linguist-extension: Gnuplot
+      linguist-shebang: Gnuplot
       vote: Gnuplot
   github.com/ANSSI-FR/FreeSpec/26c3740435884659acd7bfdb48a536bd1d0cde09/core/theories/Program.v:
     annotations:
       linguist: Coq
+      linguist-heuristics: Coq
       vote: Coq
   github.com/APEXCalculus/APEXCalculusPTX/913b6aee0033e0bd48379aea304f26c6e33b64d9/figures/fig14_05_ex_11_3DBW.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/AVsitter/AVsitter/af4de9c6bfcaaf73e4bc696e68351963834847d4/AVsitter1/AVselect.lsl:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
       vote: LSL
   github.com/AbsInt/CompCert/029329c8adc955d9ebe9030074cce0df9dcfa5f7/MenhirLib/Interpreter_correct.v:
     annotations:
       linguist: Coq
+      linguist-heuristics: Coq
       vote: Coq
   github.com/Abscissa/SDLang-D/73df77aa35944b8c22181d1badb0927fa4d5215b/example.d:
     annotations:
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/Abscissa/scriptlike/e3a8523c640d089637ab0f3133c7656c14ba4c61/src/scriptlike/file/extras.d:
     annotations:
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/AcroMace/brainfoge/11567b7923ad48ee3b810b011ac36f93c7fb803a/brainfoge.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/Actinium-project/ln-plugin-m3/c9b5c8d1d1e06f3b91f9fee3e403103194a276e1/LNPlugin.m3:
     annotations:
       human-smola: Modula-3
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Modula-3
   github.com/AdaCore/Ada_Drivers_Library/b1b3d1dfe2756e43a2eceb667d242f0f82e65dd3/boards/stm32_common/common/stm32-user_button.adb:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/AdaCore/bb-runtimes/fe68b80e712fc00381f7902b7fd6045e4929b895/arm/tms570/board_init.adb:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/AdaCore/gprbuild/a10ee080de8e4ca0db9d4cb98d434b9307afccaf/gpr/src/gpr.adb:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/AdaDoom3/AdaDoom3/544097548e80e4ce20a608da473411f1ebec18f6/Engine/neo-core-math.ads:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/AdamSpitz/klein/b9f0d4a87313f261183eed73c9f383b7f4a39607/objects/applications/asmKit/asmFrame/asmFrameAbsGen.self:
     annotations:
       linguist: Self
+      linguist-extension: Self
       vote: Self
   github.com/Adams123/OrgArquivos/44e237ded68ac94b146e0224c8d0b4b237db12b8/T2/T2/dragon.rl:
     annotations:
       human-smola: Unknown
       linguist: Ragel
+      linguist-extension: Ragel
       vote: Unknown
   github.com/Adobe-Marketing-Cloud/media-sdks/952c7edb25ef9b7cfe9ed3b089a79d0eb5552698/sdks/roku/samples/adoberokudemo/source/sampleAdobeFeed.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/Akagi201/learning-cmake/a3b8b104ab16db6c9e515f22b6bdbcd69ce5c3e6/hello-world-lib/src/CMakeLists.txt:
     annotations:
       linguist: CMake
+      linguist-filename: CMake
+      linguist-heuristics: Text
       vote: CMake
   github.com/AlDanial/cloc/8615300542fcd84a779a982043d93b7defe3f3fb/Unix/t/02_git.t:
     annotations:
       linguist: Perl
+      linguist-heuristics: Perl
       vote: Perl
   github.com/Alamofire/Alamofire/2cbf59935fbb1f26e352ce4db53f1cf9408d5313/Tests/ResponseTests.swift:
     annotations:
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/AlanTupper/BlockIO-LSL/9e3eba42a64aefc376f2f023f46f54c5b0576960/blockio.lsl:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
       vote: LSL
   github.com/AlaskanEmily/transunit/865e339a6fca16c69f61781378c5187a8b182789/transunit.compare.m:
     annotations:
       linguist: Mercury
+      linguist-heuristics: Mercury
       vote: Mercury
   github.com/Alecaddd/sequeler/e025929f03dac400db74865405a53761cfd2b146/src/Services/Types/MySQL.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/Alekaei/postfix.lol/bc736d5e07359956d1a75e8a8297755c8a1ce521/postfix.lol:
     annotations:
       linguist: LOLCODE
+      linguist-extension: LOLCODE
       vote: LOLCODE
   github.com/AlexKimov/HardTruck-RignRoll-file-formats/4b4b48a9f18359cfc5f4fec23c3091200f49d002/scripts/3dsmax/builds/raw_export.ms:
     annotations:
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: MAXScript
   github.com/AlexMckey/Louv1.1x-PoCP-F_Oz/dc7a2d1368794db7933c48955809d72b1e7e4892/Stak_Queue.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/AlexPoulsen/Kitten/3b8f82fbef468420a388e2bc9b6d0a661aacc9fd/src/arguments/handler.kit:
     annotations:
       human-smola: Kit
       linguist: Kit
+      linguist-extension: Kit
       vote: Kit
   github.com/AlexPoulsen/rogue/31490146b0c585f26b88af5e09227bd2c6641eb8/src/mapchar.kit:
     annotations:
       linguist: Kit
+      linguist-extension: Kit
       vote: Kit
   github.com/AlexPoulsen/string-builder/d5734b8114b9d512a559b8b30e5074f90b32edbf/src/xs_Rounding.kit:
     annotations:
       linguist: Kit
+      linguist-extension: Kit
       vote: Kit
   github.com/AlexTheMagnus/GEMS/7914d48489edb5d89a2c0d5d958eda6fcfe94f5f/code/GEMS.clp:
     annotations:
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: CLIPS
   github.com/AlexanderNaehring/TPFMM/0dcc2f7efadbbd0dec63c4ab27a2363027277a20/source/dialogs/dialogTester.pb:
     annotations:
       linguist: PureBasic
+      linguist-extension: PureBasic
       vote: PureBasic
   github.com/AlgorexHealth/hcc-python/807b5be06741e4a74cac23342425fa1f20bfef11/CMS-sas/F211690R.ICD9.SAS:
     annotations:
       human-smola: SAS
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/All-World/ZTE-channel-estimate-competition2019/8cd17e547a60757be7b8ca9bd66071f7ad5168db/ZTEcode/DATA111.m:
     annotations:
@@ -214,6 +264,7 @@ files:
   github.com/AllenDowney/ThinkPython/f026fb2b2deff279502f276b8a65532115db8f5a/book/figs/lumpydemo3.eps:
     annotations:
       linguist: PostScript
+      linguist-extension: PostScript
       vote: PostScript
   github.com/Allensmile/cs229_MachineLearning_AndrewNg_Coursera/4af5b0eb4acae65e63a6783aadd0020c48398534/MLMaterial/ListsTXT/list_Kannada_Fnt.m:
     annotations:
@@ -224,53 +275,67 @@ files:
     annotations:
       human-smola: INI
       linguist: Clarion
+      linguist-extension: Clarion
       vote: INI
   github.com/Altium-Designer-addons/scripts-libraries/9c9e259f9543a78ae498fa93320018c24b725032/FilterObjects/FilterObjects.pas:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/AmnonOwed/CAN_GenerativeTypography/1434a3de31dbf0077bcc1299f3d6db7f55e0906d/3D/Basic3DType/Basic3DType.pde:
     annotations:
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/AnEmortalKid/such-interview/d05dc4854d00c079403a00133386c87d2a7ce358/cards.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/Ana06/AI/2e94a2bb64536a7db3237399bd196c3315541035/Travel recommender - Jess/TravelRecommendation.clp:
     annotations:
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: CLIPS
   github.com/AndreaCrotti/yasnippet-snippets/2cc5f35cd43941175981c8774debc8303d90c101/snippets/swift-mode/uiviewcontrollerlifecycle:
     annotations:
       linguist: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/AndrewD2/DragonAGE/efe16a6e517bc8bf8ef4f3327dd8e43f8f68800c/system_resources.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
+      linguist-xml: XML
       vote: Augeas
   github.com/AndroidKnife/proguard-config/02fae4f4399893cc82bfe8580114b70160ef73e7/proguardlib/proguards/proguard-aws-1.7.pro:
     annotations:
       human-smola: Unknown
       linguist: IDL
+      linguist-heuristics: Proguard
       vote: Unknown
   github.com/AndyDentFree/rb2doxy/6229f1a9804d44ed078c2769410cc219265d839c/RunRB2Doxy/MessageDialogHelpers.rbbas:
     annotations:
       human-smola: REALbasic
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/Anniepoo/foxesandrabbits/b576f502beac7b94a28a8c517072bda49ddbac51/field.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/Anniepoo/prolog-examples/a359d15d20a79fb707e91b9265005ad781c5b69c/pirates/demo.pl:
     annotations:
       human-smola: Prolog
       linguist: Prolog
+      linguist-heuristics: Prolog
       vote: Prolog
   github.com/Anvil/bash-doxygen/94094df8620d8da7e90d5477034b0356d3ef05e3/doxygen-bash.sed:
     annotations:
       linguist: sed
+      linguist-extension: sed
+      linguist-shebang: sed
       vote: sed
   github.com/ApacheThunder/bfheroes42/9552615e0ffe6212a8d2cf5269bd906ed8586a6d/bf1942/levels/City_of_Aegean/StandardMesh/City_Scenery01_m1.rs:
     annotations:
@@ -280,44 +345,54 @@ files:
     annotations:
       human-smola: TSQL
       linguist: PL/SQL
+      linguist-heuristics: TSQL
       vote: TSQL
   github.com/App-vNext/Polly/793eb8edac13fbdefc78978ed738481bdea1270d/src/Polly/Context.Dictionary.cs:
     annotations:
       linguist: C#
+      linguist-heuristics: C#
       vote: C#
   github.com/ApplexusLabs/aws-sap-from-lambda/0492df095b29662d6a7398efe2e5cb54dfac6930/src/abap/_get_stock.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/Apress/beg-cobol-for-programmers/3d2656fadd3cd3534beab8e00f85fe96ac41f5c2/978-1-4302-6253-4_Coughlan_Ch15/Listing15-6.cbl:
     annotations:
       linguist: COBOL
+      linguist-extension: COBOL
       vote: COBOL
   github.com/Apress/practical-tla-plus/1afed6f8c95bf921adc948d23d4260d9cd300724/Chapter 1/wire.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/AquaQAnalytics/TorQ-Finance-Starter-Pack/9f06d513174cd8c34c6fda77b1a95389b11f7279/code/processes/metrics.q:
     annotations:
       linguist: q
+      linguist-heuristics: q
       vote: q
   github.com/AquaQAnalytics/TorQ/21ab087be432e55d64ae12127b28907175c4767d/code/common/compress.q:
     annotations:
       linguist: q
+      linguist-heuristics: q
       vote: q
   github.com/AquaQAnalytics/kdb-utilities/509637fe65b3cc1df28725eb4abfed84a2ad3554/q-doc/qdoc/q-doc-type.q:
     annotations:
       linguist: q
+      linguist-heuristics: q
       vote: q
   github.com/Archinamon/AndroidAspectJExample/ec3a40603f24c361e04c976a57fabe9394d7b8e3/libAjProfiler/src/main/aspectj/com/archinamon/profiler/core/AnnotationProfiler.aj:
     annotations:
       human-smola: AspectJ
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/ArctosDB/arctos/7092c8a896e70318abdf84fd7ae402d1508e7c6c/fix/test.cfm:
     annotations:
       human-smola: ColdFusion
       linguist: ColdFusion
+      linguist-extension: ColdFusion
       vote: ColdFusion
   github.com/ArkArk/15puzzle-brainfuck/2f0ad206215bac1af7082d098e9972217263bf3f/src/15puzzle.bf:
     annotations:
@@ -326,51 +401,63 @@ files:
   github.com/ArminMaj/Mule4FundementalExamTraining/222aab8e358af94c83d787dbd967adfc3bba9e71/src/test/resources/sample_data/object.dwl:
     annotations:
       linguist: DataWeave
+      linguist-extension: DataWeave
       vote: DataWeave
   github.com/ArztSamuel/Applying_EANNs/1f48f6d0f10a084673c8d7181ffabf49073e4fa3/Build/Applying EANNs_Data/Mono/etc/mono/1.0/DefaultWsdlHelpGenerator.aspx:
     annotations:
       linguist: ASP.NET
+      linguist-extension: ASP.NET
       vote: ASP.NET
   github.com/Asana/kraken/263ff701fe20d692ededb250c6003f5b8b806783/src/kraken_ctl.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
       vote: Erlang
   github.com/AssemblyScript/assemblyscript/15bb724ba956ebb5ccd4bb55763f782f1b0814aa/tests/compiler/features/threads.untouched.wat:
     annotations:
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/Astro-SMG/calc_mags/f08426a0831601f1c240e0b99d72d80c758b0400/vega_sed/A0V_KURUCZ_92.SED:
     annotations:
       human-smola: Unknown
       linguist: sed
+      linguist-extension: sed
       vote: Unknown
   github.com/Atraci/Atraci/d3fd00622f5f2e6c5d402c7a1ef2cd693f35e9ca/coffee/_trackSource.coffee:
     annotations:
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/Aurorastation/Aurora.3/00f6edb06c3e62c42b3e1ef9e38a8acd6be677cf/code/datums/trading/unique.dm:
     annotations:
       linguist: DM
+      linguist-extension: DM
       vote: DM
   "github.com/AweiLoveAndroid/The-pit-of-the-Android-Studio/68fd58ec7b4d7fc8cef8d296c38de9e46ab87877/\u5907\u4EFD/build.gradle.ftl":
     annotations:
       linguist: FreeMarker
+      linguist-extension: FreeMarker
       vote: FreeMarker
   github.com/Axford/OpenSCADMachineDesignFramework/80155e0104bb3a6d1c89bfaefa58766e24e21961/utils/surfacesolids/Renderer.scad:
     annotations:
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/Azq2/perl-html5-dom/30c19ca6e3ae15afcfa5997ab3b3bbc5951ad6f3/DOM.xs:
     annotations:
       linguist: XS
+      linguist-extension: XS
       vote: XS
   github.com/Azure/azure-cosmos-tla/f3230bc9b717bb405ddfb9bfc005dcbd7c1aee4a/general-model/cosmos_client.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/Azure/azure-quickstart-templates/2b32553b7f02b74c40e8fa1fb4ed45d45695df38/oms-azure-vminventory-solution/scripts/AzureVMInventory-MS-Mgmt.ps1:
     annotations:
       linguist: PowerShell
+      linguist-extension: PowerShell
       vote: PowerShell
   github.com/Azure/ccodashboard/9740e2fc9f26ac4490d7a5fd7523abe0ac2a67d6/queries/AKS.m:
     annotations:
@@ -380,35 +467,45 @@ files:
   github.com/BEEmod/BEE2-items/f2955185f09645db6c4cdf8b7962e1b8f7dd85bb/packages/valve/clean_style/resources/scripts/vscripts/BEE2/video_splitter_rand.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/BEEmod/BEE2.2-Resources/51414026cf8bf307bbc4cfd67afcede4878f0132/portal 2/portal2_dlc2/scripts/vscripts/fg/braid_platform.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/BGCX261/zigbee-alloy-svn-to-git/020bdb6a648a547e6bf1476533b602c4badaf82a/trunk/mac/orphan_indication.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/BSData/malifaux/e9d860dd6427a776b5f5fcd367d5d42c31f54083/Malifaux.gst:
     annotations:
+      human-smola: XML
       linguist: Gosu
-      vote: Gosu
+      linguist-xml: XML
+      vote: XML
   github.com/BSData/wh40k-heralds-of-ruin/adc97aabbfc3201a851635b3c1c08c8c2977289f/Warhammer 40,000 Heralds of Ruin 8th Edition.gst:
     annotations:
+      human-smola: XML
       linguist: Gosu
-      vote: Gosu
+      linguist-xml: XML
+      vote: XML
   github.com/BVLC/caffe/04ab089db018a292ae48d51732dd6c66766b36b6/src/caffe/layers/swish_layer.cpp:
     annotations:
       linguist: C++
+      linguist-extension: C++
       vote: C++
   github.com/BYVoid/Batsh/4e3fa5ffa990fcca8242737c1081f368f68ee6c5/src/bash_compile.ml:
     annotations:
       linguist: OCaml
+      linguist-heuristics: OCaml
       vote: OCaml
   github.com/BackupTheBerlios/busybe-svn/a9cf98b6ba3b8f85a08a2b8082bbac78370b6875/tags/0.8/sample_templates/search_noed_nodel.kid:
     annotations:
       human-smola: Genshi
       linguist: Genshi
+      linguist-extension: Genshi
       vote: Genshi
   github.com/BackupTheBerlios/radartools-svn/0f60b8b07a758e31360269a93e3a0d50efc28d2a/branches/0.21/io/import_info_ramses.pro:
     annotations:
@@ -417,6 +514,8 @@ files:
   github.com/BahamutDragon/pcgen/d285e4f36f730d2058e885315a79d3ea31341708/outputsheets/d20/4e/common_sheet/block_bio_condensed.xslt:
     annotations:
       linguist: XSLT
+      linguist-extension: XSLT
+      linguist-xml: XML
       vote: XSLT
   github.com/Bauxitedev/godot-particle-dof/834987de9abdd94adde9bbf371b49a11ea2a6e69/dofshader.shader:
     annotations:
@@ -425,19 +524,25 @@ files:
   github.com/Baystation12/Baystation12/0e60bafc44e1c2ac0ef200bad453698fc7796824/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm:
     annotations:
       linguist: DM
+      linguist-extension: DM
       vote: DM
   github.com/BazhanovMaxim/College_ToadDataModeler_Lab6/b72f60513a0a983a39c8a2d381e3530e5d63e888/logical_model_Lab6.txl:
     annotations:
       linguist: TXL
+      linguist-extension: TXL
+      linguist-xml: XML
       vote: TXL
   github.com/BazhanovMaxim/College_coursework/fe5a1ec5aa0d01f3d68948adeee168afe898e5f8/Logical_model.txl:
     annotations:
       linguist: TXL
+      linguist-extension: TXL
+      linguist-xml: XML
       vote: TXL
   github.com/BedquiltDB/bedquilt-core/beaee513a015ed0dd633b738517b33eb7c4c42a3/test/test_find_documents.py:
     annotations:
       human-smola: Python
       linguist: PL/pgSQL
+      linguist-extension: Python
       vote: Python
   github.com/BhallaLab/FindSim/c1dad5c53d08b0933a3902da531be13572c13ddc/models/submodels/b-arrestin2_20Feb2018_renamed.g:
     annotations:
@@ -447,27 +552,35 @@ files:
   github.com/BigWorldSetup/BigWorldSetup/9c3a37ba6ccc3a4ab3fe58c2106fcf76e04abef3/App/Includes/02_UDF2.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/BillFarber/ml-unit-test-example/cc38ad2ef6b58a2e69866d87183144b617897ec5/src/main/ml-data/shaks200/xml.dcl:
     annotations:
       human-smola: Unknown
       linguist: Clean
+      linguist-extension: Clean
       vote: Unknown
   github.com/Binary-Hackers/42_Subjects/eec0d8dcc5ff48729f790bfa78c125ced7eb1699/01_Piscines/Unity/d04/demoD04.app/Contents/Data/Managed/etc/mono/1.0/DefaultWsdlHelpGenerator.aspx:
     annotations:
       linguist: ASP.NET
+      linguist-extension: ASP.NET
       vote: ASP.NET
   github.com/BioJulia/Bio.jl/62e3441f00dcc52b102d9ae5e2a0a0e4981296af/generate-require.jl:
     annotations:
       linguist: Julia
+      linguist-extension: Julia
+      linguist-shebang: Julia
       vote: Julia
   github.com/Bioruebe/UniExtract2/3078900e05748837aeae4e1641ef1b1fdac03d5e/support/Deprecated/Language_NameUpdate.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/BirgittaHauser/Write-to-IFS-with-SQL/c5b235f1e521ee33198e90e5e2f87d4865a31169/QSQLSRC/WRT2IFS.sql:
     annotations:
+      human-smola: SQLPL
       linguist: SQLPL
+      linguist-heuristics: SQL
       vote: SQLPL
   github.com/BlastarIndia/msdos/0e5f0c8f8d8d4e471358303da44486bffe48715d/v20source/SYSCALL.ASM:
     annotations:
@@ -477,6 +590,7 @@ files:
   github.com/Boemska/macrocore/e3dc99b1a674c47b21673fd63ca8577b5d65a16e/meta/mm_getwebappsrvprops.sas:
     annotations:
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/BonsaiDen/Tuff.gb/b76f6574ed9f29e8f6d390c8cda05be4907ed5b8/src/game/ram/effect.gb.s:
     annotations:
@@ -486,93 +600,116 @@ files:
     annotations:
       human-smola: Objective-C
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/BraulioV/Sistema-Inversor-en-Bolsa/d57d56cfc59ee4de871b9666c58586119f389f22/src/sistemaInversor.clp:
     annotations:
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: CLIPS
   github.com/Brettm12345/doom-emacs-literate-config/3f14904692c2a81f1b2146af7d49e0bbca4082ad/snippets/js2-mode/redux:
     annotations:
       linguist: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/BrianHawley/r2-forward/b9e140f483a3d91ae917c0d12c80dce416c32518/r2-forward.r:
     annotations:
       linguist: Rebol
+      linguist-heuristics: Rebol
       vote: Rebol
   github.com/BrianSaga/herolab-megs/32e8dd462133d5a8a2325ef41b79e85891246302/styles_output.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
+      linguist-xml: XML
       vote: Augeas
   github.com/BrianSharpe/Wombat/f27750c04ce1af090d575436deda84a1d1041771/Value3D_Deriv.glsl:
     annotations:
       linguist: GLSL
+      linguist-extension: GLSL
       vote: GLSL
   github.com/BrightcoveOS/Roku-Sample-App/c8e423d45490ff792a06987cffbcd9758f33102e/source/Config.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/BrokenShell/zeta/461628a08bb8ef780b484613cda9eda215f5aa87/zeta.chpl:
     annotations:
       linguist: Chapel
+      linguist-extension: Chapel
       vote: Chapel
   github.com/BuckleScript/bucklescript/228b0973eb2986eba60efe713c0cb15bf486fec1/jscomp/test/rbset.ml:
     annotations:
       linguist: OCaml
+      linguist-heuristics: OCaml
       vote: OCaml
   github.com/BurntSushi/ripgrep/8892bf648cfec111e6e7ddd9f30e932b0371db68/grep-printer/src/color.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/C-Bouthoorn/i3config/de58cdbb9a1f2299182e25139b67cccd02b8a6f3/20-keys.i3/10-core.i3:
     annotations:
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Modula-3
   github.com/CCBR/Pipeliner/477aecebac322aae9ed8fabee361baa2961a183f/Rules/wgs.somatic.germline.calls.rl:
     annotations:
       human-smola: Unknown
       linguist: Ragel
+      linguist-extension: Ragel
       vote: Unknown
   github.com/CCTV-404/Zigbee/af227896803ef7891952487be42cbff8487d3001/Projects/zstack/Samples/GenericApp/CC2530DB/CoordinatorEB/Obj/zmac_cb.pbi:
     annotations:
       human-smola: Unknown
       linguist: PureBasic
+      linguist-extension: PureBasic
       vote: Unknown
   github.com/CFCommunity/CFScript-Community-Components/7141081569f266b4e79062f879d49f1e26e1d8f8/search.cfc:
     annotations:
       human-smola: ColdFusion CFC
       linguist: ColdFusion
+      linguist-extension: ColdFusion CFC
       vote: ColdFusion CFC
   github.com/CHEF-KOCH/regtweaks/9eb080ab2890d05a1c5fd967cb7983427a97bd02/Win 10/RS 3 (1709)/Apps/Disable Apps Autolaunch/disable_app_autolaunch.cmd:
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/CLCMacTeam/IdleLogout/159e0d8293bbf4e530866f1f286f74d00bae1e8e/macoslib/Cocoa/NSViewController.xojo_code:
     annotations:
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/CMPT-470/Asn4/3e693dc638ebd700b1180109239a614a9c030a7c/MakeCgrammar/10.Txl:
     annotations:
       linguist: TXL
+      linguist-extension: TXL
       vote: TXL
   github.com/CPColin/ceylon.markdown/2b350308064cd476fa56ea473321ffdd724194f0/source/test/ceylon/markdown/renderer/RendererTests.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/CS420Assignment2/dictionary/23d17b26b2286b212e56b04b0caab794a216fb5e/dictionary.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/CSTGit/CST-Live-Guide/49f70ad8cea30af71128da315054e0abb221a19c/README_en.md:
     annotations:
       linguist: Markdown
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/CachetHQ/Cachet/a36ebb246af2e77c0c82b4d7b59c584c4b6db9d0/app/Http/Routes/Dashboard/MetricRoutes.php:
     annotations:
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/Cam/Shopify-Theme-Framework/bb13b0f38ea3d4ff7278f5214225428da74603e9/snippets/footer.liquid:
     annotations:
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/CameronWills/OEUnit/b494161e41e5725aa4b81434753f72bb891030f9/src/OEUnit/Runner/TestMethodResult.cls:
     annotations:
@@ -581,39 +718,48 @@ files:
   github.com/CannyLab/tsne-cuda/2067f9dc19dfe12ce78ccbc3b58f43cc2afed06d/src/util/thrust_utils.cu:
     annotations:
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/CarGuo/gsy_github_app_flutter/07dded24b754646a983a0f5b6958c109ddc3224e/lib/page/repos/repository_detail_page.dart:
     annotations:
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/Carbonhell/Aliens-Colonialmarines/b830574ac837ce6c36e7d3dbc6643b610fda83e4/code/modules/mob/living/carbon/human/human_helpers.dm:
     annotations:
       linguist: DM
+      linguist-extension: DM
       vote: DM
   github.com/CarlosGS/open-radiation-detector/a887e9dcfe0f1568f1ef2a03ba7313825fc00f3b/Detector_PCB_1.0/Gerber/open_rad_detector-drl_map.plt:
     annotations:
       human-smola: Unknown
       linguist: Gnuplot
+      linguist-extension: Gnuplot
       vote: Unknown
   github.com/Carthage/Carthage/e4b4c2f12b82d795487bcbeda428477fabc8123d/Tests/XCDBLDTests/SDKSpec.swift:
     annotations:
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/CatDancer/arc-mz-patch/ffe5de2607f74224809e6d1c791035e985997146/strings.arc:
     annotations:
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/CatDancer/extend/12eb1283172b7ffb08c8798226fef49a0acaea11/extend.arc:
     annotations:
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/CatDancer/json/6c17eeae563f006bc49fb0367c18d276703c29f3/json.arc:
     annotations:
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/CausalInference/IV-Bounds/f59c7f168373e984edb5df2891c56b0d690fc006/IV_bounds.sas:
     annotations:
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/Chadderz121/wii-ct-code/8aaf1a879d276b55c4eb2abdf916e2727e4dfa81/bad0/bad0Data/mod/mod0.mod:
     annotations:
@@ -623,32 +769,40 @@ files:
   github.com/Chaferfu/tal/45ba9284d3b30f67d4b4a025abc171405fdef906/outputs/formal_small.lima.ne:
     annotations:
       linguist: Nearley
+      linguist-extension: Nearley
       vote: Nearley
   github.com/Charles-Kaminski/FastEditDistanceUsingBigDataPrefixTrees/88b8a53837b18fba0f4bef3fe39aa99faa4377f8/3_RoxieQuery.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/CharleyShattuck/myforth-arduino/09ce6220742f0810479b1cafdf7b48f678b1d22a/steno-keyboard/main.fs:
     annotations:
       linguist: Forth
+      linguist-heuristics: Forth
       vote: Forth
   github.com/Cherifabk/ArabTAG-XMG/1f83391a59ca936a9002d95521014b374cf2161b/Verbal.mg:
     annotations:
       human-smola: Unknown
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Unknown
   github.com/Choose-by-Speed/choosebyspeed_v1/551ace3a31cde9b0160ee3393fd1f2887b841157/cbs/src/main/java/com/epam/hack/choosebyspeed/domain/Promotion_Roo_Jpa_Entity.aj:
     annotations:
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/ChrisMarinos/FSharpKoans/3cfef82d86e46cedd32e9b1e99103083420d684a/FSharpKoans/AboutOptionTypes.fs:
     annotations:
       linguist: F#
+      linguist-heuristics: F#
       vote: F#
   github.com/Ciptaandhika/Automation-Android/b86a56f39f87baa862e0cee8661718a3f1462d50/Object Repository/0305_Seller/030504_TransaksiPenjualan/ToolTipSedangDiverifikasiTelahDibayar.rs:
     annotations:
+      human-smola: XML
       linguist: RenderScript
-      vote: RenderScript
+      linguist-xml: XML
+      vote: XML
   github.com/Click-to-Cloud/R.apex/cb3a662fd643f06436fc6fbda800795ea7d352d2/src/classes/RTest.cls:
     annotations:
       linguist: Apex
@@ -656,81 +810,102 @@ files:
   github.com/CliffordAnderson/XQuery4Humanists/d2b80a66460f7395528af91a61b7a9bb41cb9b36/code/graph-tei.xqy:
     annotations:
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/CliffordAnderson/ninety-nine/837be3fa6404a0d142caf693108373430ec4e386/17/test-17.xqm:
     annotations:
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/Co-dfns/APL-Skeleton/4e5bd0a8746c310c49d491f9ab36b3c1ab79158b/HW.dyalog:
     annotations:
       linguist: APL
+      linguist-extension: APL
       vote: APL
   github.com/Co-dfns/Co-dfns/9106e4e5aefbc7a6b9727d788ddc4194cce961cb/tests/t0017_tests.dyalog:
     annotations:
       linguist: APL
+      linguist-extension: APL
       vote: APL
   github.com/Co-dfns/mystika/97503191facea6c6436cdf261f9738d59013a478/tests/eps_tests.dyalog:
     annotations:
       linguist: APL
+      linguist-extension: APL
       vote: APL
   github.com/CoFH/cofh.github.io/97d37888cd8ecf7fbc360c977df7645a50cb348a/docs/1.12/thermal-foundation/tar/index.md:
     annotations:
       linguist: Markdown
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/Code-Bullet/Google-Chrome-Dino-Game-AI/9d601157baf4de54b20454170af8d276c526e113/DinoGame/DinoGame.pde:
     annotations:
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/Code-Bullet/SnakeFusion/4347882175285e011d196770bcbe537932a89e21/SmartSnakesCombine/SmartSnakesCombine.pde:
     annotations:
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/CodeHubApp/CodeHub/bdf84cf014f1195c954fc921baa840af4544a185/CodeHub.iOS/ViewControllers/DialogViewController.cs:
     annotations:
       linguist: C#
+      linguist-heuristics: C#
       vote: C#
   github.com/CoderMJLee/MJRefresh/72d558ce71256dc39c27a65a1f647469262eead6/MJRefresh/Base/MJRefreshHeader.h:
     annotations:
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/ColdBox/coldbox-platform/219f7d32d42d4e4d3b83db62eb83756577f0d9de/system/ioc/config/LogBox.cfc:
     annotations:
       human-smola: ColdFusion CFC
       linguist: ColdFusion
+      linguist-extension: ColdFusion CFC
       vote: ColdFusion CFC
   github.com/CompEpigen/CWLab/17be699cf30301dde578920e2c13d8861b7004bb/test_files/workflows/wf_chipmentation_packed.cwl:
     annotations:
       linguist: Common Workflow Language
+      linguist-extension: Common Workflow Language
       vote: Common Workflow Language
   github.com/Componolit/jwx/ea388cb7e4620fadb6d244b28870b088910f712a/tests/jwx_json_tests.ads:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/Componolit/libsparkcrypto/5901d2cae7d393d609cd81f85216cb92a66f52a9/tests/lsc_internal_test_aes.adb:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/CompositionalIT/SAFE-Dojo/f1a0a6d39a46e50f5bd31872e08f3ca5ae6c73eb/src/Client/ViewHelpers.fs:
     annotations:
       linguist: F#
+      linguist-heuristics: F#
       vote: F#
   github.com/Conal-Tuohy/PROV-RIF-SPARQL/5b1d67a3a18a69cab0f3945b1e886fe4039b6947/harvester/xproc/xproc-z-library.xpl:
     annotations:
       linguist: XProc
+      linguist-extension: XProc
       vote: XProc
   github.com/Conal-Tuohy/XProcTwitterBot/39f78cff163100d6ae3ee54fc5c644768de0ec62/twitter-bot.xpl:
     annotations:
       linguist: XProc
+      linguist-extension: XProc
       vote: XProc
   github.com/Corbas/xproc-tools/5b096c1fe7c7067cdb7f7a136f52cf9d5935759c/tests/03-threaded-xslt.xpl:
     annotations:
       linguist: XProc
+      linguist-extension: XProc
+      linguist-xml: XML
       vote: XProc
   github.com/CruiserX/sha256_plsql/2b363faf45bd50372d716cec0d7f8738ab132f59/sha256_pkgbody.sql:
     annotations:
+      human-smola: PL/SQL
       linguist: PL/SQL
+      linguist-heuristics: SQL
       vote: PL/SQL
   github.com/Cuis-Smalltalk/Cuis-Smalltalk-Dev/590566a92743c2097567cc23caf4889fdae09083/CoreUpdates/3460-SmalltalkCompleterEnhancements-p3-HernanWilkinson-2018Sep24-08h59m-HAW.1.cs.st:
     annotations:
@@ -740,6 +915,7 @@ files:
     annotations:
       human-smola: D
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/Cybereason/siofra/edb33f85ed6024f43942549b1e3cd2619ce2302b/Implant64.asm:
     annotations:
@@ -749,39 +925,48 @@ files:
   github.com/Czarto/ShopifyScripts/177ae0d67b3f484c48f7db93ed54ef07d9002587/snippets/product-color-swatch.liquid:
     annotations:
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/D-a-n-i-l-o/Ascii/4abbfd143161d788a06fddf6eff5d8db15a2d140/Ascii.monkey2:
     annotations:
       human-smola: Monkey
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/DGTresor/Saphir/7bc72c993e9ab020b47a67a5ebe393cadf43f8a6/Programmes/13-RSA_PA.sas:
     annotations:
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/DISID/disid-proofs/306096c408bf3a5accdb76dd9c9306a3700fd3a3/spring-roo-related-readonly/src/main/java/org/springframework/roo/relatedreadonly/web/PetsSearchThymeleafLinkFactory_Roo_LinkFactory.aj:
     annotations:
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/DagF/tdt4165_progspraak_h15/26d60606ce2a3b501c2db465b707139d81c48d75/assignments/assignment_6/ParseDKL.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/DannyBen/Gridy/fb6b392f41b74bf45ec91311cb80042850a5a7ea/Gridy.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/DataSciKevin/ds730_hive/2bc7a3e7a83595cabea6aab1aeeee9176d0843fc/p3.q:
     annotations:
       linguist: HiveQL
+      linguist-heuristics: HiveQL
       vote: HiveQL
   github.com/DavidFluck/factor-shell/b9bf8181ad5b626cf77904816ce91e81ba58a778/factor-shell.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/DavidOSX/Indra/0842b85cea4261b16e0e27c5bf56c03c993f7b6a/pict_1.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/DavidSkrundz/B/dfc2de8a88d34195007c38697ebc134e94964252/src/resolver/type/TypeResolve.b:
     annotations:
@@ -791,18 +976,23 @@ files:
   github.com/Deep6AI/numsuch/cd3c96b4da99bdd851539a14412fc9ff8404fbfe/src/MatrixOps.chpl:
     annotations:
       linguist: Chapel
+      linguist-extension: Chapel
       vote: Chapel
   github.com/DefinitelyTyped/DefinitelyTyped/bdb0d39904820c5f4729d12cb5f5223139231c2f/types/hig__button/hig__button-tests.tsx:
     annotations:
+      human-smola: TSX
       linguist: TypeScript
-      vote: TypeScript
+      linguist-heuristics: TSX
+      vote: TSX
   github.com/DelNov/Glyph-Scripts/3c5c3913d91cad96ed4e298da44fe87fb3c0ff71/with_plate.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/Delja/NitMetric/61d46214fb3a2418e7754cd48c62fa439c4de930/src/nitsmells.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   github.com/DennisYurichev/challenges.re/a9ba2b6db442d408bb00266abef3431e3d403a2a/9/index.m4:
     annotations:
@@ -812,14 +1002,17 @@ files:
   github.com/DestructHub/computer-programs-paradigms/b2f4dd285cf61d351b8ee0fc151b627f7edba2f7/05_tree_and_computational_complexity/01_trees/02_sort_with_tree.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/Devansh-Agarwal/Mitigating-Spectre-Meltdown/6fced3caf53555e8e86cc5a8be7f880d4ce17685/test/CodeGen/X86/avx512-logic.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/DevonMcC/JUtilities/0ead452cc741399752550e57b8f0df2759d346e5/ws.ijs:
     annotations:
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/Devuna/Devuna-IQXML/cc600e313c2c192e146adfed314daaa7054dd0c9/template/win/iQXmlPar.tpw:
     annotations:
@@ -829,34 +1022,42 @@ files:
   github.com/DiegoCoronel/ceylon-jboss-swarm/419b3181d7a5fb1e43a3e39f8246c63bbdeb9564/ceylon-wildfly-swarm-jaxrs/source/jaxrs/example/resource/EmployeeResource.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/Dierk/Real_World_Frege/e002a2aa106ecb39eff542c6aeb5cae9fd2fd830/src/main/frege/realworld/chapter4/F_Looping.fr:
     annotations:
       linguist: Frege
+      linguist-heuristics: Frege
       vote: Frege
   github.com/Dierk/frepl-gui/1ac195a18464164b6ca6751132256c5d0434529e/src/main/frege/org/frege/SketchBook.fr:
     annotations:
       linguist: Frege
+      linguist-heuristics: Frege
       vote: Frege
   github.com/Disassembler0/mikrotik-scripts/03ec5d5cee4f9476bdbe1a57e0091faeb8eae926/automatic-upgrade/upgrade.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/DoM1niC/PlayHide/ce5e34a191f36f442c4814a77733dc5a30467081/AU3/playhide/tray.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/DogLooksGood/parinfer-mode/eaad857ae4351f72a561ee3dec8943713510003f/parinferlib.el:
     annotations:
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/DoomRater/DrizzleScript/3081e8a4c754138a3fc4850225cfa6f5f964e505/Node.lsl:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
       vote: LSL
   github.com/DrItanium/catharsis/eaf210208e8de523a6ba21f92a2790a932f3e1e5/catharsis.clp:
     annotations:
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: CLIPS
   github.com/DrWaleedAYousef/Teaching/18a0f7a4afe1020c10009f44adcfa80e60d07bbb/Probability/Code/Mathematica/Ch3_TheBivariateNormalAndConditionalDistributionsMODIFIED.nb:
     annotations:
@@ -865,45 +1066,55 @@ files:
   github.com/Dridi/libvmod-querystring/f4497725b8952c2b32b2cd9dd4e85b2f3030ab04/configure.ac:
     annotations:
       linguist: M4
-      vote: M4
+      linguist-filename: M4Sugar
+      vote: Unknown
   github.com/Dryopes/Advanced-Programming/2c4626fe4cde0cc3cfbfbba5a347df57b33c7024/assigment2/serialize2start.icl:
     annotations:
       human-smola: Clean
       linguist: Clean
+      linguist-extension: Clean
       vote: Clean
   github.com/Dyalog/JSONServer/b315bac18c64435ae5ee3b62bd6ab2634ce0de64/Tests/Secure/TestSecure.dyalog:
     annotations:
       linguist: APL
+      linguist-extension: APL
       vote: APL
   github.com/Dyalog/Math/e2ddb3ec086f33c1eab72a30ffa2466686de50bc/Math.dyalog:
     annotations:
       linguist: APL
+      linguist-extension: APL
       vote: APL
   github.com/Dyalog/conga-apl/9c8d39b0a6ba7b366152a1c42769ee3110dbc612/Tests/test_websocket.dyalog:
     annotations:
       linguist: APL
+      linguist-extension: APL
       vote: APL
   github.com/ELE-Clouds/RandomPasswordGenerator/b5e33c2e78c65844fdb96a7576ba6639d844ff41/randWindow.ec:
     annotations:
       linguist: eC
+      linguist-extension: eC
       vote: eC
   github.com/ENT8R/streetcomplete-mapstyle/8bf73172826c233499b23678478727fb9881b82c/layers/land.yaml:
     annotations:
       human-smola: YAML
       linguist: YAML
+      linguist-extension: YAML
       vote: YAML
   github.com/EbTech/rust-algorithms/42db8cc763bb54814b89c5d8c75e3f5f82b0cf39/src/scanner.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/Echtzeitsysteme/cardygan/ec03af7cc6f881b78bed5d1d8e258939f0572d3c/spec/alloy/runningExample.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/Eddie-CooRo/computer-architecture/bdc4df3abf39d94251dfea665d3fb1b294d068e5/07/StackArithmetic/SimpleAdd/SimpleAdd.hack:
     annotations:
       human-smola: Unknown
       linguist: Hack
+      linguist-extension: Hack
       vote: Unknown
   github.com/EiffelSoftware/EiffelStudio/c11eba393f5c2ad3f4297743fea6c26f227d7560/Src/contrib/library/testing/framework/espec/library/es_testable.e:
     annotations:
@@ -924,45 +1135,55 @@ files:
   github.com/ElCep/dion_still_alive/ca1df17bfbb2872b4423e4afec5a6ac6e81c00ce/Dion.1952V2.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/Elkfox/Concrete/53099aff5b19eed5b20899f50d4abeda79a925af/src/sections/hero-media.liquid:
     annotations:
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/ElmerCSC/elmerfem/779ab43935168b85fd3657a7a05406837e051dc5/mathlibs/src/lapack/zungl2.f:
     annotations:
       linguist: Fortran
+      linguist-heuristics: Fortran
       vote: Fortran
   github.com/Endurance-Robotics/ChatBots/9e957067c84fe36d517220255947a88a3bf4d910/botabout/botlibre/scripts/Orders.self:
     annotations:
       human-smola: Unknown
       linguist: Self
+      linguist-extension: Self
       vote: Unknown
   github.com/Enyby/APK-Info/e84671b3fc993c2c0b10c042e55d70c31d0360ef/Application-source/APK-Info.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/Eratosthenes/jscripts/8fee71bfc84d9fbb497e03e74b9d2dfb5f322a8a/caesar_shift.ijs:
     annotations:
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/Eric-GH/CMPT470-Advanced-Software-Engineering/7a3fc428c8c43e4c1772f3fab68a714c168f96be/suportmaterials/Pascal_PrettyPrinter/makePascalgrammar/15.Txl:
     annotations:
       linguist: TXL
+      linguist-extension: TXL
       vote: TXL
   github.com/EricZimmerman/RECmd/41efec6fe08e17ee37287e4af781838a2391b4fe/BatchExamples/BatchExample.reb:
     annotations:
       human-smola: Unknown
       linguist: Rebol
+      linguist-extension: Rebol
       vote: Unknown
   github.com/ErinvanderVeen/Saga/ccfcfe45248ccc081814de217062bd10326ac49b/Character.dcl:
     annotations:
       human-smola: Clean
       linguist: Clean
+      linguist-extension: Clean
       vote: Clean
   github.com/ErrkO/Manjaro-Desktop-Settings/3b246cfb71d467ca8131296d8518ba61e6e0a58e/config.i3:
     annotations:
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Modula-3
   github.com/EvanHahn/brainfuck-web-app/487cc274f056752494d7bea7013f05a3c89f6c09/server.bf:
     annotations:
@@ -971,109 +1192,137 @@ files:
   github.com/Everteam-Software/xforms-manager/d67dc3d07fd6a0e8d3492847d6a4685a4cae4b3e/src/main/webapp/WEB-INF/workflow/config/prologue-portlet.xpl:
     annotations:
       linguist: XProc
+      linguist-extension: XProc
       vote: XProc
   github.com/ExcidiumStation/SCP-13/426a7bbdde92954e77c50ab500b9737237b3b964/code/game/machinery/limbgrower.dm:
     annotations:
       linguist: DM
+      linguist-extension: DM
       vote: DM
   github.com/ExpressionEngine/ExpressionEngine-User-Guide/867c896fa0191c9ba3e2f70481dcc4ae298e965b/docs/control-panel/settings/index.md:
     annotations:
       linguist: Markdown
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/Eyescale/CMake/8b69d72180aef3de93d9692781026d7069a9d8d8/FindXDR.cmake:
     annotations:
       linguist: CMake
+      linguist-extension: CMake
       vote: CMake
   github.com/Ezandora/Guide/cb8ec045e425eaf69da4f5637bb4cf2191a2b2f0/Source/relay/Guide/Quests/Intergalaktik.ash:
     annotations:
       linguist: AGS Script
+      linguist-extension: AGS Script
       vote: AGS Script
   github.com/Ezandora/Neverending-Party/b590fa831a4f3f342d49184dd78c659c45b1889a/Release/scripts/Party.ash:
     annotations:
       linguist: AGS Script
+      linguist-extension: AGS Script
       vote: AGS Script
   github.com/Ezandora/Voting-Booth/b1fd2feb6ee62e85910ef447145e3f9fcc50d74d/Release/scripts/VotingBooth.ash:
     annotations:
       linguist: AGS Script
+      linguist-extension: AGS Script
       vote: AGS Script
   github.com/FQrabbit/SSTap-Rule/539611002319e2e2830f3b012ba2ff6087e53753/tools/windows_route_print.bat:
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/FROGGS/p6-File-Spec/636c7a24d1ff9cb68c0b7fa65c4f44100cde6b69/lib/File/Spec/Win32.pm:
     annotations:
       human-smola: Raku
       linguist: Raku
+      linguist-heuristics: Raku
       vote: Raku
   github.com/FabLabWgtn/material-profiles/5448010c3c613ebdd18ea43b635fb15b8944fa0a/Laser Settings 105W/Leather/Leather 0.84 no charcoal.las:
     annotations:
       linguist: Lasso
+      linguist-extension: Lasso
       vote: Lasso
   github.com/Fabiana79/Ejercicios-de-practica-2019/c80606f511a62a00f7f62f2eaecba385028827c2/example.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/Fabien-Chouteau/Wee-Noise-Maker/1dc881c541583fe058c3ac240c11e1ce8b36746a/software/src/wnm-audio_dac.adb:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/Factual/drake/3659c116790f1796261d6d23373de8bba1b663be/src/drake/shell.clj:
     annotations:
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/FahadGhouri/ZIMPL_ILPSolver_TasktoMultiProcessorAssignment/bc33f3559e95a9ad4ad1735142244b431413b0f4/multi_processor_task_assignment.zpl:
     annotations:
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Zimpl
   github.com/FahadGhouri/ZIMPL_ILP_TaskScheduling/278595b6cdaa7aa77babe52fa0a8c3d1022219bf/scheduler.zpl:
     annotations:
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Zimpl
   github.com/FedeLochbaum/World-s-Hardest/94ac2fc35eb670e30e92fe58a47c63a84dbf16cb/android/build/intermediates/transforms/mergeJavaRes/debug/0/com/badlogic/gdx/utils/JsonReader.rl:
     annotations:
       linguist: Ragel
+      linguist-extension: Ragel
       vote: Ragel
   github.com/FelisCatus/SwitchyOmega/472962254559604a0aad9374c0a431ffefd4151f/omega-target-chromium-extension/grunt/po2crx.coffee:
     annotations:
       human-smola: CoffeeScript
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/Feru98/Willy/178e4fe61f5bc83faf5b2ba74d2453fada623c5a/willy.clp:
     annotations:
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: CLIPS
   github.com/FireHatLabs/backdraft-client-example/1343d97d4a876ccc9728dd8141059964cd436aaa/app/public/hb/registration.hb:
     annotations:
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Harbour
   github.com/FlaviusAetius/furry-octo-computing-machine/362215277e32606ffc22869f342777cbe091de1e/chips/Mux.tst:
     annotations:
       linguist: Scilab
+      linguist-heuristics: Scilab
       vote: Scilab
   github.com/FloopCZ/tensorflow_cc/775609e9ed045ef8bfbbfb0b02b3c5af89ed5d38/example/CMakeLists.txt:
     annotations:
       linguist: CMake
+      linguist-filename: CMake
+      linguist-heuristics: Text
       vote: CMake
   github.com/FluxML/Flux.jl/08804a06d242224c12e1ca465cde5fadf4915b8e/src/data/cmudict.jl:
     annotations:
       linguist: Julia
+      linguist-extension: Julia
       vote: Julia
   github.com/FluxML/Zygote.jl/6ac5b5b478f4ae726c55a6d871ddc10e13cc5ac1/src/lib/number.jl:
     annotations:
       linguist: Julia
+      linguist-extension: Julia
       vote: Julia
   github.com/FluxML/model-zoo/076472c7226d924c67bebaa55659d458dd1e3a4e/other/bitstring-parity/xor3.jl:
     annotations:
       linguist: Julia
+      linguist-extension: Julia
       vote: Julia
   github.com/Foadsf/Cmathtuts/6894fd1100f3cb2aa85634e55ae4edf81d801948/A_fortran/test36/f90_calls_c/kronrod_prb.f90:
     annotations:
+      human-smola: Fortran
       linguist: Fortran
+      linguist-extension: Fortran
       vote: Fortran
   github.com/ForNeVeR/jtray/7ed1f9a1ebdc53aca6cfcfc70fca51c2f3aea83d/src/main/frege/Application.fr:
     annotations:
       linguist: Frege
+      linguist-heuristics: Frege
       vote: Frege
   github.com/FormidableLabs/seattlejsconf-app/6cee2cd9bcfd926a0010e3d00e781161455f5c53/re/types/GraphQLTag.re:
     annotations:
@@ -1083,107 +1332,133 @@ files:
   github.com/FortAwesome/Font-Awesome/1c1b102b2ba19518d77e60e97cf1b4ebf133bba0/js-packages/@fortawesome/free-solid-svg-icons/faBlender.js:
     annotations:
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/Foxboron/HyREPL/bfeb7d81ce556a1ece4ac25838c79de8b54cea3b/HyREPL/workarounds.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
       vote: Hy
   github.com/Fr0sT-Brutal/awesome-pascal/9e951e2d84c748b2fc52398dadb5c8f66bf028bf/contributing.md:
     annotations:
       human-smola: Markdown
       linguist: Pascal
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/FrankR85/GnuCOBOL-Dev-Environment/a3c9b51fd9b3fda9e9e0e80724f5c2dbf44101cd/cobol/anagram/src/ANAGRAMM.cbl:
     annotations:
       linguist: COBOL
+      linguist-extension: COBOL
       vote: COBOL
   github.com/FreeGIS/Postgis_Coordinate_Transform/05ff4a6c8a2262b1e0733fec55e7ede5a7c44515/FreeGIS_Coordinate_Transform.sql:
     annotations:
       linguist: PL/pgSQL
+      linguist-heuristics: PL/pgSQL
       vote: PL/pgSQL
   github.com/FreezeWu/intellisoft/57acd71c7fbd4970ecd473b2acbc92d6a6b2b42d/ws_objects/auto_export.pbl.src/w_table_message.srw:
     annotations:
       linguist: PowerBuilder
+      linguist-extension: PowerBuilder
       vote: PowerBuilder
   github.com/Frege/frege-native-gen/b8b78636879cec89d1e8226a9c810e5681eab8a7/src/main/frege/frege/nativegen/NativeGen.fr:
     annotations:
       linguist: Frege
+      linguist-heuristics: Frege
       vote: Frege
   github.com/Frege/frege-repl/a344127bbcc7f211505bca5c59f29a77971bfc51/frege-repl-core/src/main/frege/frege/repl/Gui.fr:
     annotations:
       linguist: Frege
+      linguist-heuristics: Frege
       vote: Frege
   github.com/Frege/frege/a3c4f77cbc8f5e065d4003ff914bfb025fecce84/frege/compiler/Kinds.fr:
     annotations:
       linguist: Frege
+      linguist-heuristics: Frege
       vote: Frege
   github.com/Fuco1/litable/b0278f3f8dcff424bfbdfdefb545b1fbff33206f/litable.el:
     annotations:
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/Fuco1/smartparens/9738360eb2afb58b4c21815f9d5c793b8125f540/test/smartparens-wrapping-test.el:
     annotations:
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/GLN/MIDIFlower/ab0f03b86a9be35bde55f6171db31a4be60a2490/src/MIDIFlowerPetal.ck:
     annotations:
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/GNOME/perl-glib/0801a2b1e82f3c04cb8f994b22609d1199917028/GValue.xs:
     annotations:
       linguist: XS
+      linguist-extension: XS
       vote: XS
   github.com/GSA/frpp-load/d00717551840691103d79147a7f3e08ff00584f9/src/test/resources/sample_data/list_Result.dwl:
     annotations:
       linguist: DataWeave
+      linguist-extension: DataWeave
       vote: DataWeave
   github.com/GUI/lua-resty-auto-ssl/b4118691ce12fc2f407a82e5de80a4c512190775/spec/sockproc_file_descriptors_spec.lua:
     annotations:
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/GWRon/Dig/52110eb92f07158de70819a08771762cb1f455c2/base.util.graphicsmanager.ng.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/GWRon/GenusPrime/6de3d9128a699c168c94e22a7b857150e5d977b3/source/Dig/base.gfx.sprite.particle.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/GWRon/bmx-ng-samples/66b4c4d3e20cc19626d2be53cd0bed073bfe58e1/birdie/games/tiledrop/tiledrop.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/Gabriel439/bench/846dea7caeb0aee81870898b80345b9d71484f86/src/Main.hs:
     annotations:
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/Gabriel439/haskell-nix/8d109db4b335038842e8dcfd223348ab0928ffbe/project4/nix/optparse-applicative.nix:
     annotations:
       linguist: Nix
+      linguist-extension: Nix
       vote: Nix
   github.com/GaelleLeTreut/IMACLIM-Country/b4e960f26a0aa3d93f6fdf8e63299558a38a261d/code/Systeme_StatJCH.sce:
     annotations:
       linguist: Scilab
+      linguist-extension: Scilab
       vote: Scilab
   github.com/GaloisInc/cryptol/ddbd6643267e60754b7a6f2dfd84110193ef00c8/src/Cryptol/TypeCheck/SimpType.hs:
     annotations:
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/GaloisInc/llvm-pretty-bc-parser/25edd30d067a9ec4176cc10fcccf513db37d8ac7/disasm-test/cpp/templates.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/GaloisInc/reopt/99814ad5b248ad1abec829f3bd9c7866a85c1c7e/llvm-merge-example-ubuntu/example/llvm-latest/__simple_malloc_400860.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/Gamerfiend/kit-ecs/8ab8a2c861820acf24a0f24aa19647b50821da18/src/ecs.kit:
     annotations:
       linguist: Kit
+      linguist-extension: Kit
       vote: Kit
   github.com/Gamerfiend/raykit/aece527a6f2684feaf8d1081426764b6edc6b91d/raykit.kit:
     annotations:
       linguist: Kit
+      linguist-extension: Kit
       vote: Kit
   github.com/Gaxil/Unity-InteriorMapping/78194254efe646aee5c9784dc23338a263c14343/Assets/Shaders/InteriorMapping.shader:
     annotations:
@@ -1192,59 +1467,74 @@ files:
   github.com/Genymobile/scrcpy/3ea47423217775d2519fb5ac61edd55072639a64/app/tests/test_control_msg_serialize.c:
     annotations:
       linguist: C
+      linguist-extension: C
       vote: C
   github.com/GerardWassink/SCEPSIS/8c3d210512b75e50296fbf07f154def603492116/source/scepsis.rexx:
     annotations:
       linguist: REXX
+      linguist-extension: REXX
+      linguist-shebang: REXX
       vote: REXX
   github.com/Ghostkeeper/SettingsGuide/bcca70acf673b70dcf7b561a538d0f00ef92793b/resources/articles/material_break_preparation_speed.md:
     annotations:
       linguist: Markdown
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/GillesArcas/sapid-lisp/2775bcf84a0ccf99a4d2aa327d2a3d254b3b9d5f/print.l:
     annotations:
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
       vote: PicoLisp
   github.com/GillesK/Protheus-Advpl-OO-Framework/514471f006072209b0febb2221939b2cd07e4d20/Importacao/TSICExeAut.prw:
     annotations:
       human-smola: xBase
       linguist: xBase
+      linguist-extension: xBase
       vote: xBase
   github.com/GioSensation/gravida/19c7b41c24b222c4842842c390293218391d9486/web-development.kit:
     annotations:
       linguist: Kit
+      linguist-extension: Kit
       vote: Kit
   github.com/GiovineItalia/Gadfly.jl/6d68260d2960aedb546618db31e65489e81d74f3/src/theme.jl:
     annotations:
       linguist: Julia
+      linguist-extension: Julia
       vote: Julia
   github.com/GoogleChromeLabs/squoosh/8bf741ed4eba55e6309d9c27f44b19008b57c6fa/src/codecs/rotate/processor.ts:
     annotations:
       linguist: TypeScript
+      linguist-heuristics: TypeScript
       vote: TypeScript
   github.com/GregoryVds/PokemOz-Functional-Programming-Game/15e4bda5ac58cef5bb67d603e7f15eff3c70fca8/gameIntro.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/Guevara-chan/AntiEye/b2fb73c18e23d675fd774ba6cdbcf974257e7d32/checker/checker.boo:
     annotations:
       linguist: Boo
+      linguist-extension: Boo
       vote: Boo
   "github.com/Guevara-chan/Re-combine/28a4dbc4ea86f6d8226cf098aaba4714636bcdd7/Re\u02D0combine.boo":
     annotations:
       linguist: Boo
+      linguist-extension: Boo
       vote: Boo
   github.com/GuillermoSBR/ParcialGit/9c427bcdce7bde7b98f2c1d4cdf74564e9b7bbdc/src/Parcial.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/Gulkbag/BrainfuckTOS/db02e5efe776b1dd3b6dea6bb3872391a1357718/Brainfuck.HC:
     annotations:
       linguist: HolyC
+      linguist-extension: HolyC
       vote: HolyC
   github.com/HEX4114/Project_Quality_Alloy/1bad1d4a4ff888a8e038fe73a6c99d24e095937a/AlloyDroneProject.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/HGldJ1966/guru-lang/a6b85e707d46ea7314ae5eb5e88c4b04deefccf6/tests/golfsock/checkh.g:
     annotations:
@@ -1254,23 +1544,28 @@ files:
   github.com/HHS-AHRQ/MEPS/53f134c03115d3170dbf30e52403d5403e295755/SAS/workshop_exercises/exercise_4a/Exercise4a.sas:
     annotations:
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/Haneke/HanekeSwift/41c1efc82a9b7cefa4381f79669ab1e32b867b16/HanekeTests/NSHTTPURLResponse+HanekeTests.swift:
     annotations:
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/HangfireIO/Hangfire/29800f396e39d4f91df339524b95a670f1c39041/src/Hangfire.SqlServer/SqlServerJobQueue.cs:
     annotations:
       linguist: C#
+      linguist-heuristics: C#
       vote: C#
   github.com/Hanks10100/wasm-examples/dad3d379dc501c60bfed24b8846ddaf5f0ff8d63/benchmark/tail/fibc.wast:
     annotations:
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/Harry-Chen/fpga-virtual-console/7e7e14b8db7d299dab24095b0f6e660720715220/src/display/FontShapeRenderer.sv:
     annotations:
       human-smola: SystemVerilog
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/HarshTrivedi/paraphrase-generation-web-demo/b2e1bbc946323b47b17e77ed1a08b0220591d463/bllip/models/WSJ/parser/tt.g:
     annotations:
@@ -1281,45 +1576,55 @@ files:
     annotations:
       human-smola: Unknown
       linguist: PowerBuilder
+      linguist-extension: PowerBuilder
       vote: Unknown
   github.com/HauyuChen/Parking-System/171034f27df89d7c3e60a78b8dd163389c21bb85/Parking-ZigBee/ParkingSystem/CC2530DB/CoordinatorEB/Obj/hal_assert.pbi:
     annotations:
       human-smola: Unknown
       linguist: PureBasic
+      linguist-extension: PureBasic
       vote: Unknown
   github.com/HaxeFlixel/flixel-addons/19ae61b4688e03ae6aa6ccbc1997148adf50b564/flixel/addons/display/FlxTiledSprite.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/HaxeFlixel/flixel/c46bd967d999b3e920133c3ed7b85410929e7bb2/flixel/system/debug/stats/Stats.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/HaxeFoundation/haxe/91dc4be111f3e521e2c5219b76d328a779f30ac9/std/php/JsonSerializable.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/HeapsIO/heaps/fdcb3e02d5cf88d52bdd4fada588f02e1edf4e0b/h3d/shader/pbr/PropsDefinition.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/HeidiSQL/HeidiSQL/17e75e70dad1a3ec82a26427540133e9931b57a1/source/detours/Demo/InstDecodeDemo/Demo1/Demo1.dpr:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/HenningB/ceylon.ant/278d2e1f226a17f0c71dc10bcdd5ae44946f10fc/source/test/ceylon/ant/testAnt.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/Heracles-Brigade/rotbd/690b67d7b9f01460c5d7f588a608b2748c990ded/src/mp/race/multrc02/multrc02.LGT:
     annotations:
       human-smola: Unknown
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Unknown
   github.com/HerrLeise/LsMenuBar-RB-XJ-/e688ce715d7f5020a12877a55878ba953e43e6a0/Classes/LsMenuItem.rbbas:
     annotations:
       human-smola: REALbasic
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/HexHive/printbf/711c0ddad3d2d0bb8aeb4292de94ea94d6278257/bfprogs/life.bf:
     annotations:
@@ -1328,26 +1633,33 @@ files:
   github.com/HoTT/HoTT/b20bb573739284349a968bb219405255c744049d/theories/Fibrations.v:
     annotations:
       linguist: Coq
+      linguist-heuristics: Coq
+      linguist-modeline: Coq
       vote: Coq
   github.com/Holarse-Linuxgaming/ashley-madison-simulator/a59cdcc45652fcb6e9f249c61e98b7acee42fea1/ircbot.lol:
     annotations:
       linguist: LOLCODE
+      linguist-extension: LOLCODE
       vote: LOLCODE
   github.com/Homebrew/brew/1d41481d2d99a74a477eec1af38466ad790762c5/Library/Homebrew/test/linkage_cache_store_spec.rb:
     annotations:
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/HotKeyIt/ahkdll-v1-release/3ff1a2f7f233b74b4913d38a58d966c15d7dbdcc/lib/GlobalVarsScript.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/HrafnkellNK/dotfiles/258c458bd82d07a7dbb697dd316069a3d0b4eff8/config.i3:
     annotations:
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Modula-3
   github.com/HubSpot/BuckyClient/646ab9ebcbcaaab4e68c7fcbf66e109dd418b3b3/bucky.coffee:
     annotations:
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/Huioqy/NTU_EE6222_MACHINE_VISION_Assignment/dc16bffff892bd0e6fa96a442e60561ee37d43be/Assignment1/RVFL_cross_validation/car/car_R.m:
     annotations:
@@ -1357,35 +1669,43 @@ files:
   github.com/HujiangTechnology/gradle_plugin_android_aspectjx/1aaac7711ff1cae054158729a0b77ac52fa72d8b/aspectjx/src/main/groovy/com/hujiang/gradle/plugin/android/aspectjx/internal/FileType.groovy:
     annotations:
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/IBM/zos-tools-and-toys/38bc9d804b60ea7d05ba26372383dba26fa0f6a2/colonies/colonies.rexx:
     annotations:
       linguist: REXX
+      linguist-extension: REXX
       vote: REXX
   github.com/IBMSpectrumComputing/lsf-perl-api/553a75b2469c554f4dbd556d6f982255148a366f/LSF-Base/Base.xs:
     annotations:
       linguist: XS
+      linguist-extension: XS
       vote: XS
   github.com/IJTAG-Ecosystem/Public/c09f43976b4941104e35f7ca227931afc6406037/ScanCell.icl:
     annotations:
       human-smola: Unknown
       linguist: Clean
+      linguist-extension: Clean
       vote: Unknown
   github.com/IP-XOP/gencurvefit/5e9732aa5831a02d82c069f0235d1d28a1fcabfc/extra/GeneticOptimisation.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/IRNAS/KORUZA/6f780bef1325ae6874493f9cbfb66782d68ab6df/main_structure/libraries/24BYJ48.scad:
     annotations:
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/IanRapley/Makura-Bot/e71e8967b28b87f871df33e4f5eb572afcd838ed/Grammar-poetry.ne:
     annotations:
       linguist: Nearley
+      linguist-extension: Nearley
       vote: Nearley
   github.com/IbrahimIrfan/chess/b93a80d0e69831d763ef483b95d5868813a4508b/Main.t:
     annotations:
       linguist: Turing
+      linguist-heuristics: Turing
       vote: Turing
   github.com/ImJohnMDaniel/at4dx/03067ddc0b24e4945d561df71b5c1a4674bd89ff/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessCriteriaWithExistingRecs.cls:
     annotations:
@@ -1394,163 +1714,209 @@ files:
   github.com/InQuest/malware-samples/fcb42e2881c9004d5f6c2286fd91457eab374a17/CVE-2018-4878-Adobe-Flash-DRM-UAF-0day/swf-1a3269253784f76e3480e4b3de312dfee878f99045ccfd2231acb5ba57d8ed0d-dfi/5Cx1e5Cx19.as:
     annotations:
       linguist: AngelScript
+      linguist-heuristics: AngelScript
       vote: AngelScript
   github.com/IngenieriaWebUCA/iw2016-tempojobs/3b493c0f403dd1c3f4b13b18e9ffe1beef6e3bfa/src/main/java/es/uca/iw/tempojobs/web/DemandanteController_Roo_GvNIXDatatables.aj:
     annotations:
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/InsertKoinIO/koin/2a64ce465193411a0c772d3aa623bdd669beb5e9/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/ext/android/FragmentExt.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/IntelligentVisibility/CalendarTimeChooser/abbc61d673dbc23877e1e6ff0047a7991cdf21c3/3_Cal-Time Chooser Custom Classes/Calendar.xojo_code:
     annotations:
       human-smola: Xojo
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/IoLanguage/eerie/882524741add116efa8575b0a48876b458654a42/io/Eerie/PackageInstaller/File.io:
     annotations:
       linguist: Io
+      linguist-extension: Io
       vote: Io
   github.com/IonicaBizau/node-cobol/b3084a8262166a324dcaf54d976f6f3f8712b2a1/cobol-samples/hopper.cbl:
     annotations:
       linguist: COBOL
+      linguist-extension: COBOL
       vote: COBOL
   github.com/IonicaBizau/node-fortran/f3155f0b767c70377fca4cb19550432cf9dd991b/fortran-samples/john-backus.f:
     annotations:
       human-smola: Fortran
       linguist: Fortran
+      linguist-heuristics: Fortran
       vote: Fortran
   github.com/IonicaBizau/node.cobol/d180cc957ed925c1b38ba5e980d1f9e2e0fa2130/lib/node-exec.cbl:
     annotations:
       linguist: COBOL
+      linguist-extension: COBOL
       vote: COBOL
   github.com/IsNull/ahkDBA/412a939d226fe80b624df3f04ee8a7908531b8b3/Lib/ADO.ahk:
     annotations:
       human-smola: AutoHotkey
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/J2TEAM/idm-trial-reset/4d2c80c38de2dc4c14e32038dd89e979ee931b99/src/core.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/JCumin/Brachylog/22cbc9547cf3d7ab9d1b8cd56c11276622cea17c/src/brachylog.pl:
     annotations:
       linguist: Prolog
+      linguist-heuristics: Prolog
       vote: Prolog
   github.com/JEG2/dotfiles/fd67ac959a3b25028836503c369325b8377eea93/spacemacs.d/snippets/ruby-mode/io/parse_options.yasnippet:
     annotations:
       linguist: YASnippet
+      linguist-extension: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/JHUISI/autocrypt/7eda9de098a18e3d8de7e8440150b760ed04d973/BLS/bls-full-AUTO.ec:
     annotations:
       linguist: eC
+      linguist-extension: eC
       vote: eC
   github.com/JKISoftware/HAL-Webinar/0fbcdc77580cd5cc7b433665b6e07393198fcd8d/HAL Webinar.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/JKISoftware/JKI-State-Machine-Objects/a1fe80a548495f49d8201947138fd0572cd23c01/src/JKI SMO.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/JKISoftware/JKI-State-Machine/4bb0ec29b99bb1bddc9874a040867e14cd4d1b7f/source/JKI State Machine.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/JOfTheAncientGermanSpear/Simple-Time-Stretcher-Scilab/638360ea04ee4951f9a4e550d45fcea0bc01c867/src/scilab/timeStretch.sci:
     annotations:
       human-smola: Scilab
       linguist: Scilab
+      linguist-extension: Scilab
       vote: Scilab
   github.com/Jack000/Expose/257d6b1bf39493e65a3b955fca50231516495875/Markdown_1.0.1/Markdown.pl:
     annotations:
       linguist: Perl
+      linguist-heuristics: Perl
       vote: Perl
   github.com/Jackysi/advancedtomato-gui/98271fb13e17db702e22d388d798113dcd4ccaac/bwm-realtime.asp:
     annotations:
       linguist: Classic ASP
+      linguist-extension: Classic ASP
       vote: Classic ASP
   github.com/JacquesCarette/TheoriesAndDataStructures/4fb450b1e4ce5169af7843c92d0bb1dda5fdc44c/Helpers/Hardy.lagda:
     annotations:
+      human-smola: Literate Agda
       linguist: Agda
-      vote: Agda
+      linguist-extension: Literate Agda
+      vote: Literate Agda
   github.com/Jahdrien/FileReader/e76e00e018a6eae492bd4cbf235695f982626b00/src/File/FileInput.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/JamesDeFabia/FinanceLibrary/1f1e690441cd197b691086e55710cb07fd471bc7/Finance.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/JamesMc86/G-CLI/21937031d24b562bb2be25480bd102a6d9c8341e/Integration Tests/CLI Integration Tests.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/Jamini/NEVUnity/2b888654254598ab88dfd90de698a404fec366ca/code/modules/mob/living/carbon/alien/alien.dm:
     annotations:
       linguist: DM
+      linguist-extension: DM
       vote: DM
   github.com/JanJaeken/christoffel/0ea31138993ec0458ac15841396771d432ca23b6/gnuplot/enh_cube.gnu:
     annotations:
       linguist: Gnuplot
+      linguist-extension: Gnuplot
       vote: Gnuplot
   github.com/JaneliaSciComp/DataPro/eb18cbf0b1282d2874bd1cd712f1f73c3a1f7d14/DP_PulseStimulus.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/JaraBreda/VermenigvuldigVierkant/438da01e930652abf628d678737fcdfdb736e7cb/Imp/globals.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/JayHoltslander/CF-Cache-Status/6623cd5e0cc1af257ef5bc49bce9cfca202bb880/src/_footer.kit:
     annotations:
       linguist: Kit
+      linguist-extension: Kit
       vote: Kit
   github.com/JeeJay23/dotfiles/9ef75d37851dff19f535d75daf998859fb390159/config.i3:
     annotations:
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Modula-3
   github.com/JeffBezanson/femtolisp/ec7601076a976f845bc05ad6bd3ed5b8cde58a97/lib/sort.scm:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
       vote: Scheme
   github.com/JessYanCoding/ArmsComponent-Template/eda7ebda29b662150e83040059a23f8d95e6056e/NewArmsComponent/recipe.xml.ftl:
     annotations:
       linguist: FreeMarker
+      linguist-extension: FreeMarker
+      linguist-xml: XML
       vote: FreeMarker
   github.com/JessYanCoding/MVPArms-Module-Template/162950a0592232681ffcf5062edfe007ad841523/NewArmsModule/root/src/app_package/GlobalConfiguration.java.ftl:
     annotations:
       linguist: FreeMarker
+      linguist-extension: FreeMarker
       vote: FreeMarker
   github.com/JessYanCoding/MVPArmsTemplate/2490af5733d409e1867b09d33f8965b04d25def1/MVPArtTemplate/root/src/app_package/ArtActivity.java.ftl:
     annotations:
       linguist: FreeMarker
+      linguist-extension: FreeMarker
       vote: FreeMarker
   github.com/JetBrains/Nitra/b287b8a42237fac4d993444e7e3af9240b601503/Boot2/Nitra.Grammar/Model/FSM/FSM.n:
     annotations:
       linguist: Nemerle
+      linguist-heuristics: Nemerle
       vote: Nemerle
   github.com/JetBrains/kotlin-native/045b20a36b8a1fe86716a99cb25f03021e583592/backend.native/tests/codegen/try/finally4.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/JetBrains/kotlin/7f4b568021d56715bbb7f4897b432394c2d04baa/idea/src/org/jetbrains/kotlin/idea/versions/KotlinRuntimeLibraryUtil.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/JideGuru/FlutterSocialAppUIKit/3457ea080e945b60bcb876b729dea0ce4b24a700/lib/widgets/chat_item.dart:
     annotations:
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/Jimbobnz/ABL-HTTP-Web-Request/3234898ea33c4dc138045656cd0c73bbae95328f/co/dsg/http/examples/XML-RESTFul-Get.p:
     annotations:
       linguist: OpenEdge ABL
+      linguist-heuristics: OpenEdge ABL
       vote: OpenEdge ABL
   github.com/Jimbobnz/ABL-XLSX-Reader/a8378bf2d05b8c342d3d4d45d7dc44a9e1415ba4/OfficeOpenXML/OfficeOpenSpreadsheetMLSAXHandler.p:
     annotations:
       linguist: OpenEdge ABL
+      linguist-heuristics: OpenEdge ABL
       vote: OpenEdge ABL
   github.com/Jimbobnz/ABL-XLSX-Writer/2f4e210d49ca919dace26cb6d22544db6176481a/ABL-XLSX-Writer/writer/Format.cls:
     annotations:
@@ -1560,18 +1926,22 @@ files:
     annotations:
       human-smola: HiveQL
       linguist: HiveQL
+      linguist-heuristics: HiveQL
       vote: HiveQL
   github.com/JochenHeizmann/ld28/5757c43c9022d1919d53778d0eb4963861fe7607/src/level.monkey:
     annotations:
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/Joelbyte/verdi-neruda/1bbfbddc9266ec5eab38f6a10bdb0db715b82f16/bench_queens.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/Joelbyte/weak-bases/f9177567412033cd722eaad1e8877ac1d7aa6006/relations.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/JohannesPfeifer/DSGE_mod/736e0a66d6908ea3acda5c34cf2f7e04448293a7/Gali_2008/Gali_2008_chapter_5_commitment.mod:
     annotations:
@@ -1581,74 +1951,92 @@ files:
   github.com/JohnEarnest/Mako/2edacbcc736dc6a53cfe33e63f00371fb0cf1a01/lib/External/BMP.fs:
     annotations:
       linguist: Forth
+      linguist-heuristics: Forth
       vote: Forth
   github.com/JonasOlson/chrooms/39b0853cb37e046b14d70da149444df1d2d5ad99/chrooms/murmur.ice:
     annotations:
       linguist: Slice
+      linguist-heuristics: Slice
       vote: Slice
   github.com/JonathanSalwan/Tigress_protection/79c696976a7ae19c9385c2fb6d6d558f95be7b4c/llvm_expressions/sample13-virt-dispatcher-linear.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/Jophyy/Game101/24fbfe47cfc4d41d9264f9aa1e36efe9e0b825cf/com.Game101.mycompany.game101/Main.eq:
     annotations:
       linguist: EQ
+      linguist-extension: EQ
       vote: EQ
   github.com/JordanMartinez/purescript-jordans-reference/cf7ff6362c4b26229b386f36ccd99f25644744db/11-Syntax/01-Basic-Syntax/src/03-TypeClasses-and-Newtypes/10-Keyword--Newtype.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/JorgeSilva7/Prog-Distribuida-PFJ/db50ad783bd41a8f6c0ef05cb2e53b9ff9e4d9b5/SmartHome_jsilva.ice:
     annotations:
       linguist: Slice
+      linguist-heuristics: Slice
       vote: Slice
   github.com/Jscottkasten/uvs-advanced-library/10738964eed569aa568db7a76dde625c87a33c36/Src/Mirah/Android/com/UVS/Innovations/AdvancedLibrary/Debugging/AppExceptionHandlerActivity.mirah:
     annotations:
       linguist: Mirah
+      linguist-extension: Mirah
       vote: Mirah
   github.com/JuliaCI/BenchmarkTools.jl/408a1ed8c32715352a31227637c5a961ed1fdd41/test/ExecutionTests.jl:
     annotations:
       linguist: Julia
+      linguist-extension: Julia
       vote: Julia
   github.com/JuliaDiffEq/DifferentialEquations.jl/a4ca6cad8e7a5227de985c56980d932db0fcbfcf/src/ode_default_alg.jl:
     annotations:
       linguist: Julia
+      linguist-extension: Julia
       vote: Julia
   github.com/JuliaLang/IJulia.jl/0df1f5fc5199dc7b7d99ad5f330bb9263fd68968/test/install.jl:
     annotations:
       linguist: Julia
+      linguist-extension: Julia
       vote: Julia
   github.com/JuliaLang/julia/ba4f858cd0618e209b81a1800005662769cdc1c1/stdlib/REPL/src/emoji_symbols.jl:
     annotations:
       linguist: Julia
+      linguist-extension: Julia
       vote: Julia
   github.com/JuliaOpt/JuMP.jl/fc2bb8ad1c99a6bf4597af9a9703af7900bcb6ce/src/JuMP.jl:
     annotations:
       linguist: Julia
+      linguist-extension: Julia
       vote: Julia
   github.com/JuliaPlots/Plots.jl/464c0271f026e53037c64a30c3dc3b40e0dd1ec3/src/recipes.jl:
     annotations:
       linguist: Julia
+      linguist-extension: Julia
       vote: Julia
   github.com/JuliaWeb/HTTP.jl/1cbcef9dbeb2b982ed83d4979b28318035041d3a/src/parseutils.jl:
     annotations:
       linguist: Julia
+      linguist-extension: Julia
       vote: Julia
   github.com/Jurigag/fast-micro-router-phalcon/9ff5df404740052c4efc5509144b4a53a63265cc/fastmicro/FastRouter.zep:
     annotations:
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/JustInTime666/Projet-info2/6df52dfbfacbedc0978c3cbf9d2e61cd7aa0d59f/ozplayer/tests.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/Jutho/TensorOperations.jl/ed30b0fb8bba7bc5d44101c2696f62af41ab0f93/src/indexnotation/verifiers.jl:
     annotations:
       linguist: Julia
+      linguist-extension: Julia
       vote: Julia
   github.com/KDE/latte-dock/484741558e93496dab464caa9f724c15e312ea75/containment/package/contents/ui/editmode/HeaderSettings.qml:
     annotations:
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/KIRPAT/keyboard-macros/e8f5c5294bafc70927b1609e4903fecf8c850968/my_keyboard/G800V-AHK.ASC:
     annotations:
@@ -1658,23 +2046,28 @@ files:
   github.com/KONEY/octamed-arexx-repo/da1f635fe68d082570e137df68289974c65ea739/calc_playtime.rexx:
     annotations:
       linguist: REXX
+      linguist-extension: REXX
       vote: REXX
   github.com/KaiDrange/Axoloti-Block/24ddfb3e0d4e71099d4030d3c77127544f016cb7/Axoloti/patches/BlocksProgramChanger.axs:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   "github.com/KaiserY/rust-book-chinese/6fce7ce2042fd5e47b1bd4b3c16ef7f35277be91/content/Borrow and AsRef Borrow \u548C AsRef.md":
     annotations:
       human-smola: Markdown
       linguist: Markdown
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/KaiserY/trpl-zh-cn/c5e422c00166c9d20829478e3306b2786f0870db/src/ch06-02-match.md:
     annotations:
       linguist: Markdown
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/KarlLofholm/lofholm-se/55f866851227538a27394f1159182e7c567aeccb/source/kit/_pages/operan.kit:
     annotations:
       linguist: Kit
+      linguist-extension: Kit
       vote: Kit
   github.com/KaroDievas/oop-openedge/8e2a97cdad3bfc3fc7853d4a916adb56054668e2/factory/Yamaha.cls:
     annotations:
@@ -1683,10 +2076,12 @@ files:
   github.com/Karthikvishw/RubyFeatureExtractor/1013bb492dc57a7639e2fb7445153584c8867f60/input/ruby.txl:
     annotations:
       linguist: TXL
+      linguist-extension: TXL
       vote: TXL
   github.com/KeplerStation/KeplerStation/959759790b949f7ff5aebe88be7b6fe392a4dd3f/modular_citadel/code/game/objects/items/melee/eutactic_blades.dm:
     annotations:
       linguist: DM
+      linguist-extension: DM
       vote: DM
   github.com/KerasL/Homework/1d4a62b97c68b040f5c1a2106132956d87589176/Grocery.t:
     annotations:
@@ -1695,79 +2090,98 @@ files:
   github.com/KevinLiddle/Ioke_TTT/06712c777a22e24be42142ecc3ecdd8de74285b3/spec/machine_player_spec.ik:
     annotations:
       linguist: Ioke
+      linguist-extension: Ioke
       vote: Ioke
   github.com/KhronosGroup/SPIRV-Cross/b56c2f4271e139ab6db68315a4c0d6e24b0fe788/reference/shaders-msl/tese/quad.tese:
     annotations:
       human-smola: GLSL
       linguist: GLSL
+      linguist-extension: GLSL
       vote: GLSL
   github.com/KhronosGroup/glTF-Sample-Models/18912e96c60245f71a3775d365c990009307a11a/1.0/VC/glTF/VC5FS.glsl:
     annotations:
       linguist: GLSL
+      linguist-extension: GLSL
       vote: GLSL
   github.com/KiCad/kicad-winbuilder/c6b67026184bd9aae6f7c0633ea7bc720b1edb1a/nsis/nsProcess.nsh:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/KimBruce/StaticTyping/a6292c398ce7964730c208ed59dee4706ac73906/StaticTyping.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/Kimbsy/lolcode/830341dcaae473e652c115eb782b95e4a113755a/ICANHAZPRIME.lol:
     annotations:
       linguist: LOLCODE
+      linguist-extension: LOLCODE
       vote: LOLCODE
   github.com/Kimundi/greenwasm/9afe805aa534c752dd1c62b8978a305a9bc2f640/greenwasm-spectest/testsuite/select.wast:
     annotations:
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/Kode/Kha/91400b060fafc3e5b856e299d01ed543963ff06a/Sources/kha/Sound.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/Kodein-Framework/Kodein-DI/6088c4883fbaa54875f7ffe8edec24ab3f824c63/kodein-di-erased/src/jvmTest/kotlin/org/kodein/di/erased/ErasedJvmTests_00_Factory.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/Kodiologist/Rogue-TV/b4af5944ebedf4cea2791362d9929b0dae224ea7/roguetv/map.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
       vote: Hy
   github.com/KoishiKomeiji/TouhouGame/251a6a8a96cfccd1a9a9d751c4c1e120fc1a87b2/Classes/Enemies/StandardEnemies.tu:
     annotations:
       linguist: Turing
+      linguist-extension: Turing
       vote: Turing
   github.com/Kong/kong/56a1e4027aff511f2733c1310a3274b087a65619/kong/db/declarative/init.lua:
     annotations:
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/Kotlin/anko/acb7e606dfca0ebd5becf04b93c5b932e9575246/anko/library/generated/cardview-v7/src/main/java/Layouts.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/KovaaK/SensitivityMatcher/2fc4f74a3d87a224dd368727f9f0838f134f4754/ReleaseAssets/bin/SensitivityMatcher.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/Kuma-Cheatsheet/sql/6f283766bdf28730b84e86860b11a9fbd4599aa9/code/Table-Values/Departments.csv:
     annotations:
       linguist: CSV
+      linguist-extension: CSV
       vote: CSV
   github.com/KurtisLiggett/Simple-IP-Config/48e1b5dc37cbc9c53a6819fdc6b3b731d871d1bf/main.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/KxSystems/kdb-tick/afc67eda6dfbb2ca89322f702db23ee68c2c7be3/tick/r.q:
     annotations:
       linguist: q
+      linguist-heuristics: q
       vote: q
   github.com/KxSystems/kdb/f7e01e8379faaccdb8306a83650f6e1618423d33/tick/chainedtick.q:
     annotations:
       linguist: q
+      linguist-heuristics: q
       vote: q
   github.com/KyleLavorato/TCPStream/810f0f1f3ce957882bb65bd2d1ca2007ce88634c/Application/GENERATOR/TXL/generateMake.txl:
     annotations:
       linguist: TXL
+      linguist-extension: TXL
       vote: TXL
   github.com/Kylebrown9/BabyShark/365223466ad173cd7a68f26c419e43013e5a73b4/baby_shark.bf:
     annotations:
@@ -1776,29 +2190,36 @@ files:
   github.com/LEXBLAS/jsonapi/47c21a87939a74561fd2161fa8dc741fef6ebb84/tar115.sra:
     annotations:
       linguist: PowerBuilder
+      linguist-extension: PowerBuilder
       vote: PowerBuilder
   github.com/LGalaxiesPublicRelease/LGalaxies_PublicRepository/47be08275c251cc49b0824d2bf0cb82bb2acc9cf/AuxCode/Idl/Misc/utils/idlutils/pro/trace/fchebyshev_split.pro:
     annotations:
       linguist: IDL
+      linguist-heuristics: IDL
       vote: IDL
   github.com/LHSNet/PCORNet-CDM/361bd96f8604e3f30bc2071a6193c66d0ac2e7f7/PCORNet-CDM-v4.1/sas/create_individual_tables/pcornet_cdm_4_1_procedures.sas:
     annotations:
       human-smola: SAS
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/LPLemnij/HW2/6e27f7b1888a7334ccf37f96146baaf49cb56f88/test.SED:
     annotations:
       human-smola: INI
       linguist: sed
+      linguist-extension: sed
       vote: INI
   github.com/LabVIEW-DCAF/ModbusModules/b98448706e167279a209bcfb94d04c3d54921596/source/editor node/modbus slave editor dev.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/LastOfTheCarelessMen/Vector/621355e8b5fe25564afd8ba9ce461f91e4569dcf/svg.pl:
     annotations:
       human-smola: Raku
       linguist: Raku
+      linguist-heuristics: Raku
       vote: Raku
   github.com/LaverdeS/Argument_Political_Membership/f127aaab83d578cc06d4fdfcd303eaa6d48669f8/Canadian-Parliament/Senate_Debates/hansard.36.2.senate.debates.2000-05-10.54.e/hansard.36.2.senate.debates.2000-05-10.54.e:
     annotations:
@@ -1807,40 +2228,50 @@ files:
   github.com/LeartS/loleuler/f8f508b45f07f8c59043c1e25756e369e246f965/010.lol:
     annotations:
       linguist: LOLCODE
+      linguist-extension: LOLCODE
       vote: LOLCODE
   github.com/Lehs/BIG-INTEGER-ANS-FORTH/4d072e39cf7951362af79de1005cce65cf3e966e/BigIntANSForth.txt:
     annotations:
+      human-smola: Forth
       linguist: Forth
+      linguist-heuristics: Text
       vote: Forth
   github.com/Leont/perlio-utf8_strict/c7a3bcc55d77468700b49fe6bbbb4493613f908a/utf8_strict.xs:
     annotations:
       linguist: XS
+      linguist-extension: XS
       vote: XS
   github.com/Leushenko/ybc/b69312c6bc9aad5752119df04f93a50d05486755/ybexpressions.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/LibreELEC/LibreELEC.tv/cfe1640715ce139aae0e5f08e9a79e9ede007423/packages/devel/yajl/package.mk:
     annotations:
       human-smola: Shell
       linguist: Makefile
+      linguist-extension: Makefile
       vote: Shell
   github.com/LibreHealthIO/community-infra/6620815aeed8af197798469c4dacabfd1572c1be/ansible/host_vars/toolkit.librehealth.io:
     annotations:
       human-smola: YAML
       linguist: Io
+      linguist-extension: Io
       vote: YAML
   github.com/LightTable/LightTable/177077d3f3a2457873a3a117812dde60d84134f5/src/lt/objs/plugins.cljs:
     annotations:
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/Lillecarl/ROS_Scripts/f58c478db9b7361c494e98ae61cb4e722c0a51b4/Tunnels/UpdateTunnelsFromComments.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/LisiLisenok/Chime/bdc7ffd652b3e34cac535d0e408f8ffd771ee26e/source/herd/schedule/chime/cron/parseCronStyle.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/LispCookbook/cl-cookbook/9fed0f1e3c910a2d3e0f38b02d1a61b96bd957d6/_includes/code/s23.lisp:
     annotations:
@@ -1850,18 +2281,22 @@ files:
   github.com/LnL7/nix-darwin/3fde04a384d4edf68b726178349a12b9aeb1e05d/modules/services/synapse-bt.nix:
     annotations:
       linguist: Nix
+      linguist-extension: Nix
       vote: Nix
   github.com/LogtalkDotOrg/logtalk2/9140cd69321531dac1fe15381b3506108965ebc7/library/setp.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/LookAtThisUrl/Resume/ea44667000aff8207f69eb7580ff45841f40f205/tea/index.kit:
     annotations:
       linguist: Kit
+      linguist-extension: Kit
       vote: Kit
   github.com/Lord-Kamina/Deluge-Magnet-Handler/d14f5e7b446050763bb2584e8091eb66c894d088/Magnet Handler.applescript:
     annotations:
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/LouisChang/The-Total-Weighted-Tardiness-Scheduling/06ba58d6ff51afd6e4814ec17c6c392b8a1d2314/Scheduling_HW3_2.mod:
     annotations:
@@ -1870,6 +2305,7 @@ files:
   github.com/LouisJenkinsCS/Distributed-Data-Structures/beb76110e161168a0f096e15815eed206993ce03/testing/Benchmark.chpl:
     annotations:
       linguist: Chapel
+      linguist-extension: Chapel
       vote: Chapel
   github.com/LuaDist-testing/luascope/62d4cbb270f3951bd7730acbb83679f33c755981/t/usage.t:
     annotations:
@@ -1879,63 +2315,78 @@ files:
   github.com/LubomirBednar/PhD/d5e04c89361b06905b0e00e1a79be89bd69849e9/E7/E7_RT-qPCR_template.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/LucasWolschick/Monkeynauts/3920b842e1a0ee1c88d97201d3e9247e8663ddeb/src/Asteroids.monkey2:
     annotations:
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/LukeSmithxyz/vul/2f031ac7017eba3642173c40e37396cd290fb50b/vul.awk:
     annotations:
       linguist: Awk
+      linguist-extension: Awk
       vote: Awk
   github.com/Luminoid/urban-transportation-system/9e8c945247290429106f4a75aa64661501e37a90/UrbanTransportationSystem.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/M165437/laravel-blueprint-docs/f82c0b2e4ebcdc29c2bdb220372f15e5c8a44a2a/example.apib:
     annotations:
       linguist: API Blueprint
+      linguist-extension: API Blueprint
       vote: API Blueprint
   github.com/MBcode/CLIPSmsc/05a813b3993104fb8ea82700bd1cec85a2949e6d/csd.auth.gr/o-device/functions.clp:
     annotations:
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: CLIPS
   github.com/MIPSfpga/schoolMIPS/986ff72cfee670b57f74fc2dafdb7f9318507dd3/src/sm_register.v:
     annotations:
       linguist: Verilog
+      linguist-heuristics: Verilog
       vote: Verilog
   github.com/MIT-LCP/mimic-cookbook/15957afb8efb2cac28d417cfa9d1c1761997c434/hana/setup.sql:
     annotations:
       linguist: SQLPL
-      vote: SQLPL
+      linguist-heuristics: SQL
+      vote: Unknown
   github.com/MJVL/BTS-Zebra-Projects/1a120b7376e737b7b5d7af8248f5459fc3f71baf/ZPL files/On a Stick Scan.zpl:
     annotations:
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Zimpl
   github.com/MLstate/birdy/bd1017bd828c5e23de4c09b16f774cd1f0ffb34c/src/model/msg.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/MLstate/hello_recaptcha/645e219ee958cd43e8f5543cb3a130ca8c0e1641/hello_recaptcha_test.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/MOderkerk/rexx/5ef41525367152cc5ee38c8fb0b4eab41040878f/gzip.rexx:
     annotations:
       linguist: REXX
+      linguist-extension: REXX
       vote: REXX
   github.com/Ma1ak/Monkey-Color/2ebb06c6df3fb51296f7ed4d122e280ec529e405/MonkeyColor.monkey:
     annotations:
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/Macri-man/MathModels/4cd2345874020cd0809d0bf9c62c76bc8a1fa5a9/alloy/diningphilosepher.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/Madave94/AspectJFoo/50746f2a5b750f7c602bf3d65dca5c0b33627e89/src/LockerMessage.aj:
     annotations:
       human-smola: AspectJ
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/MagerValp/ArcadeGameSelector/e21f22ff84ca3d6014e95e2c3c45214bbeaa6c3f/AGS2Menu.e:
     annotations:
@@ -1946,14 +2397,17 @@ files:
     annotations:
       human-ajnavarro: Unknown
       linguist: NewLisp
+      linguist-heuristics: NewLisp
       vote: Unknown
   github.com/MahmoudFayed/WeightHistory/a57ac374af1287c28df80a164ee52a2a69c4690f/weighthistory.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/MajdiSobain/mini-rnote/2d6699e3293570e25a8fdc92f6743e39ebdb4996/applications/minirnote/rnote.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/MakeNowJust/quine/1edbe9eeb2f7c5bd4f29a60ca5eba9a17fe6c944/quine.eiffel.e:
     annotations:
@@ -1963,27 +2417,33 @@ files:
   github.com/Makiah/BotW-SBFRES-to-FBX/d6552301e27eb147610afdc1ba19df9816d26d7b/fbxextraction/Libraries/WiiU_BFRESImporter/BFRES Script_R4_Debug.ms:
     annotations:
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: MAXScript
   github.com/Malabarba/Nameless/a3a1ce3ec0c5724bcbfe553d831bd4f6b3fe863a/nameless.el:
     annotations:
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/Malabarba/speed-of-thought-lisp/ed2356a325c7a4a88ec1bd31381c8666e8997e97/sotlisp.el:
     annotations:
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/Malurth/Auto-2-day-HCCS/e4d7c651c4ce4a9ac181d1de66ddefa6c5b62c63/relay/relay_AutoHCCS.ash:
     annotations:
       linguist: AGS Script
+      linguist-extension: AGS Script
       vote: AGS Script
   github.com/Manitary/advent-of-code/803f38a11d2e7980d46b42bb80bc5e0cc2c31830/2018/18_11.mg:
     annotations:
       human-smola: Unknown
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Unknown
   github.com/MarkGoldberg/ClarionCommunity/245397dfa3374aad578559d352659fb27cc8a43f/CW/Demos/CopyConstructor/CopyConstructor.clw:
     annotations:
       linguist: Clarion
+      linguist-extension: Clarion
       vote: Clarion
   github.com/MarkGoldberg/CwUnit/72a6833d1a5e0bc5d646d31f3f2bd1eb6e8885b7/CwUnit/ctTestDlls.inc:
     annotations:
@@ -1992,31 +2452,38 @@ files:
   github.com/MarkRoddy/brstest/7be7ba593b1841a258fa0e36b1741d5e79127377/source/test_testsuite.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/Martinfx/Cobol/f1bb3163d6673fc72a831623de4f9fc8bde7a062/OpenCobol/String/String.cbl:
     annotations:
       linguist: COBOL
+      linguist-extension: COBOL
       vote: COBOL
   github.com/MartynEcc0/Custom-Light-Bars/20ce516e8ad07015087b640d3e740b34634a6286/Pakistan v1.2 - Copy/Pakistan Master/Previous/v1_08/Include/expressions_primary_verbose_front_rear.ec:
     annotations:
       human-smola: Unknown
       linguist: eC
+      linguist-extension: eC
       vote: Unknown
   github.com/MathGravel/ProjetINF7845/2491435747e211c088983e56de27d5904eea6db7/Midi/midifile.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   github.com/MattTuttle/hxnet/47c2cad01689eb1dd7da76e0e2379ca0a84967fd/test/TcpTest.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/Matthewspear/OFList/b31fd504373f0bafaf2c66e1a9974a31f88d2f76/OFList.scpt:
     annotations:
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/Max64000/nitauth/9c179f46389ebc409dbe7949295bfac06696cdef/authtoken.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   github.com/Mayank-Khurmai/Html-Css-PHP-Login/826de60c623991cfaecf4f585c8442c6d2c33f6d/Index.php:
     annotations:
@@ -2026,10 +2493,13 @@ files:
   github.com/MediaBrowser/Emby.Roku/0908e13f68433284c1b411f094a1be62cf781ec4/source/PhotoSpringboardScreen.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/Mercury-Language/mercury/0a1f289b6d4f464822f853f982d319032b4f17f6/tests/valid/instance_unconstrained_tvar.m:
     annotations:
       linguist: Mercury
+      linguist-heuristics: Mercury
+      linguist-modeline: Mercury
       vote: Mercury
   github.com/MetaCell/NEURON-UI/2a642c78a127a500ba139b83bb8d263035b52be7/neuron_ui/models/PTCell/mod/hsyn.mod:
     annotations:
@@ -2039,104 +2509,132 @@ files:
   github.com/Michael-Kelley/CABAL-Online-3ds-Scripts/51cbd3dd919e75106ad11c9c9a405620a1d75454/export_ebm_cabal.ms:
     annotations:
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: MAXScript
   github.com/MichaelBurge/pornview/b4aefdc0e49504aa88345b96710bd86645ab2477/PV/SetoidLists.v:
     annotations:
       linguist: Coq
+      linguist-heuristics: Coq
       vote: Coq
   github.com/Microalg/microalg/75b7f8fbf57614e25a10943fc22ad480a3fa285f/microalg_export_python.l:
     annotations:
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
       vote: PicoLisp
   github.com/MicrosoftDocs/architecture-center/1f4c13198e35b36a4cf0abcfa5783e796f34fb51/build/topic-pages/templates/tile.liquid:
     annotations:
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/MicrosoftDocs/azure-docs/26ae64aa2167b4b9c1edb2748425d16f0ff2aac8/.openpublishing.build.ps1:
     annotations:
       linguist: PowerShell
+      linguist-extension: PowerShell
       vote: PowerShell
   github.com/MicrosoftLearning/edX_DAT215x_Microsoft_SQL_Database_Development/5c8a3a9a84a55d3e5be82e889085fda9babe1387/Labs/DAT215_2/Lab_Solution/Lab3.sql:
     annotations:
+      human-smola: TSQL
       linguist: SQLPL
-      vote: SQLPL
+      linguist-heuristics: TSQL
+      vote: TSQL
   github.com/Mijyuoon/Chatur-Redux/fc49bf12c51ba612ef14f5432b9daa1143769607/MijMarkup/Properties/AssemblyInfo.n:
     annotations:
       linguist: Nemerle
+      linguist-heuristics: Nemerle
       vote: Nemerle
   github.com/MikeHart66/fantomEngine/41dd816c40d6e6bc815e6e36b332d5f759b5bcd7/cftTween.monkey:
     annotations:
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/MikeHeiber/Excimontec_Analysis/253fedb5db0dd7f459854ef2174e1020f3cfac7f/Excimontec-analysis.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/MikeInnes/Lazy.jl/5ab3bf23bbd54a0c88b5d867fcb5a9d37d43c4a2/test/runtests.jl:
     annotations:
       linguist: Julia
+      linguist-extension: Julia
       vote: Julia
   github.com/Mille366/Hourboost/bb39c8cf698f57378f31060343456164dea0ad23/Release/HourBoostr/GlobalDB.hb:
     annotations:
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Harbour
   "github.com/MisterBooo/LeetCodeAnimation/a0346c24c8d98aa58fabafd4d84b950edcc12ee1/notes/LeetCode\u7B2C24\u53F7\u95EE\u9898\uFF1A\u4E24\u4E24\u4EA4\u6362\u94FE\u8868\u4E2D\u7684\u8282\u70B9.md":
     annotations:
       human-smola: Markdown
       linguist: Java
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/Mitchboo/XojoiOSWrapper/b9754f962a3883c3bb6110ae6bacf79067345272/SetNavigationBarColor.xojo_code:
     annotations:
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/ModalityTeam/Modality-toolkit/cf6aa3f34b555387ba7dabb694ddcbb7a3d64e61/Modality/MKtlDescriptions/qunexus/keith-mcmillen-qunexus_port1_AB.desc.scd:
     annotations:
       human-smola: SuperCollider
       linguist: SuperCollider
+      linguist-extension: SuperCollider
       vote: SuperCollider
   github.com/MooersLab/pymolsnips/f7e59501567d6edaedb67deb4c5a0666bc680394/yasnippetspymolsnips/coordinate:
     annotations:
       linguist: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/Morpheu5/MathParser/b1d08f6cb022767c9fcab5a546a8026bf47af14a/src/assets/grammar.ne:
     annotations:
       linguist: Nearley
+      linguist-extension: Nearley
       vote: Nearley
   github.com/Morriar/CatFacts/1e5eccb9c011ec2965f2d7e9b3eabd4eb4bfe3ed/src/app.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   github.com/Morriar/Missions/28de15b97636b5017f69e72d650ce7f6e48c504c/tests/model/test_stats.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   github.com/Morriar/nitrpg/489fde727e3d7945a2786818099fa581808c6c83/src/test_events.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   github.com/Morriar/watchdog/33039f6445fb6b51a649d0d5d7d36e6ac05b9c46/src/api/api_users.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   "github.com/Mr-xn/BurpSuite-collections/d5f569d13f6a0cbe18e06b5ccb555889419a78a7/\u521B\u5EFA\u684C\u9762\u5FEB\u6377\u65B9\u5F0F.bat":
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/MuSAELab/BLE-Toolkit-LabVIEW/18cc144a525d082682106224d2c3ecef436dc205/ble_toolkit.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/MuSAELab/MuLES/8d0bd7041aa401360fecc1c8427acd5c22709ca4/MuLES_source/MuLES.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/NBISweden/workflow-tools-evaluation/619aa77e0c6fc27055ecf0a54f2954ec382efd0e/002-resequencing/resequencing_workflow.cwl:
     annotations:
       linguist: Common Workflow Language
+      linguist-extension: Common Workflow Language
       vote: Common Workflow Language
   github.com/NHALX/Shen-SBCL/15e72f49e3df145455c36e39e4f43a6e9b5aebee/Platforms/SBCL/backend.shen:
     annotations:
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/NIDCD/lsnm_in_python/c244ba39627840485919ca395c08287eded3cf2c/visual_model/subject_19/lgnsev1h.w:
     annotations:
@@ -2146,137 +2644,173 @@ files:
   github.com/NISystemsEngineering/FrontPanelLayout/01dae98e23e6550075da82ad2f26d03920d111d5/trunk/source/Panel Layout.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/NISystemsEngineering/LinuxRT-IPC/5bbdb1230a3485122ddc2afb6433c6b28e99b013/Development/LinuxRT-IPC.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/NVIDIA/cutlass/7c0cd26d13e0e0c41a5b6874f06976575e613e72/test/unit/gemm/device/gemm_f16t_f16n_f16t_volta_tensor_op_f16_sm70.cu:
     annotations:
       human-smola: CUDA
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/NVIDIA/deepops/854996da8285c1a458f01f06e664951c5c90a3c8/containers/kubeflow-jupyter-web-app/releaser/lib/ksonnet-lib/v1.8.0/k.libsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/NVIDIA/nv-wavenet/03f69576f6c6b984340c1ddef2288e3f7d1102ca/nv_wavenet.cuh:
     annotations:
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/NVIDIA/nvidia-docker/f65beafbfa8734328af38a4dd8270687f6507abb/Makefile:
     annotations:
       linguist: Makefile
+      linguist-filename: Makefile
       vote: Makefile
   github.com/NVlabs/cub/c3cceac115c072fb63df1836ff46d8c60d9eb304/cub/block/block_histogram.cuh:
     annotations:
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/Nachiten/Gimnasio_Pokemon/ab9505ef84c4288096b1a9f93912c975e4187a6d/src/pokemon.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/Nadrew/console/4807bcb21f9721884cdb237997a9f9c437eafbac/code/hardware/door.dm:
     annotations:
       human-smola: DM
       linguist: DM
+      linguist-extension: DM
       vote: DM
   github.com/NaldoDj/BlackTDN/9e4d338557043fe76d14e7fae30354a1b3f908d2/templates/include/protheus/fwschedule.ch:
     annotations:
       human-smola: xBase
       linguist: xBase
+      linguist-heuristics: xBase
       vote: xBase
   github.com/NaldoDj/xml-rpc/6f3edcaaf4c178b36e0ff591b332d6f098178bda/bin/commit.hb:
     annotations:
       human-smola: Harbour
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Harbour
   github.com/Nani-o/ansible-role-dotfiles/92c9921a308aa4d3014acdcd9a4d33d94d46c2ee/tasks/main.yml:
     annotations:
       linguist: YAML
+      linguist-extension: YAML
       vote: YAML
   github.com/Nani-o/ansible-role-fzf/fbf8f55278b1bdf1a7b6b49026b8a325584f1c28/tasks/main.yml:
     annotations:
       linguist: YAML
+      linguist-extension: YAML
       vote: YAML
   github.com/Nani-o/ansible-role-golang/30732cdc5ce2903f7d34cc1b566b8f3ba8a4b615/tests/post-check.yml:
     annotations:
       linguist: YAML
+      linguist-extension: YAML
       vote: YAML
   github.com/Nani-o/ansible-role-home-assistant/e8cf19c3ecc08ea27ba6313a5eefda8af9319f25/tests/post-check.yml:
     annotations:
       linguist: YAML
+      linguist-extension: YAML
       vote: YAML
   github.com/Nani-o/ansible-role-lxd/e4be464d9e0993566d767232e19438450c3f0724/.travis.yml:
     annotations:
       human-smola: YAML
       linguist: YAML
+      linguist-extension: YAML
       vote: YAML
   github.com/Nani-o/ansible-role-netdata/bd0338dc9455594ad1d37b6c5cbd50da49c861a2/meta/main.yml:
     annotations:
       linguist: YAML
+      linguist-extension: YAML
       vote: YAML
   github.com/Nani-o/ansible-role-ohmyzsh/af8207f2beee12dd4a32bfb934d29053f2e28f16/tasks/ohmyzsh.yml:
     annotations:
       linguist: YAML
+      linguist-extension: YAML
       vote: YAML
   github.com/Nani-o/ansible-role-python/b9d161ebb2147af72dc0e602fa41e4539b7e9e6b/tasks/packages.yml:
     annotations:
       linguist: YAML
+      linguist-extension: YAML
       vote: YAML
   github.com/Nani-o/ansible-role-seedbox/7ef8c9691ad2971120628928d7e0acc3aaca121a/tasks/youtube-dl.yml:
     annotations:
       linguist: YAML
+      linguist-extension: YAML
       vote: YAML
   github.com/Neilpang/acme.sh/3d2df3ba93dfcb3eb4510fadd2d33a43f74ff586/dnsapi/dns_one.sh:
     annotations:
       linguist: Shell
+      linguist-extension: Shell
+      linguist-modeline: Shell
+      linguist-shebang: Shell
       vote: Shell
   github.com/NetLogo/Galapagos/01a04d07b83400a251255a2c8887e9ac8cecf3b3/public/modelslib/Sample Models/Art/Follower.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/NetLogo/models/773d1e1005fac5b0833d84fc139c98b4f386d1ab/HubNet Activities/BeeSmart HubNet.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/Netflix/asgard/648102625a4b6d2c3669b7837c2a5768c20b16a3/test/unit/com/netflix/asgard/model/InstanceTypeDataTests.groovy:
     annotations:
       human-smola: Groovy
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/Netflix/atlas/b79a0bd57f75e64a774a45c2336d8c1aae48f206/project/plugins.sbt:
     annotations:
       human-smola: Scala
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/Netflix/fast_jsonapi/3df917f4073bc3752c2078a84099bc85d5b4f8b9/spec/shared/contexts/jsonapi_group_context.rb:
     annotations:
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/Netflix/vectorflow/7ba548ebb70d60e2dd4a8afcee722bd4c9529c83/src/vectorflow/optimizers.d:
     annotations:
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/NextronSystems/APTSimulator/30cbecc4663641ed43767361ca22d46cc5a80eb0/test-sets/command-and-control/wmi-backdoor-c2.bat:
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/NimParsers/parsetoml/329cc618fe27a6c89708d1fa17ddc72f8da97e08/tests/test1.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/NixOS/nixpkgs/b69a51a08bc3a5e84d89fbe79d033049fb66ab4e/pkgs/development/python-modules/azure-applicationinsights/default.nix:
     annotations:
       linguist: Nix
+      linguist-extension: Nix
       vote: Nix
   github.com/Nobiles2/MySQLToolBox/a932a6c0f0885472f3dc2944406477512165ff7c/getPhpSerializedArrayValueByKey.sql:
     annotations:
       linguist: SQLPL
-      vote: SQLPL
+      linguist-heuristics: SQL
+      vote: Unknown
   github.com/OCSInventory-NG/Packager-for-Windows/3751643d51807aa76631be8642d6d0116b2f5211/Packager/ListBox.nsi:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/OCamlPro/ocp-typechecker/cd37d443d627ceb22289685995a0356da96f7fe8/autoconf/m4/ax_compare_version.m4:
     annotations:
@@ -2285,62 +2819,77 @@ files:
   github.com/OSEHRA-Sandbox/VistA/886b9c4c5043ad75173d3667287efe8b7706ec05/Packages/Integrated Billing/Patches/IB_2.0_501/IB-2_SEQ-453_PAT-501.KID:
     annotations:
       linguist: Genshi
+      linguist-extension: Genshi
       vote: Genshi
   github.com/OSEHRA/FOIA_Mirror/1bcf94ce6d6ae5bcf71aab9eaf8ecf05d42340cd/Packages/Pharmacy Data Management/Patches/PSS_1.0_139/pss-1_seq-126_pat-139.kid:
     annotations:
       linguist: Genshi
+      linguist-extension: Genshi
       vote: Genshi
   github.com/OSEHRA/SAMI-VAPALS-ELCAP/d354333ef0a2a75b4d5b2ed6a325c31f22a5409f/kids/SDVALLPTS.KID:
     annotations:
       linguist: Genshi
+      linguist-extension: Genshi
       vote: Genshi
   github.com/OSEHRA/VistA/076f96148bdd0a8aefeebf2ee205f61ae0e06333/Packages/Incident Reporting/Patches/QAN_2.0_33/QAN-2_SEQ-33_PAT-33.KID:
     annotations:
       linguist: Genshi
+      linguist-extension: Genshi
       vote: Genshi
   github.com/OTRS/otrs/f585e59959e3ea357ea55f77f0d5f4d5dc5dc292/scripts/test/Selenium/Agent/CalendarLimitOverview.t:
     annotations:
       linguist: Perl
+      linguist-heuristics: Perl
       vote: Perl
   github.com/Oaprendiz/hb3D/943a6f256254513ee5c53dc4cbc37216497d0d74/bin/commit.hb:
     annotations:
       human-smola: Harbour
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Harbour
   github.com/Oleg-N-Cher/OfrontPlus/1773f295502f4424407f205a6af6a4b05c425e60/Lib/Mod/Args.Mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/Omegaice/WOTTankRanges/90067c21f69ee59e45e6f0ae48c02f1d3d0825b3/xvm/xvm/l10n/fi.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/OneIdentity/Polypkg/20ea9e5170a83daec883dd7fa69914dfb00eaa32/pp.back.kit:
     annotations:
       human-smola: Unknown
       linguist: Kit
+      linguist-extension: Kit
       vote: Unknown
   github.com/OpenAADL/ocarina/121766ca577b01853354ff5991f73d22f5675a5c/src/core/model/ocarina-analyzer-aadl_ema-naming_rules.ads:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/OpenAgricultureFoundation/openag-electrical/be6492c78674adf6ce789993769e7397fa714b48/prj/pfc-edu/v1.0/Mechanical/$rpr_data/doc2/cfg1/prj1/hist/2bb1f54b-48c6-4e50-8a79-87f54ee7c389/pnts_geom/8cb73fbc-ad73-4e95-a2ce-0bd8c07aec20.plot:
     annotations:
       human-smola: XML
       linguist: Gnuplot
+      linguist-extension: Gnuplot
+      linguist-xml: XML
       vote: XML
   github.com/OpenCollar/OpenCollarOwnerHud/9ea19d6ac238b98d57cc34a699c7605ba461abcc/SPARE_PARTS/OpenCollarHUD - hudspy.lsl:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
       vote: LSL
   github.com/OpenCollar/opencollar/18df2a5a90fb38cc187222c8a463a77ff87a843a/src/collar/oc_auth.lsl:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
       vote: LSL
   github.com/OpenCollarTeam/OpenCollar/46d063a1bebb5c6d608a21b142bec739a299aff6/src/collar/oc_particle.lsl:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
       vote: LSL
   github.com/OpenEuphoria/euphoria/3c9ad415ad36db3e8f2ecbb966233f77a4464d3c/tests/t_tokenize.e:
     annotations:
@@ -2350,95 +2899,117 @@ files:
   github.com/OpenFlutter/Flutter-Notebook/817011cb39e24bbba936f9f3fc09bce823835a2a/mecury_project/example/keep_alive_demo/test/widget_test.dart:
     annotations:
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/OpenMandrivaAssociation/filesystem/0d59f03d02290907b22e6016c39133a2ef85d13c/iso_3166.sed:
     annotations:
       linguist: sed
+      linguist-extension: sed
       vote: sed
   github.com/OpenNC/Cuffs/89e02e6873d50ea86a551e2ad23657f0ce654ebc/right-forearm/root/OpenNC - update.lsl:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
       vote: LSL
   github.com/OpenSourcePFCLibraries/12.6/e9284cf51bb590a1d071fe5b88ba398751bda79e/demoapp/pfc_n_cst_explorer.sru:
     annotations:
       linguist: PowerBuilder
+      linguist-extension: PowerBuilder
       vote: PowerBuilder
   github.com/OpenSourcePFCLibraries/2017/4c410a1631b8a54cf3f639c7914a8668c0419930/pfcmain/pfc_n_base.sru:
     annotations:
       linguist: PowerBuilder
+      linguist-extension: PowerBuilder
       vote: PowerBuilder
   github.com/OpenVPN/openvpn-build/2f5bedfb152ad608b2804cad2f85a9934d71e14e/windows-nsis/DotNetChecker.nsh:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/OppDavid/CS420-Final-Project/2ff809d67b291245b4eab84c5e6460f38d874e7b/logic.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/OptimaSystems/GAP/e159b301cbe8b099fa0dfdc1e0083a26076a9ef2/GAP_Tests.dyalog:
     annotations:
       linguist: APL
+      linguist-extension: APL
       vote: APL
   github.com/OraOpenSource/OXAR/5ab2cd5ac44468f121d52d0b64f9393b7e9e724e/addons/aop/install_db_sample_obj.sql:
     annotations:
       human-smola: PL/SQL
       linguist: PL/SQL
+      linguist-heuristics: PL/SQL
       vote: PL/SQL
   github.com/OraOpenSource/language-oracle/f3fd20a22b5752e8c4fd17b75f089cdaa2aee2d5/utility/longfunctionlist.sql:
     annotations:
       human-smola: PL/SQL
       linguist: PL/SQL
+      linguist-heuristics: SQL
       vote: PL/SQL
   github.com/OrysyaStus/UCSD_Data_Mining_Certificate/423a11cc4bead8696330683f1700243e5e52bd73/BIOL40190_SAS_ProgrammingI_DATA_Step_and_PROC_Fundamentals/A1_ReadinginData_PermanentDataSets_Formats_Labels_ConditionalProcessing_Looping_Dates/chapter4_Creating_Permanent_SAS_Data_Sets.sas:
     annotations:
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/Ourous/dirty/49f264f8e1838c894ab915c66e870e1b980c49c1/Dirty/Backend/Number.icl:
     annotations:
       human-smola: Clean
       linguist: Clean
+      linguist-extension: Clean
       vote: Clean
   github.com/Outworldz/LSL-Scripts/a1e8de1f0f6688d6110723c8bb04fd1090bb1c60/The_Blue_Whale_project/The_Blue_Whale_project/Object/The_Blue_Whale_project_1.lsl:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
       vote: LSL
   github.com/PGTima/ExpertSystem/5b4177fedf33d910ea5f29048f4fe66680cdccce/health.clp:
     annotations:
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: CLIPS
   github.com/PRML/PRMLT/50a654cd556d4f33a34132a1163bbaf47b1ebc2b/chapter10/mixGaussVb.m:
     annotations:
       linguist: MATLAB
+      linguist-heuristics: MATLAB
       vote: MATLAB
   github.com/PSEmulator/Client/6f644a754736b7a44f4fd660562dbe1bf1ade87f/expansion1/expansion1/ugd03.zpl:
     annotations:
       human-smola: Unknown
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Unknown
   github.com/PSLmodels/taxdata/c3d35a627a3a1fd96b49671ebd2874f43df0194a/cps_data/State Database - 2015/Production File/Programs/CreateProductionFile2015V1.SAS:
     annotations:
       human-smola: SAS
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/PSPDFKit-labs/bypass/0e44e6582f1e2ec580cbc21df6d907e7df5f2a3b/lib/bypass/plug.ex:
     annotations:
       linguist: Elixir
+      linguist-extension: Elixir
       vote: Elixir
   github.com/Paebbels/JSON-for-VHDL/80100fd6dd8c0cf27c7356391f6cbfb5efcddd42/JSONTestSuite/TopLevel.vhdl:
     annotations:
       linguist: VHDL
+      linguist-extension: VHDL
       vote: VHDL
   github.com/Pagedraw/pagedraw/e3bdc2f26b0eaf57a91fbf70d35e4e43ffaeff5b/src/blocks/triangle-block.cjsx:
     annotations:
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/Pakz001/Monkey2examples/51a38eaa27d78e4cb853241535bc337c6c6d2d37/Beginners - Microsecs and Millisecs.monkey2:
     annotations:
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/Pakz001/MonkeyXExamples/6e5fd232a6cdb3bf8bdd58fc7d82ad7dd44d4a54/Monkey-X - Flow Fields Multiple Agents.monkey:
     annotations:
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/Panaedra/panaedra_oe_demo_lowdep/8d97817dfe43e427d29ca50821b5d3b24066f99f/src/panaedra/msroot/mspy/logic/sc_mspython_externals_lowdep_def.i:
     annotations:
@@ -2453,15 +3024,18 @@ files:
   github.com/PapirusDevelopmentTeam/arc-kde/04873ca3f4b46fda46c39dc4778af0762be947e6/plasma/look-and-feel/com.github.varlesh.arc-dark/contents/splash/Splash.qml:
     annotations:
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/ParadiseSS13/Paradise/8b9f6632038bbc98f93ce1c0740c3d7ea5f0f9cc/code/modules/nano/subsystem.dm:
     annotations:
       linguist: DM
+      linguist-extension: DM
       vote: DM
   github.com/ParadoxChains/BScFunctionalProgramming-2019-Fall/8c6cfe6082907867d7b1a7b1890e23631fc34261/Sample Tests/SampleMidterm2.icl:
     annotations:
       human-smola: Clean
       linguist: Clean
+      linguist-extension: Clean
       vote: Clean
   github.com/Parou/Cocoa-Biscuit-Cake-with-Marshmallow-Cheese-Creme/6ede21dc025ec8f9daf2fb51f80f0b946a764df6/brainfuck/recipe.bf:
     annotations:
@@ -2470,279 +3044,350 @@ files:
   github.com/Pascal-J/Jchess/b05f63d7b3cf555cabac27a705998d7c6b2153c3/chess.ijs:
     annotations:
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/Pascal-J/type-system-j/ce294fb8d683848ed519b48fc5d01544fef5fb44/typesys.ijs:
     annotations:
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/Passw4r/dotfiles/a068dd0db007aa84d1e8c5539de129e41390305f/config.i3:
     annotations:
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Modula-3
   github.com/PaulBatchelor/libline/67f99c121fb407e97c5363177a07cd4e9c79fa53/point.w:
     annotations:
       linguist: CWeb
+      linguist-heuristics: CWeb
       vote: CWeb
   github.com/PaulBatchelor/the_oscillator/2ec14caab1d8d067c170a853d503247f28218578/oscillator.w:
     annotations:
       linguist: CWeb
+      linguist-heuristics: CWeb
       vote: CWeb
   github.com/PaulBone/mfcgi/6a3722cd472d6682df6c7578b1a15815c5a9eacc/basic.m:
     annotations:
       linguist: Mercury
+      linguist-heuristics: Mercury
       vote: Mercury
   github.com/PaulBrownMagic/BedSit/c3f18ce19b346fc1397d9d2ae25a5dd01e1eef4e/sit_man.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/PaulBrownMagic/PongTalk/ba190e020babc818a22df8cdf1c5e66d08df8fae/loader.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/PaulBrownMagic/RADruntime/40d491b5d5a7a3a70bfc12e9a50d50f9d549edf5/radruntime.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/PaulBrownMagic/TrackTime/387c63ab6e69b03ed241067b56b6c31e9b2b04e8/loader.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/PavelPawlowski/SQL-Scripts/6a8df239f22a581a00ab3254406c03f0d4ace6fe/SSISDB/sp_SSISExportProject.sql:
     annotations:
       human-smola: TSQL
       linguist: PL/SQL
+      linguist-heuristics: TSQL
       vote: TSQL
   github.com/PavlezT/Tiva-MCU-TM4C123G-LaunchPad/88256c7ba6b5ac657f10a13b3e6cee4afd6b26b0/blinkyAlien/Debug/bme280_old.rl:
     annotations:
       linguist: Ragel
+      linguist-extension: Ragel
       vote: Ragel
   github.com/Pebaz/RGB/6736ea0f3898a334050589fdc1074022a27273c3/example/multiple_struct_variable_declarations.reds:
     annotations:
       human-ajnavarro: C
       linguist: Red
+      linguist-extension: Red
       vote: C
   github.com/Peltoche/lsd/c4d5f5ea0b1ee9ae549438b58df79f00fa209023/src/meta/windows_utils.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/PerseusDL/canonical-greekLit/0a655908a93a386ab4ab81121e1d699323758b38/pre-install.xql:
     annotations:
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/PeterHuZQ/EOS-Dapp/23a2dd9042e0f18a8e8bd5fd80ef20016cb4ef4b/contract/motherday/motherday.wast:
     annotations:
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/PeterJudge-PSC/abl_performance_workshop/0a7f5497c18ad345a1ef8c48f12d7b7e3662e950/profiler_labs/src/function_inline.p:
     annotations:
       human-smola: OpenEdge ABL
       linguist: OpenEdge ABL
+      linguist-heuristics: OpenEdge ABL
       vote: OpenEdge ABL
   github.com/PhilHudson/yasnippets/bb34caf975e5bd88f0072f3bd68e5b805872fd50/org-mode/letterhead:
     annotations:
       linguist: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/PhilippSalvisberg/plscope-utils/6314afd7232fd039ea26e19584fb670a31890028/database/test/package/test_dd_util.pks:
     annotations:
       human-smola: PL/SQL
       linguist: PL/SQL
+      linguist-extension: PL/SQL
       vote: PL/SQL
   github.com/PhilippeSigaud/Pegged/dc2a85b9c026878920c3bbbe5ced68c0fa5f07a2/pegged/examples/c.d:
     annotations:
       human-smola: D
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/PipelineAI/pipeline/599f7747907fccb797fcd6013f8071f768d0f388/eks/demo/.cache/kubeflow/kubeflow-9804feb9fc23fc30075632a857087f4b529294e2/components/k8s-model-server/images/releaser/environments/prow/.metadata/k.libsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/PixelPaladin/mx2-crt/4166970549461bacb24bbf73921abae16a9f0f6b/example/example.monkey2:
     annotations:
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/PlasmaLang/plasma/183531e28a473222cd5bf738797bc74dcbb504b9/src/ast.m:
     annotations:
       linguist: Mercury
+      linguist-heuristics: Mercury
       vote: Mercury
   github.com/Pluies/SICP/8acad308245bbd35ebce8f7ae73d093e64b7bbc7/Chapter 1.scm:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
       vote: Scheme
   github.com/PolarisSS13/Polaris/176444e1a74bb4f9c22fad3ff1d6d7ae0964450f/code/game/gamemodes/changeling/powers/rapid_regen.dm:
     annotations:
       linguist: DM
+      linguist-extension: DM
       vote: DM
   github.com/PolyJIT/polli/832ccdbcd43608695a78409b89294e9053dbce78/test/pprof/SingleSourceBenchmarks/main_for.body.22.us.i.pjit.scop.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/Polytonic/Glitter/fa5393b1548edd56b5bb39442dca837aabe1e80c/CMakeLists.txt:
     annotations:
       linguist: CMake
+      linguist-filename: CMake
+      linguist-heuristics: Text
       vote: CMake
   github.com/Poofjunior/fpga_fast_serial_sort/fca3dbde3cf935aede9c98cc27ac020027b1e974/spi_slave_interface.sv:
     annotations:
       human-smola: SystemVerilog
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/PortableApps/Launcher/3eec0c4623b01f92f1fdd1d99cf13261e69d8c08/App/NSIS/Contrib/Language files/Welsh.nsh:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/PostgREST/postgrest/9847e60dcace57b9ae2f4fbba4ba9bcabceae4c6/test/Feature/NoJwtSpec.hs:
     annotations:
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/PostgresApp/PostgresApp/93d23787898bff1d331d6ca0a937d97b0191b164/Postgres/ClientLauncher.swift:
     annotations:
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/PowerShell/PowerShell/d58a82ad19fbfad81e85778c8b08cb1b28f58fce/src/System.Management.Automation/logging/LogProvider.cs:
     annotations:
       linguist: C#
+      linguist-heuristics: C#
       vote: C#
   github.com/PowerShellMafia/CimSweep/6398e098d3712f9d2e69e7945abc6dbaefb6843e/CimSweep/Tests/Core.CimSweep.Tests.ps1:
     annotations:
       linguist: PowerShell
+      linguist-extension: PowerShell
       vote: PowerShell
   github.com/PowerShellMafia/PowerSploit/c7985c9bc31e92bb6243c177d7d1d7e68b6f1816/Exfiltration/Get-Keystrokes.ps1:
     annotations:
       linguist: PowerShell
+      linguist-extension: PowerShell
       vote: PowerShell
   github.com/PowerSystemsHIL/HIL_2015_Symposium/eed049bb94777a38fc10745cb3d2ea2ce75c8e9c/HIL2015_Symposium_Package/04 Top Level Model/relay_slave_cfg13.opal:
     annotations:
       linguist: Opal
+      linguist-extension: Opal
       vote: Opal
   github.com/Prodesire/Python-Guide-CN/74cb46fefa684e0ca2f2ff6bd291172bf16ddfb6/make.bat:
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/ProfFan/render2plasmid/e438c95f22196e40a1b229dd4d6ecfd52bc6fd56/render.hb:
     annotations:
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Harbour
   github.com/ProjectDent/ARKit-CoreLocation/f302e970055dbc4739082168f49eb7906294e52e/Node Demos/PickerViewController.swift:
     annotations:
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/Ptujec/LaunchBar/a5d8da916a8e2970ea217e7780ec8d805cee2038/iTunes - Fade in out.applescript:
     annotations:
       human-ajnavarro: AppleScript
       human-smola: AppleScript
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/Pulover/PuloversMacroCreator/15f44d68f7cdf6b79df43c6871761c0773981272/LIB/Class_ObjIni.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/QEF/q-e/4132a64778b91c4b090d0213938e00d7b2b64b10/QHA/Debye/cheval.f:
     annotations:
       linguist: Fortran
+      linguist-heuristics: Fortran
       vote: Fortran
   github.com/QWaveSystems/QwaveSys-Raspberry-Pi-Package/9dd7b4350b984bc5434addbc2568bc5523f4cc03/@Examples/Ex_OpenCV_Object_Tracking3.0_Display/Example OpenCV Object Tracking3.0.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/QuentinDuval/IdrisReducers/2947ffa3559b642baeb3e43d7bb382e16bd073a8/src/Transducers/Utils.idr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/Quick/Quick/87c48488f1874132b164c33839b05f76e7cd0d8c/Tests/QuickTests/QuickAfterSuiteTests/AfterSuiteTests.swift:
     annotations:
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/R4PaSs/advent_of_code_2016/a210a64c14374d942eaf53ff6f4d92224d63f807/day2/day2_p2.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   github.com/R4PaSs/brewnit/2e8cf983d6dbae1e57f2d1c79cb3a98d2e992c26/src/model/model.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   github.com/RAKINJA/foro_alpha/900100201950675af4e6927184837674b5effa9e/modelo/proyecto_foro_logico.txl:
     annotations:
       linguist: TXL
+      linguist-extension: TXL
+      linguist-xml: XML
       vote: TXL
   github.com/RBXSystems/mongo-labview-driver/498a6b187783d3c27e21d825a4ab7bb10b2177b9/MongoDB.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/RRUZ/vcl-styles-plugins/622af90d06696290d2beb7962265c31797bbdae0/NSIS plugin/NSISVCLStyles.dpr:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/RRUZ/vcl-styles-utils/e4828aafd3053d026c73cfa7e9c6e0edccc2b0e1/Common/Vcl.Styles.Utils.SysControls.pas:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/Ratany/lsl-repo/bb56eed379877d0c127618cb382b636342d0b136/projects/lib/getlinknumbers.lsl:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
       vote: LSL
   github.com/RayPragma/jmrccz/1de90644cca0fac0894a585e302d84fc76057b17/call_jmrcc.zpl:
     annotations:
       human-smola: Unknown
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Unknown
   github.com/RayeWang/easyadmin/44dcf3d2429ef696c65e986baf5d21c56ab20820/src/main/resources/templates/index.ftl:
     annotations:
       human-smola: FreeMarker
       linguist: FreeMarker
+      linguist-extension: FreeMarker
       vote: FreeMarker
   github.com/ReactiveCocoa/ReactiveCocoa/21deb683540db0d059dd7945627493275936b7db/ReactiveCocoaTests/UIKit/UIActivityIndicatorViewSpec.swift:
     annotations:
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/ReactiveX/rxdart/8b01e7504218063a3373fcb25d63f3ad9d547b05/lib/src/streams/utils.dart:
     annotations:
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/RednibCoding/HumanAttack/006324d2a513bac6e7eaefd58769602c398ca4f9/classes.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/RednibCoding/VirtualChessboard/e1e1be021bc5690dc84dd68c09cbf5ffced5178f/TBoard.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/Redth/PushSharp/f68bb1e0309d8d5cf4fde73fab87e6afc6072e7b/PushSharp.Windows/WnsConfiguration.cs:
     annotations:
       linguist: C#
+      linguist-heuristics: C#
       vote: C#
   github.com/Reference-LAPACK/lapack/6dfa4d4b52c5624dbf9ed8d5a7a8ae21978aa4a4/TESTING/LIN/cerrsy.f:
     annotations:
       linguist: Fortran
+      linguist-heuristics: Fortran
       vote: Fortran
   github.com/ResearchKit/ResearchKit/e19dfbff8d5c33a2d43ed78dcaa024fe0e35db25/ResearchKit/Common/ORKFormStepViewController_Internal.h:
     annotations:
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/RexOps/rex-build/f714b530c9efe4d3dfff6d27e02eb6e6d1f018ae/tests.d/report/report.rex:
     annotations:
       human-smola: Perl
       linguist: REXX
+      linguist-extension: REXX
       vote: Perl
   github.com/Riverside-Software/pct/ed3cb187b53a39f0605cbd6a96c0c7d8431f0bbe/src/progress/pct/compile.p:
     annotations:
       linguist: OpenEdge ABL
+      linguist-heuristics: OpenEdge ABL
       vote: OpenEdge ABL
   github.com/RoaLogic/ahb3lite_interconnect/001b78acab45a71a16ff156b7d94b6264c243a2f/bench/verilog/AHBBusTr.sv:
     annotations:
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/Robert-Tice/AdaRoombot/3fd24658ec075f5b0cc22fe1c29205f901b731cd/src/commands.adb:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/Robinlovelace/geocompr/64672e1a7b54cc05756885240d216b70222ba3dc/code/04-areal-example.R:
     annotations:
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/Rochii/PikeAlgorithms/48e10bd738456606a832b19fdbd2993d4e4fcafe/Search/binarySearch.pike:
     annotations:
       linguist: Pike
+      linguist-extension: Pike
+      linguist-shebang: Pike
       vote: Pike
   github.com/Roniius/hoimi/ac85a9c815483b9b309f332cb94ea2a330ffeb59/hoimi.mod:
     annotations:
@@ -2751,64 +3396,81 @@ files:
   github.com/Rosuav/Gypsum/8e846b55a973029aced36142cc5d588e8aa83874/globals.pike:
     annotations:
       linguist: Pike
+      linguist-extension: Pike
       vote: Pike
   github.com/Rosuav/LetItTrans/0b3357b41cf6d00c91777adc5285dd3b9fa9c5ab/compare.pike:
     annotations:
       linguist: Pike
+      linguist-extension: Pike
       vote: Pike
   github.com/Rosuav/shed/5dd03487d35df85c9b3f627c97854c4004651b30/wpa_config.pike:
     annotations:
       linguist: Pike
+      linguist-extension: Pike
       vote: Pike
   github.com/RubinLiuChina/hellofromchina/3ca2df62c836189087c3eef2acafd531e5c09226/helloView.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/Rupal-IIITD/chapel/924d61041a2be840e2fb06b937cbe6bfe33a81bc/merge.chpl:
     annotations:
       linguist: Chapel
+      linguist-extension: Chapel
       vote: Chapel
   github.com/RustemB/rosetta-code-v/b61d91bb0d39f37c7bf625b786a25c129e02e774/associative_array_creation.v:
     annotations:
       linguist: V
+      linguist-heuristics: V
       vote: V
   github.com/S25214/.dot/4a05cd1a5f830a4aa25f0b3e2bb402f7929353b2/.i3:
     annotations:
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Modula-3
   github.com/SAP/abap-platform-yy/a4d240f59fe32c89c342edf0ac1f073950772d45/src/zcl_yy_data_element_structure.clas.testclasses.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/SAPConsultores/abap/89cdf7c91e968a1e0b57383e7917f9b242fb3263/alv/ZF_ALV_SIMPLE.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/SCM-NV/ftl/ae537ca0ea6f24e597c2871fdd67354df04c269a/instantiations/ftlDynArrayInt.F90:
     annotations:
       human-smola: Fortran
       linguist: Fortran
+      linguist-extension: Fortran
       vote: Fortran
   github.com/SCons/scons/c6ca3bdd2ad8e9a6ceea398934d84def9ba7c497/src/engine/SCons/Tool/docbook/docbook-xsl-1.76.1/xhtml-1_1/graphics.xsl:
     annotations:
       linguist: XSLT
+      linguist-extension: XSLT
+      linguist-xml: XML
       vote: XSLT
   github.com/SDWebImage/SDWebImage/253a5eb7f20c24d428abdae03864a3a336604d1f/SDWebImage/Private/NSBezierPath+RoundedCorners.h:
     annotations:
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/SI-RISCV/e200_opensource/e13b209364f9995375464691638cc8dc3da5615a/rtl/e203/core/e203_exu_alu_lsuagu.v:
     annotations:
       human-smola: Verilog
       linguist: Verilog
+      linguist-heuristics: Verilog
       vote: Verilog
   github.com/SKU-IT/SKU-logo/131ee89af1b06459272f0ef39e660bcc0c71aa69/sku.svg:
     annotations:
       linguist: SVG
+      linguist-extension: SVG
+      linguist-xml: XML
       vote: SVG
   github.com/SWI-Prolog/swish/8093e9249e234fed861b8af8c5d02007fda69a48/lib/gitty_driver_bdb.pl:
     annotations:
       linguist: Prolog
+      linguist-heuristics: Prolog
       vote: Prolog
   github.com/Safecast/Solarcast/47e183c6914bd4001a5e97be3722c66a07cf82af/geiger-module/kicad/OPENHARDWARE_small.mod:
     annotations:
@@ -2819,6 +3481,7 @@ files:
   github.com/Saizan/miller/17637ec5267fac2f2072f8c5d5e2a82d11505a46/Injections.agda:
     annotations:
       linguist: Agda
+      linguist-extension: Agda
       vote: Agda
   github.com/SalesforceFoundation/Cumulus/3f91613d1f607c688d9c2522f111d538a46372b0/src/classes/ADDR_Validator.cls:
     annotations:
@@ -2835,19 +3498,23 @@ files:
   github.com/Sandstoneblade/BoD/6f81495171d8f20b64c87d6709e7acb17c3ef0f3/BoD.ash:
     annotations:
       linguist: AGS Script
+      linguist-extension: AGS Script
       vote: AGS Script
   github.com/SaptakS/clipsCodes/94a08eb56a3050ed1e9d4171df0261fce897b3d6/palindrome.clp:
     annotations:
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: CLIPS
   github.com/SarahChabane/correct-by-construction-SR-systems/c6de239cb1b85ebfedbdb6f19ecf41d73d5b8010/abstioa.ec:
     annotations:
       human-smola: Unknown
       linguist: eC
+      linguist-extension: eC
       vote: Unknown
   github.com/ScilabOrg/scilab/59989ac47463fc47ca5c246dd4597dd4440329dd/scilab/modules/string/tests/benchmarks/bench_strsubst.tst:
     annotations:
       linguist: Scilab
+      linguist-heuristics: Scilab
       vote: Scilab
   github.com/SeasideSt/Seaside/4ba832de34f9b54ddd3c586966d5ffcacd1df150/repository/Seaside-Welcome.package/WAWelcomeExampleFlow.class/instance/renderChooseCheeseCodeOn..st:
     annotations:
@@ -2860,10 +3527,12 @@ files:
   github.com/SelfBatteries/crc32/e0cc5a49e766442c09bef8a5db90796f2df7e726/crc32.self:
     annotations:
       linguist: Self
+      linguist-extension: Self
       vote: Self
   github.com/SelfBatteries/http_client/c24d7ebd7660cba370e497ea4a88dfe1162061d4/http_client.self:
     annotations:
       linguist: Self
+      linguist-extension: Self
       vote: Self
   github.com/SemRoCo/giskard_pr2/c326dbd58f0daf334bd390130fe8b8f465dee96a/controller_specs/pr2_pouring_example/templates/tilt_down_controller.yaml.lisp:
     annotations:
@@ -2873,173 +3542,215 @@ files:
   github.com/Shan1024/chalk/077eea314f1e42e24839d5058c6a82154c306089/chalk/resources/sample.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/Shanjaq/peanut/1f590eaac0c24cfc79a3c38b3a9d8be9f7e45455/phcc/inferno.hc:
     annotations:
       linguist: HolyC
+      linguist-extension: HolyC
       vote: HolyC
   github.com/Shanjaq/uhexen2-progs/f9eb2b52316d9cdeae1acb06774ccf3b18e07786/h2/entity.hc:
     annotations:
       linguist: HolyC
+      linguist-extension: HolyC
       vote: HolyC
   github.com/ShaoqingRen/faster_rcnn/49ad0990512a5d6e34f56e3c6596eb5fbf22f651/utils/prep_im_for_blob.m:
     annotations:
       human-smola: MATLAB
       linguist: MATLAB
+      linguist-heuristics: MATLAB
       vote: MATLAB
   github.com/Shen-Language/shen-sources/fe5ee036ef195d71c292217dd9da121da4e6fc3b/sources/types.shen:
     annotations:
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/ShizouHeiwajima/HourBoostr/2971df4ca7d88fd9c0610b4440facb419939758f/GlobalDB.hb:
     annotations:
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Harbour
   github.com/Shopify/shopify-css-import/68b660e1ea258795f10b9cad5677a12c479d645f/css/_reset.scss.liquid:
     annotations:
       human-smola: Liquid
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/Shopify/skeleton-theme/c89f9f7eb3c509a5d08a586a4b4d73f8b14c024b/src/layout/theme.liquid:
     annotations:
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/Shopify/starter-theme/452b2c6c612af0075bb5de9dc16c4678d9d1c23b/src/snippets/social-meta-tags.liquid:
     annotations:
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/Shougo/vimfiler.vim/26d3fec10cb8921d510064411784301794229a93/autoload/vital/_vimfiler/Vim/Buffer.vim:
     annotations:
       linguist: Vim script
+      linguist-extension: Vim script
       vote: Vim script
   github.com/SicroAtGit/PureBasic-CodeArchiv-Rebirth/27b2548b1c18738cfc00b67c0931310c19db9feb/FileSystem/CopyFilesEx.pbi:
     annotations:
       linguist: PureBasic
+      linguist-extension: PureBasic
       vote: PureBasic
   github.com/SimpleMobileTools/Simple-Calendar/76751f4177ac25f5c52d8a74d34abdad60e88a3a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/YearlyCalendarImpl.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/Skruvkork/doge-form/5539bd092d59cf91598a54c7c73876a85c6d70e9/wow.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/Sleepwalking/libgvps/2f1b4106d72f8f8138dc447bf0123820c0772cbd/gvps_sampled.hc:
     annotations:
       linguist: HolyC
+      linguist-extension: HolyC
       vote: HolyC
   github.com/SlimerDude/afBedSheet/27fb6fee4ab672022f27d625856b3a50435fc5e2/fan/Main.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/SlimerDude/afBounce/de764549b46b91d904cb9fd88d29987fa2fcdb44/fan/public/Hidden.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/SlimerDude/afMicromod/911a105ba02aab36d89cc02ac11b0a2f5e7bfa1d/build.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/SlimerDude/afSitemap/fe917324517a66a26b684c43aca4f37162315d7c/fan/public/SitemapModule.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/SmartThingsCommunity/SmartThingsPublic/d0f9407005d1c064dc7ba25ef48bb127a949a8ef/smartapps/smartthings/bon-voyage.src/bon-voyage.groovy:
     annotations:
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/Snailclimb/JavaGuide/5345b5d608ad1f784ffcd40a88fe17117a46e8a7/index.html:
     annotations:
       human-smola: HTML
       linguist: Java
+      linguist-extension: HTML
       vote: HTML
   github.com/Snaipe/libcsptr/5bc7aad8cab5f8d9d64308dcffb1a397e86a6b0c/.cmake/Modules/uninstall.cmake:
     annotations:
       linguist: CMake
+      linguist-extension: CMake
       vote: CMake
   github.com/SnapKit/Masonry/8bd77ea92bbe995e14c454f821200b222e5a8804/Masonry/MASUtilities.h:
     annotations:
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/SoftSec-KAIST/CodeAlchemist/411fc58c562efaf524a3ca1ce80c9492ca89448a/src/Fuzzer/Fuzzer.fs:
     annotations:
       linguist: F#
+      linguist-heuristics: F#
       vote: F#
   github.com/Solido/awesome-flutter/2c9fa49cee71a4455412f66534a61e7abcad7362/contributing.md:
     annotations:
       human-smola: Markdown
       linguist: Dart
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/SoloMornington/Solos-Script-Repository/58b469186ecfb2b3dfb7fb73beab33a1f3bdd0ac/very_basic/[solo] Donation Box 1.3.lsl:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
       vote: LSL
   github.com/Soluto/kubernetes-deployment-demo/c34b4682544659038ac7fb9cd171758952f12bcf/server/httpd.lol:
     annotations:
       linguist: LOLCODE
+      linguist-extension: LOLCODE
       vote: LOLCODE
   github.com/SonarSource/sonar-scanning-examples/81dc6cadd7ed98302eca04100d842712f3e68cd5/sonarqube-scanner/src/cobol/Custmnt2.cbl:
     annotations:
       linguist: COBOL
+      linguist-extension: COBOL
       vote: COBOL
   github.com/SopaXorzTaker/fxesplus/0d7f01b22e60db41688184491be1d8b25a60fdf1/tools/u8-sdk/M610415.DCL:
     annotations:
       human-smola: Unknown
       linguist: Clean
+      linguist-extension: Clean
       vote: Unknown
   github.com/SortableJS/Vue.Draggable/2df59aecda6901d56a83bfd299e67973482271c5/src/vuedraggable.js:
     annotations:
       human-smola: JavaScript
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/SpaceAceMonkey/simpletrie/6b40bfcd7f6b52b1cd0bd54b948a2b8ff1eb93ff/modules/spaceace/simpletrie/cTrie.monkey:
     annotations:
       human-smola: Monkey
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/SparkhoundSQL/sql-server-toolbox/b2611217a12002ba20335319f16f2e0bc1b1b6eb/lab - dynamic data masking.sql:
     annotations:
+      human-smola: TSQL
       linguist: SQL
-      vote: SQL
+      linguist-heuristics: TSQL
+      vote: TSQL
   github.com/Spartee/_MasonTest2/4bcd925330029bfd53d5befdd758703b395d9207/src/_MasonTest2.chpl:
     annotations:
       linguist: Chapel
+      linguist-extension: Chapel
       vote: Chapel
   github.com/Spirent/cloudstress/602783b84dbcb4363195dd359ef7f60d710d5f48/config.zpl:
     annotations:
       human-smola: Unknown
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Unknown
   github.com/Spirit-of-Oberon/ProjectOberon2013/72966ea608613dad76f5afdd57578c7e53741bd3/Sources/Kernel.Mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/SquidDev/urn/6e6717cf1376b0950e569e3771cb7e287aed291d/lib/data/function.lisp:
     annotations:
       human-smola: Unknown
       linguist: Common Lisp
+      linguist-heuristics: Common Lisp
       vote: Unknown
   github.com/SquishyStrawberry/dogescript-ircbot/bd90b226ffd53cb9c73d1bd06a57aba5f2191679/ircLib.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/StPeres-Cerebellum/Igor2p/5ae364cd14a36dc1b096eaeeed91c6d9fce268be/ArduinoSerialPort.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/StefanSchroeder/Golang-Regex-Tutorial/642a426f1f29b7793eacf84672b6fb8fe649e4df/extract_examples.pl:
     annotations:
       human-smola: Perl
       linguist: Perl
+      linguist-heuristics: Perl
       vote: Perl
   github.com/Stovoy/LOLCODE-Snake/e0cd9fc487b630fd3925710719cc3a551320e515/LOLCODE-Snake.lol:
     annotations:
       linguist: LOLCODE
+      linguist-extension: LOLCODE
       vote: LOLCODE
   github.com/StreisandEffect/streisand/be8e7a1d3523cc4d4b0caa74e13b346afc2650c7/playbooks/roles/test-client/templates/streisand-gateway-test.sh.j2:
     annotations:
       human-smola: Shell
       linguist: Shell
+      linguist-extension: HTML+Django
+      linguist-shebang: Shell
       vote: Shell
   github.com/Student-projects/Eiffel-P2P/73aebedbc61a5ee53cc61fc720dced37a16ec384/Client_Interface/src/target_packet.e:
     annotations:
@@ -3048,66 +3759,82 @@ files:
   github.com/SuaveIO/suave/a84ac8b93954e155fb8dc78a26d3a9a73cff45af/src/Suave/Tcp.fs:
     annotations:
       linguist: F#
+      linguist-heuristics: F#
       vote: F#
   github.com/Sugz/SugzTools/5fd9c2c9db37ccaab72ad34abe1f58912f095295/Maxscript/scripts/SugzTools/Managers/GfxConflictManager/v2/Gfx_Conflict_Manager_01.ms:
     annotations:
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: MAXScript
   github.com/SukkaW/Koolshare-Clash/34e5b6769b379f1c5b5d647904fbfbb7a7309264/koolclash/webs/Module_koolclash.asp:
     annotations:
       human-smola: Classic ASP
       linguist: Classic ASP
+      linguist-extension: Classic ASP
       vote: Classic ASP
   github.com/Summer-Summer/ComputerArchitectureLab/8ad310416c1909d1e3bc42500b2dd870a675c592/1_VerilogSourceCode/1_CPUCore_src/EXSegReg.v:
     annotations:
       human-smola: Verilog
       linguist: Verilog
+      linguist-heuristics: Verilog
       vote: Verilog
   github.com/SumrainChan/Numerical-Calculation-Collection/d583df6ba68ba25962c7f08985c0f0c70e53b051/Item01/Item01.sce:
     annotations:
       human-smola: Scilab
       linguist: Scilab
+      linguist-extension: Scilab
       vote: Scilab
   github.com/SunnyLi/MapleTuring/340e2955a2a6dc389bfe386154d10a421b4c782a/MapleTuring (Final).t:
     annotations:
       linguist: Turing
+      linguist-heuristics: Turing
       vote: Turing
   github.com/SuriyaaKudoIsc/Apache-v2.4.10-Win32/e7640733ba91a15808a301337e38a58f0e73c12c/manual/rewrite/intro.html.fr:
     annotations:
       linguist: Frege
+      linguist-heuristics: Frege
+      linguist-xml: XML
       vote: Frege
   github.com/SwiftForWindows/SwiftForWindows/908c68d93170140ecd932527c4d76bf9f7a8f21f/SwiftForWIndows.nsi:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/SwiftyJSON/SwiftyJSON/bad5f2f94a71216a32c030a3586bdcfc1f7e660b/Tests/SwiftJSONTests/CodableTests.swift:
     annotations:
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/Swordfish90/cool-retro-term/64e007f1fd602815b2d66c0b9a513324cdf99a87/app/qml/BurnInEffect.qml:
     annotations:
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/Syampuuh/Titanfall2-orig/9e57b224ae7df25f61b1f44a0dcb7dea705fbd2b/vscripts/weapons/mp_ability_pathchooser.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/Syampuuh/Titanfall2/9bfcea43ecf2a12fc3783ce22e63e439f422c045/scripts/vscripts/gamemodes/cl_gamemode_lts_bomb.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/Syampuuh/TitanfallApexLegends/bd920139bf74f6f5877ab86da60be421ac6953ef/scripts/vscripts/mp/sh_comms_menu.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/SymbiFlow/prjxray/4cec0817abeb5b702c19a509dda2a1e891c1ce3b/minitests/timing/picosoc_noflash.v:
     annotations:
       human-smola: Verilog
       linguist: Coq
+      linguist-heuristics: Coq
       vote: Verilog
   github.com/SynEdit/SynEdit/0b43ec1a701ddafd85eff858ee63b4a3083ce602/Source/SynEditDocumentManager.pas:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/Syntopia/Fragmentarium/7f5f918793e4cac35b0648208fff0cfc7d4a2c43/Fragmentarium-Source/Examples/Include/Progressive2D.frag:
     annotations:
@@ -3121,157 +3848,201 @@ files:
   github.com/TASVideos/BizHawk-Prereqs/da69507863ef24782f462563ef65d8f3401515db/bizhawk_prereqs.nsi:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/TCArknight/7thSea2E/65ce26c6c544254ecabd95ad8a0d342f72421e69/styles_output.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
+      linguist-xml: XML
       vote: Augeas
   github.com/TCArknight/Fate_Tianxia/4c20f42a5d1a327eedf997f480ff2b59645e5956/tianxia_styles_output.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
+      linguist-xml: XML
       vote: Augeas
   github.com/TCArknight/Fate_VentureCity/841e7b6bd2770f3674f8d7b7557f7ff07c32d2db/venturecity_style_ui.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
+      linguist-xml: XML
       vote: Augeas
   github.com/TCArknight/STAdventures/fb040236436b9a10ad7898a30aa8a004f66f4de7/styles_ui.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
+      linguist-xml: XML
       vote: Augeas
   github.com/TVTower/TVTower/5676257938b428920bbb01b05cb4649f65297ada/source/game.player.boss.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/TadasBaltrusaitis/OpenFace/ad1b3cc45ca05c762b87356c18ad030fcf0f746e/matlab_runners/Head Pose Experiments/calcBUerror.m:
     annotations:
       linguist: MATLAB
+      linguist-heuristics: MATLAB
       vote: MATLAB
   github.com/TakeoffAndroid/MaterialTabsTemplate/baa697a543cf341e4777250daab0e532409d6d73/root/src/app_package/AbstractModel.java.ftl:
     annotations:
       linguist: FreeMarker
+      linguist-extension: FreeMarker
       vote: FreeMarker
   github.com/TakeoffAndroid/RecyclerViewTemplate/6590e98547fed5f40e37fc2170eba9d0b4cff562/root/res/layout/item_recycler_google_play.xml.ftl:
     annotations:
       linguist: FreeMarker
+      linguist-extension: FreeMarker
+      linguist-xml: XML
       vote: FreeMarker
   github.com/TaranVH/2nd-keyboard/5e03713a12cf22037feaaa6e3729482d25fa5579/Intercept/FULL_extra_keyboard.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/TauCetiStation/TauCetiClassic/0368f0e0bfd2be994316a3ccd25508a2ac04a907/code/modules/clothing/under/jobs/medsci.dm:
     annotations:
       linguist: DM
+      linguist-extension: DM
       vote: DM
   "github.com/Tavalik/SQL_TScripts/cff0afb916f4746ca6d8e76de70c9b8ac1b4fc76/\u041F\u0440\u043E\u0441\u0442\u0430\u044F_\u043C\u043E\u0434\u0435\u043B\u044C_\u0438_\u0441\u0436\u0430\u0442\u0438\u0435_\u043B\u043E\u0433\u0430_\u043D\u0435\u0441\u043A\u043E\u043B\u044C\u043A\u0438\u0445_\u0411\u0414.sql":
     annotations:
       linguist: SQLPL
-      vote: SQLPL
+      linguist-heuristics: TSQL
+      vote: Unknown
   github.com/TeamTilapia/vscode-tilapia/e237d0d770951c280b4755918fb2d88c0fd49131/example-tla/ModelingDeployments.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/Tencent/MMKV/a0c9fa9efdf3d5659f62b13eb7af95d499609ea9/Win32/MMKV/MmapedFile.cpp:
     annotations:
       linguist: C++
+      linguist-extension: C++
       vote: C++
   github.com/TexanInParis/Effective-SQL/8047973838c2780da1795742793016faff36315c/Oracle/Chapter 09/Listing 9.015.sql:
     annotations:
       human-smola: PL/SQL
       linguist: PL/SQL
+      linguist-heuristics: SQL
       vote: PL/SQL
   github.com/ThatsNotAUsername/MEMo/9d97bd0b2e4eed22e2f9265e87dd3e50d9aefde6/MMB_github/matrix.eq:
     annotations:
       human-smola: Unknown
       linguist: EQ
+      linguist-extension: EQ
       vote: Unknown
   github.com/TheBeachMaster/v-lang/6a1d9e9a731d4464d8380710083599586288c1af/helloworld/hello.v:
     annotations:
       linguist: V
+      linguist-heuristics: V
       vote: V
   github.com/TheCatPlusPlus/terra-efi/a3c8839c8f8bc6db2e178f9735b381a7072635af/src/efi.t:
     annotations:
       linguist: Terra
+      linguist-modeline: Terra
       vote: Terra
   github.com/TheLartians/CPM.cmake/f8d4e959bbbb5840c17f1a7c21d1334fe0a3d436/test/unit/cache.cmake:
     annotations:
       linguist: CMake
+      linguist-extension: CMake
       vote: CMake
   github.com/TheMozg/awk-raycaster/43826af19ff54e49ced2c7a20761994bf94e9b2e/awkaster.awk:
     annotations:
       linguist: Awk
+      linguist-extension: Awk
       vote: Awk
   github.com/TheStoku/Basemode/df06af9b8c1ea12f8dadf94e45a92f84b7958237/basemode/client.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/TheoWinterhalter/formal-type-theory/93ac197dfde912d77af9b0f4fd9f7d2422ba7dfc/src/checking_tactics.v:
     annotations:
       linguist: Coq
+      linguist-heuristics: Coq
       vote: Coq
   github.com/Theodus/jennet/589585d3d8f0e8747237b75058ffc0f2b0dc0edf/jennet/serverinfo.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/Thomas-George-T/FlumeHiveTwitterApp/b99a4d6bb1d0cdbdd4245587bcf7a0f19bc8e37b/Hive scripts/create_tweets_avro_table.q:
     annotations:
       linguist: HiveQL
+      linguist-heuristics: HiveQL
       vote: HiveQL
   github.com/Thomas-George-T/HackerRank-SQL-Challenges-Solutions/c5fb14ca91355e55db24c8ea54ccb2008d8b40c0/Basic Join/Ollivander's Inventory.sql:
     annotations:
       linguist: SQL
+      linguist-heuristics: SQL
       vote: SQL
   github.com/ThomasJaeger/VisualMASM/b809d4efa0202523333f29fb3a84122fea410b22/VisualMASM.dpr:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/ThomasMGeo/1Minute_Python/5983d9d93d1b4054ff6c39db914dffe544e0fcc2/swung_discovery.las:
     annotations:
       linguist: Lasso
+      linguist-extension: Lasso
       vote: Lasso
   github.com/ThomasTJdev/nim_websitecreator/07c6bdacebe501cbd69ef07cb9590762d2f0b3a2/nimwcpkg/databases/_standarddatas.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/ThomasWeiser/elmfire/02919d285ef94cc8f4473719705220c1b1ae6ffe/test/src/Tests.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/TiarkRompf/scala-escape/bab5b9ce005aa8aae42898231aac28ec9cb54407/coq/stlc2.v:
     annotations:
       linguist: Coq
+      linguist-heuristics: Coq
       vote: Coq
   github.com/TimmHess/UERoboCup/bb65923970cd650a591ed54045e611fb291a958d/TrainingSetGenerator/TrainingSetGeneratorConfig.pri:
     annotations:
       linguist: QMake
+      linguist-extension: QMake
       vote: QMake
   github.com/Tinywan/zephir-framework/dd89b56581c51d0cf1acc773b515ff8342add93a/zephirlib/zephirlib/Module/Think/Test.zep:
     annotations:
       human-smola: Zephir
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/TitusLVR/BMAX_Connector/ffd7da02131087b11012234267917d313d1a3d30/3dsmax/BMAX/install.ms:
     annotations:
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: MAXScript
   github.com/TomasHubelbauer/blender-gargantua/7a5425fc9ed4760e383651c106b2961b3c1aa76d/README.md:
     annotations:
       linguist: Markdown
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/TomasHubelbauer/vso-shortlink/6364b092feb9b44122f0d58e8fd925d0342ae1e2/README.md:
     annotations:
       linguist: Markdown
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/Toubic/Traveller/9368954bb1fd959f77dfa5d9825fa3e3e36afd39/views/partials/selectCountry.hb:
     annotations:
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Harbour
   github.com/Trendyol/android-guidelines/395b78a6d47ea3379d43e4237f727f438849f83d/android_studio_live_templates/file_and_code_templates/TrendyolData/recipe.xml.ftl:
     annotations:
       linguist: FreeMarker
+      linguist-extension: FreeMarker
+      linguist-xml: XML
       vote: FreeMarker
   github.com/Trovarius/dojo_dnasp_26_05_11/2d0a483376240a0fc34543ce4f3ad1b69bea08fc/Dojo_Troco/Class1.boo:
     annotations:
       linguist: Boo
+      linguist-extension: Boo
       vote: Boo
   github.com/TrumpyGoad/Project_EUROPA/99965591f8a2a701771ef602a95133f650becd68/Project_EUROPA.mod:
     annotations:
@@ -3280,6 +4051,7 @@ files:
   github.com/Ttl/vna2/3ac7fbd8dcb66ba613c0f0530b64f8f3035a6b4c/fpga/vna/vna.srcs/sim_1/new/ft2232_behavioral.vhd:
     annotations:
       linguist: VHDL
+      linguist-extension: VHDL
       vote: VHDL
   github.com/Ttreintaysiete/chaves/9972f5b735048064f86628ce642d3d94d7502cea/v2/hardware/chaves.pro:
     annotations:
@@ -3294,70 +4066,86 @@ files:
     annotations:
       human-smola: Shell
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Shell
   github.com/TxGVNN/emacs-k8s-mode/5984acee6f3891afa78acfd1d08c44a24953a233/snippets/k8s-mode/persistentvolumeclaim:
     annotations:
       linguist: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/TypeUnsafe/golo-f/5923f02735239943ff60b14f0fc468bcc65850ae/02.yloiseau.option.decorator.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/TypeUnsafe/golo-tour/00d980cef4912dd8f97cc72153e6c9ab0234b8fd/07-golo.06.RivieraJUG/04-golo-s-touch/sandbox/06-b-promises.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/TypeUnsafe/guino/b1bf0832650f81872a9c94682f4f041af9c6c752/imports/coap.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/Uberi/Autocomplete/c5eeb780f64968862896122cea2681718a215bff/Autocomplete.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/UndeadKernel/emacs_doom_private/0785943612d7e98e2cf1aff6931415d211913765/snippets/processing-mode/glGenBuffers:
     annotations:
       linguist: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/UniMath/Foundations/df19211f602ab71ee44f0ae4de2a19170c5b9e4d/Current_work/semisimplicial2.v:
     annotations:
       linguist: Coq
+      linguist-heuristics: Coq
       vote: Coq
   github.com/UniMath/UniMath/4ecbfc82071291d54b33d1f30f2b390c31c15dc2/UniMath/CategoryTheory/Subcategory/Limits.v:
     annotations:
       linguist: Coq
+      linguist-heuristics: Coq
       vote: Coq
   github.com/Unity-Technologies/UnityCsReference/4fc5eb0fb2c7f5fb09f990fc99f162c8d06d9570/Editor/Mono/Audio/WaveformPreview.cs:
     annotations:
       linguist: C#
+      linguist-heuristics: C#
       vote: C#
   github.com/Universal-Rom-Tools/Universal-XML-Scraper/96188e0dc4451770ee42f5a4ec8f0a024bca1bb8/Include/ADO_CONSTANTS.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/VFPX/FoxBarcode/dfbf9191c1657d5ebd75217cdb4c3195e91e8233/FoxBarcode_v_1_19/main.prg:
     annotations:
       human-smola: xBase
       linguist: xBase
+      linguist-extension: xBase
       vote: xBase
   github.com/VFPX/Thor/f573201d78343e867fb25d7319b6d884e336cba0/Thor/Source/thor_tool_thorinternalrepository.prg:
     annotations:
       human-smola: xBase
       linguist: xBase
+      linguist-extension: xBase
       vote: xBase
   github.com/VFPX/nfJson/f5788cd32181d84a02b0d4c8ecf84a9a0c2fc248/nfJson/nfjsonread.PRG:
     annotations:
       human-smola: xBase
       linguist: xBase
+      linguist-extension: xBase
       vote: xBase
   github.com/VLSI-EDA/PoC/51248a8a85c05baa86be10399100871211d9f557/src/fifo/fifo_cc_got.vhdl:
     annotations:
       linguist: VHDL
+      linguist-extension: VHDL
       vote: VHDL
   github.com/VSoftTechnologies/DUnitX/96199b34ca5726c4ac0871bf1943fb1712eb4dae/Expert/DUnitX.Expert.Forms.NewProjectWizard.dfm:
     annotations:
       human-smola: Pascal
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/VU-Programming/pad-skeleton-c/8fa1edff0992c83f85be7311a371510f327e70d5/files/bonus/brainfuck/mandelbrot.b:
     annotations:
@@ -3367,171 +4155,211 @@ files:
   github.com/VUnit/vunit/6958f271da67288f19a79fd1afeccc776da0dfcc/vunit/vhdl/com/test/tb_com_deprecated.vhd:
     annotations:
       linguist: VHDL
+      linguist-extension: VHDL
       vote: VHDL
   github.com/Valama/valama/a7539fa031f1888c4704d587112832a11f4949b4/src/ui/search.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/ValveSoftware/Proton/71d463772997f4b2cc2c5eabbd99883fbdc538a6/lsteamclient/steamworks_sdk_118/matchmakingtypes.h:
     annotations:
       human-smola: C++
       linguist: C++
+      linguist-heuristics: C++
       vote: C++
   github.com/VerificationExcellence/SystemVerilogReference/ee380e02a487527df6e7b5d11c52966b98cb8688/projects/DualPortRam/dualport_ram.sv:
     annotations:
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/VerticalResearchGroup/miaow/143929c4163edfd559be4086aa9895cd80cee465/src/verilog/rtl/exec/rd_port_9_to_1.v:
     annotations:
       human-smola: Verilog
       linguist: Verilog
+      linguist-heuristics: Verilog
       vote: Verilog
   github.com/VincentToups/jkmeans/20cd1cdb9414aed63755c0e73a709436466b12b7/example.ijs:
     annotations:
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/VirtualWorldsRepos/Script-Repository/54293eafe2b8f4e35a8bd9cac4e4bbb77899386b/Codeslacker/Battle-Tactics/Templates/Script_Template.lslp:
     annotations:
       human-smola: LSL
       linguist: LSL
+      linguist-extension: LSL
       vote: LSL
   github.com/VladD2/Nemerle-Articles/13bd42452e2b8fe51d635a08b2420cb82ac6f65a/TheNemerle/Nemerle-macros-intro/Projects/MacroIntro/DisposableTest/Main.n:
     annotations:
       linguist: Nemerle
+      linguist-heuristics: Nemerle
       vote: Nemerle
   github.com/Vladar4/nimgame2/980a7c2433b3581011d2b6c9f02bdd05830fb88b/nimgame2/gui/textinput.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/Vladilit/fpga-multi-effect/914165384e8338703e32a70b74bf98645ff8208e/ip_repo/VL_user_Distortion_1.0/sim_1/new/Distortion_tb.vhd:
     annotations:
       linguist: VHDL
+      linguist-extension: VHDL
       vote: VHDL
   github.com/Voiteh/Gecon/6e7ea91b07826cf5d9209d4b95925dbba783c8b7/source/herd/gecon/core/api/transformer/Converter.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/Vonng/Capslock/eb3fbbdbaa546d3e84c31a74ccd56eb906977338/win/CapsLock.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/W4RH4WK/Debloat-Windows-10/dd31e78c0572e85503b34636357496a664f435a5/scripts/block-telemetry.ps1:
     annotations:
       linguist: PowerShell
+      linguist-extension: PowerShell
       vote: PowerShell
   github.com/WMTU/collielabelprinter/0c866937ed1b53dd8221b33ffdcff58051f892c4/default.zpl:
     annotations:
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Zimpl
   github.com/WOLVS/HOG_ZYNQ/d34fb6ccfa115eeb18ab2ff0f1402bf09ad7d2de/src/c/hls/gray2scale/solution1/.autopilot/db/a.export.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/WallarooLabs/pony-kafka/c767e467a514b326d47aa52575a11e9c73f80cc1/pony-kafka/compression/zlib.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/WallarooLabs/wallaroo/3e5df057b9550ebe301d57f76d1ba8b015d045dd/lib/wallaroo/core/network/control_sender_connect_notifier.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/WanAndroid/AndroidStudioTemplates/7808187009ba57b4acfc5bceb4c73f535c710de0/activities/ViewPagerWithTabActivity/root/src/app_package/SimpleFragment.java.ftl:
     annotations:
       linguist: FreeMarker
+      linguist-extension: FreeMarker
       vote: FreeMarker
   github.com/WebAssembly/binaryen/4ad7a2cfd0b3ac14fbe767d50e4994f8297d37f6/test/wasm2js/br_table_temp.wast:
     annotations:
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/WebAssembly/esm-integration/884066deab4669b582269e6dddaeb9948c2ba67a/test/core/align.wast:
     annotations:
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/WebAssembly/gc/7f3258d1dcc3f91bc0e23e863f53ac6cbdeaf4b4/test/core/call.wast:
     annotations:
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/WebAssembly/interface-types/0930a4db3c998b495c8fea7295989266befec213/test/core/typecheck.wast:
     annotations:
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/WebAssembly/reference-types/303c94206dd108ee210dd45377b61bebed21d57f/test/core/binary-leb128.wast:
     annotations:
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/WebAssembly/simd/fc9c9fbbbd005f1cc9f781615e4d53124b4a662f/test/core/utf8-invalid-encoding.wast:
     annotations:
       human-smola: WebAssembly
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/WebAssembly/spec/af825a74982dac2565359e1f4d76191307afc8bf/test/core/unreachable.wast:
     annotations:
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/WebAssembly/threads/4cbecad0ed0af9bf3ca1b58d6dc4c6ad5c865240/test/core/br_table.wast:
     annotations:
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/WebGHC/wasm-cross/3918e50d9cf6bf6d2177e06f02e3fb4be89cb829/llvm-head/clang/default.nix:
     annotations:
       linguist: Nix
+      linguist-extension: Nix
       vote: Nix
   github.com/WebGLSamples/WebGLSamples.github.io/79a3ef4783f8d97b3d0332b7cbd16ffe5dfbc2f9/aquarium/source_assets/Scenes/GlobeInner.ma:
     annotations:
       human-smola: Unknown
       linguist: Wolfram Language
+      linguist-extension: Wolfram Language
       vote: Unknown
   github.com/Whispe/Zzz/a97920633783841d34f1b87c8b32420f1a59a03f/schedule.zpl:
     annotations:
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Zimpl
   github.com/Wilfred/emacs-refactor/ed430d55bd7504cb51d9f2b9e1b3c4b4ca93dafc/emr-scheme.el:
     annotations:
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/Willster419/RelhaxModpackDatabase/b8d5a18ba2f4da762226fb6e288a2841b0f143f5/patch_regressions/followPath/check_01.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/Windastella/godothub_client/9bc39187046db210b201f2c3f7378742c373cbb3/godothub/scripts/godothub.gd:
     annotations:
       human-smola: GDScript
       linguist: GAP
+      linguist-heuristics: GAP
       vote: GDScript
   github.com/WindowsExploits/Exploits/ccaaf21ef8fc92941ea285e0160071148631637c/CVE-2016-7255/CVE-2016-7255.ps1:
     annotations:
       linguist: PowerShell
+      linguist-extension: PowerShell
       vote: PowerShell
   github.com/WindowsLies/BlockWindows/1d719fec48cc2610987abbc11107feeca82ddd1c/unblock.bat:
     annotations:
       human-smola: Batchfile
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/WolframResearch/WolframLanguageForJupyter/6dab4f757685583a181972bbe42507b626657942/WolframLanguageForJupyter/Resources/EvaluationUtilities.wl:
     annotations:
       linguist: Wolfram Language
+      linguist-extension: Wolfram Language
       vote: Wolfram Language
   github.com/WordPress/secure-swfupload/25531ecc4d2345abf6df86dcb6996877fdb8d72a/core/Flash/FileItem.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/Wox-launcher/Wox/6c62f1ff1da452ae66dab67e47aa6e62852ae8c1/Wox.Core/Plugin/PluginConfig.cs:
     annotations:
       linguist: C#
+      linguist-heuristics: C#
       vote: C#
   github.com/Wrobelaf/KEL/7094767aa3854b2b9bc53283b851cf8b66fcf718/WrobelKEL/Q_High_Income.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/X-Sharp/XSharpPublic/65113ea9a92fdd1499e91f9c7372413ed1c76d59/Runtime/VOSDK/Source/VOSDK/GUI_Classes_SDK/MMContainer.prg:
     annotations:
       human-smola: xBase
       linguist: xBase
+      linguist-extension: xBase
       vote: xBase
   github.com/XD-DENG/SQL-exercise/e05d781341c3791951ddf54c94ee32ca11cf5896/SQL_exercise_07/7_questions_and_solutions.sql:
     annotations:
       human-smola: SQL
       linguist: PL/pgSQL
+      linguist-heuristics: SQL
       vote: SQL
   github.com/XKCP/XKCP/e8e6b1d45861ea6fc0957ab27a401f42aef0d033/lib/low/KeccakP-800/OptimizedAsmARM/KeccakP-800-u2-armv6m-le-armcc.s:
     annotations:
@@ -3540,19 +4368,23 @@ files:
   github.com/XVimProject/XVim/53c652421ca8ad63a2380a5cad316b1997999b8a/XVim/XVimEval.m:
     annotations:
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/XiaohuWang0921/logtalk-xpce/766eb2d93205a3c232c9d380029e5e86215a8115/xpce.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/Xilinx/RFNoC-HLS-ATSC-RX/569c83f00c2214cc356d80a03f185276baa8e3ad/rfnoc/src/rfnoc-atsc_rx/rfnoc/testbenches/noc_block_fpll_tb/noc_block_fpll_tb.sv:
     annotations:
       human-smola: SystemVerilog
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/Y2Z/monolith/491185e191b09051f25ca5a0809ee576e42a9d44/src/tests/utils.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/Yangmchuyue/homework/f08d68c639981b149c12805e1869573124ebf9bc/Lesson 48/Sorting_arrays.t:
     annotations:
@@ -3561,52 +4393,64 @@ files:
   github.com/YellowAfterlife/openfl-bitfive/7f1274ba5b34cf320aae9b75d934f37f07abb901/openfl/display/StageDisplayState.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/YifengL/gurace/4fb1abc81d260395919f96cb685998ee10bda192/immutableSet.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/Yohko/IgorProTools/09ef2c30ce71d9226601d814d8dbe87c41c0a9ac/Igor Procedures/tools/tools_utils.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/Yubico/yubioath-desktop/333caeba0b63b3549903b4f3af79a8238c0d7402/qml/NewCredentialView.qml:
     annotations:
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/ZCXL/JsonParse/40eecb66b353ca9d25de5cd0e9f2622740ca7a93/JSON.g4:
     annotations:
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: ANTLR
   github.com/ZGIS/spatial-simulation/1b5d8d73c2dbdfafb4fab4ddd879184e5c50a3bf/PublishedModels/Wallentin & Neuwirth 2017/003_agent-stock - stock-stock.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/Zamlox/red-tools/6b760535636c5589ae437b27e0ec4756f90a2bdf/svg/agent.red:
     annotations:
       human-ajnavarro: Red
       linguist: Red
+      linguist-extension: Red
       vote: Red
   github.com/Zemnmez/nearley-unicode/c68df5297197fd61f02d3d4d3cd82794573f3627/unicode-9.0.0/Bidi_Class/Right_To_Left.ne:
     annotations:
       linguist: Nearley
+      linguist-extension: Nearley
       vote: Nearley
   github.com/Zeroloop/l-unit8/cb7038949aab93e494660a1e7a37cdd5198e87e3/index.lasso:
     annotations:
       human-smola: Lasso
       linguist: Lasso
+      linguist-extension: Lasso
       vote: Lasso
   github.com/Zetaphor/second-life-lsl/9c85f0b55b4fc77ce48c34cb314919584909fa46/HyperMedia Toolkit/_Storage Controller.lsl:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
       vote: LSL
   github.com/ZipCPU/zipcpu/752bcc9485609f1f094100719262a7c2d386d6b7/rtl/core/mpyop.v:
     annotations:
       linguist: Verilog
+      linguist-heuristics: Verilog
       vote: Verilog
   github.com/Zoclee/mongodb-xojodriver/bb1c5c5c33b6f9c1f4d76562ab007e731864bc9e/source/MongoDriver.xojo_code:
     annotations:
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/a-chol/farewell_pcb/2e4309cd28fb4bb2b90e118542b90524a321b6a0/farewell.pretty/farewell_logomod.mod:
     annotations:
@@ -3621,38 +4465,47 @@ files:
   github.com/aaaSOS/scip/5c999caf95a66f64e51670a74e02748fe4e37e29/tetris.zpl:
     annotations:
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Zimpl
   github.com/aahrens1/lassopack/f673f4a47ba2fa2d39bc98dda205d59298e53f93/Stata/lasso2.ado:
     annotations:
       linguist: Stata
+      linguist-extension: Stata
       vote: Stata
   github.com/aahrens1/pdslasso/8b70a5adca3e9b0853640f0a121de9fa83421ce2/Stata/cs_pdslasso.do:
     annotations:
       linguist: Stata
+      linguist-extension: Stata
       vote: Stata
   github.com/aamaricci/SciFortran/621d26e5888cc242040df0c8058e815e423d2542/src/lapack/zlabrd.f:
     annotations:
       linguist: Fortran
+      linguist-heuristics: Fortran
       vote: Fortran
   github.com/aamii/Candy/52fad7c4253c3b440d4ab490c8c8b35dc7294100/Candy.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/aaronfreimark/Apple-ID-AppleScript/a1457690a6f98d9f4045ecaa152df85393384a6d/Enterprise iOS Apple ID Creator.applescript:
     annotations:
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/aaronknister/augeas-lens-lvm_conf/2ad05fa693c635000b5ca691e1d2732c7a08da04/lvm_conf.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
       vote: Augeas
   github.com/abapkochbuch/Sources/159775b787fcbc4c6b7eff01e505144b7c33a437/kapitel_04/mzbook_demo_dyn_grid2_get_di01.prog.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/abend0c1/hidrdd/7072b259eba10d980bc091482fa3fa584e052e2e/rd.rex:
     annotations:
       linguist: REXX
+      linguist-extension: REXX
       vote: REXX
   github.com/abevoelker/abl-core/0cf36209f5e650ccec204cecefd80ac9492258b6/com/abevoelker/abl/lang/String.cls:
     annotations:
@@ -3665,57 +4518,70 @@ files:
   github.com/abhi-r3v0/EVABS/0a1fbadd30ed5fa6253f382c934470b37859fb79/app/.externalNativeBuild/cmake/debug/x86_64/CMakeFiles/3.6.0-rc2/CMakeCXXCompiler.cmake:
     annotations:
       linguist: CMake
+      linguist-extension: CMake
       vote: CMake
   github.com/abo-abo/lispy/c8da3c9ed3355bcf2b427b0ee7935cfdd6e6703e/targets/interactive-init.el:
     annotations:
       human-smola: Emacs Lisp
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/abougouffa/m2hpf/339c579b9fa91407930f7edb0b32c5edf4367ebe/mod/Test.mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/abramhindle/inc/d4beb0429ac6a566c743fe0fc08a6511b31c6584/reference/jbumgardner-in-c.ck:
     annotations:
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/abscondment/mirah-guide/c955665ccdea656a82ed2fb651a4ce6eb3c55268/src/org/threebrothers/Locator.mirah:
     annotations:
       linguist: Mirah
+      linguist-extension: Mirah
       vote: Mirah
   github.com/absinthe-graphql/absinthe/92bbf1d068709b81b2541f2c629764a572199aa4/lib/absinthe/phase/schema/arguments/normalize.ex:
     annotations:
       linguist: Elixir
+      linguist-extension: Elixir
       vote: Elixir
   github.com/acani/Chats/dcf91487d0ac360d3e556b550cb818cb7883372a/Servers/Database/functions/login.sql:
     annotations:
       human-smola: PL/pgSQL
       linguist: SQLPL
+      linguist-heuristics: PL/pgSQL
       vote: PL/pgSQL
   github.com/acaudwell/Gource/7e793c96cbfb8d742c690f4a9bec49880f985e60/src/gource.h:
     annotations:
       linguist: C++
+      linguist-heuristics: C++
       vote: C++
   github.com/achlipala/frap/93ef5add7a69eb8aacb5eacd37f91a5c4e104251/SepCancel.v:
     annotations:
       linguist: Coq
+      linguist-heuristics: Coq
       vote: Coq
   github.com/achoczaj/CPD--SAS--Statistics_1-Introduction_to_ANOVA_Regression_and_Logistic_Regression/d2da58ea3a849b9b53a37870eef447edfbdc6ecc/notes/L6_ Model_Building_and_Scoring_for_Prediction.sas:
     annotations:
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/adampash/texter/5fae19b5876c68f02b8da727e6feabed2c3c521a/includes/functions/printablelist.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/adikhosla/feature-extraction/290f3e54cfcb319ca6d1a82f8a0cea4fc31190f8/util/create_grid.m:
     annotations:
       human-smola: MATLAB
       linguist: MATLAB
+      linguist-heuristics: MATLAB
       vote: MATLAB
   github.com/adkelley/javascript-to-purescript/2fc5da3d58cc23eab300de9846e562d32bbc68b4/tut22/resources/Box.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/adobe-fonts/source-han-sans/e251b7a4fecc7c5bc57d25cb2c2e92a3e8980a39/Regular/OTC/cidfontinfo.OTC.HW.SC:
     annotations:
@@ -3726,18 +4592,23 @@ files:
     annotations:
       human-smola: XSLT
       linguist: XSLT
+      linguist-extension: XSLT
+      linguist-xml: XML
       vote: XSLT
   github.com/adsworth/ABAP-Utils/a3b490a260d6f85d6162da4e3ceda41d0789eec5/LCL_ISU_STRUCTURE_READ.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/aduros/flambe/37d28ae22e4ad1772c9feef008cfad31af6877e4/src/flambe/platform/shader/FillRectGL.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/aeternity/aeternity/2710ff7e3a33c1e1cc1d2dbdcdcf59c028e9eea2/apps/aecontract/test/aect_create_tx_tests.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
       vote: Erlang
   github.com/afawcett/force-di/d01cc46f066fdaf761fb5c1c1b523aedf8d1469d/force-di/test/classes/di_InjectorControllerTest.cls:
     annotations:
@@ -3750,44 +4621,55 @@ files:
   github.com/afollestad/material-dialogs/ccb32177a73f764fbea7c61147c9883788c0b44d/core/src/main/java/com/afollestad/materialdialogs/internal/list/PlainListDialogAdapter.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/aford4074/informixcdc/de354d0a9ba96ee580a029686cc23bea10d62c0a/ext/_informixcdcmodule.ec:
     annotations:
       human-smola: C
       linguist: eC
+      linguist-extension: eC
       vote: C
   github.com/agentzh/perl-parsing-library-benchmark/39a5962eb5d18f7052587d6df212674b5206ff58/calc-Rakudo.p6:
     annotations:
       human-smola: Raku
       linguist: Raku
+      linguist-extension: Raku
       vote: Raku
   github.com/aglab2/LiveSplitAutoSplitters/7336c132bbbbed87f4d87e3f29524e61d28b2bdd/igt-test.lsl:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
+      linguist-xml: XML
       vote: LSL
   github.com/agoodquant/qinfra/f80cd5976a56c740ad9a862be2891ef725615f9b/qinfra.q:
     annotations:
       linguist: q
+      linguist-heuristics: q
       vote: q
   github.com/aguimaraesduarte/challenge-lexisnexis/290af63d326c262370c865699328177801ea969c/Code_AndreDuarte.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/agussustian2017/DS/5f3640bf5494805c746d88241df9a53b6b485ae4/rsab.zpl:
     annotations:
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Zimpl
   github.com/ahmedbougacha/dagger/75005d8b578c3c8aff75f87301895a2eb2ad04e5/test/CodeGen/PowerPC/asm-dialect.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/ahungry/ats2-scratch/6ed1c05bc47be1b26cec5e0611fffe12d0f97980/hello.dats:
     annotations:
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/ai-se/HPCCTuning/e97dc5cf2364597aa00195e47a12c38fb48adadc/ecl-ml/ML/Regression/Sparse/OLS_LU.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/aikuaiven/aiku-system/2e1362eaae1312bbb2889366d886d27270a7f377/wip/advapi32-api.lisp:
     annotations:
@@ -3797,214 +4679,267 @@ files:
   github.com/airbnb/lottie-android/3cf8ff4e79abefeb18dfa0c5d73ed72bfe5318b9/lottie/src/main/java/com/airbnb/lottie/value/LottieFrameInfo.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/airbnb/swift/096797e8b7cf4b4893a161b8e658305f76177e86/README.md:
     annotations:
       human-smola: Markdown
       linguist: Markdown
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/ajaxm/DogeScript/cd6ba876434616117169a20c38c152302c71827d/clock_angle.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/ajholanda/nixus/b17119a0274f1fed07da305b55169b1760f4c43f/nixus.w:
     annotations:
       linguist: CWeb
+      linguist-heuristics: CWeb
       vote: CWeb
   github.com/ajnirp/j-scripts/a446fcc54d6d7f1a6a39f990b2336b922051149c/euler/11.ijs:
     annotations:
       human-smola: J
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/akayambu/oozie-workflows/ba047a0f594fb97dc27256e8a24e4480dd3a4ba1/hivemapreducemultiactions/script.q:
     annotations:
       linguist: HiveQL
+      linguist-heuristics: HiveQL
       vote: HiveQL
   github.com/akeefer/gosu-git/e4378814824d5de6a1d7bdc73b0771aeac4eb561/build.vark:
     annotations:
       linguist: Gosu
+      linguist-extension: Gosu
       vote: Gosu
   github.com/akeep/nanopass-framework/0a9ebfca5b17ff5c46ed84af9b7b2ab1dbccb182/nanopass/pass.ss:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
       vote: Scheme
   github.com/akiraux/Akira/cab952dee4591b6bde34d670c1f853f5a3ff6b19/src/Models/FillsItemModel.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/akka/akka/97c5305e0d692675681525da58cfc9429f5153a5/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkForeachParallelSpec.scala:
     annotations:
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/akoprow/OpaHOWTOs/925c57e6394815b8efc9c4623e19a801949355a6/select.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/akrizhevsky/cuda-convnet2/3238bf0367f63eb370e897b9e5714794cb67ddc2/cudaconvnet/include/messages.cuh:
     annotations:
       human-smola: CUDA
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/akveo/eva-icons/8705bd5553c400d639b72a369be81ec0a57dbe15/src/app/@theme/theme.module.ts:
     annotations:
       linguist: TypeScript
+      linguist-heuristics: TypeScript
       vote: TypeScript
   github.com/alangarf/apple-one/6df00e716144d94f0935523017fc43e6e4f7393f/rtl/boards/ice40hx8k-b-evn/apple1_hx8k.v:
     annotations:
       linguist: Verilog
+      linguist-heuristics: Verilog
       vote: Verilog
   github.com/albandescottes/EIT/999139b2e56f2ff7e74bf29865648688d8d0bdef/files/v/formal-tst.NE.key.04oct95_small.txt.ref.ne:
     annotations:
       linguist: Nearley
+      linguist-extension: Nearley
       vote: Nearley
   github.com/alda-lang/alda/e6631f2cf387f517b2cbc06f491d11d71fdda61b/build.boot:
     annotations:
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/alecmuffett/eotk/d6021400df94479fe28d928aecacff98d1bc7822/templates.d/nginx.conf.txt:
     annotations:
       human-ajnavarro: Awk
       human-smola: Awk
       linguist: Awk
+      linguist-heuristics: Text
+      linguist-modeline: Awk
       vote: Awk
   github.com/alex-ren/MTVeri/240ecd6ae18d9e8cb75a74ba27f1f748ab67bb46/scratch/ATS-parse-emit/CIL/TEST/queens.dats:
     annotations:
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/alex-ren/ats2spin/27330f94c1c1ea8772189239f19dedfc7049a7e2/scratch/conversion/Promela.sats:
     annotations:
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/alexanderfefelov/mikrotik-routeros-scripts/4de420da4c4757f421f6ed279b5882af7ffef618/ringtones/arkanoid.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/alexazhou/VeryNginx/b66ef2ee6a108279653316323bd8ac026dd7ccd8/verynginx/lua_script/module/browser_verify.lua:
     annotations:
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/alexdantas/doge-toe/42eb115bea004b37242c0ac1e6fbe089c48cb111/toe.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/alexmingoia/purescript-pux/3bf523f696e215d2564c325de3ec98dd04691b68/src/Pux/DOM/HTML/Attributes.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/alfg/docker-nginx-rtmp/73f7698aeb76c947092451e839501e4089be5591/static/stat.xsl:
     annotations:
       linguist: XSLT
+      linguist-extension: XSLT
+      linguist-xml: XML
       vote: XSLT
   github.com/alfg/murmur-rest/c08ac32cc9db906b03c1a27e047184a7b2889877/Murmur.ice:
     annotations:
       linguist: Slice
+      linguist-heuristics: Slice
       vote: Slice
   github.com/algernon/adderall/a94ab60fe6322a8d50011cd78107dc083a21c901/tests/schemer/chapter01.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
       vote: Hy
   github.com/algo1unsam/2019s1-juego-integrador-bomberman/89309da0c4f646684751700ebd5e5e603ec762b3/src/HUD.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/alhassy/AgdaCheatSheet/14597cf3ce5bb985ba4dcb1a3f7384fda8f129c3/CompilingAgda.agda:
     annotations:
       linguist: Agda
+      linguist-extension: Agda
       vote: Agda
   github.com/alibaba/druid/bd8e80bdd80c62a31910a8f5eec6d1669acf8b63/src/main/java/com/alibaba/druid/sql/dialect/oracle/ast/stmt/OracleForeignKey.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/alibaba/fastjson/adc8642927d5830b841d95637f69340d233dd03f/src/test/java/com/alibaba/json/bvt/path/JSONPath_field_access_filter_in_int.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/alibaba/fish-redux/77b827379b02d47dc5fc20d9022ef5d09102c5b7/example/lib/global_store/reducer.dart:
     annotations:
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/alibaba/flutter-go/c337f72c49fa1593b0457b980986c9c374f72256/lib/widgets/components/Menu/CheckedPopupMenuItem/index.dart:
     annotations:
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/alishak/TAG/5a0615a91af91f2c3ef3d369020e933c749a29d3/TXL/generateHeader.txl:
     annotations:
       linguist: TXL
+      linguist-extension: TXL
       vote: TXL
   github.com/alkana/ZExcel/5815a46da04bcb7bde13ae1f7849aa5fbb77f741/zexcel/worksheet/columniterator.zep:
     annotations:
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/alkresin/guiserver/01692dace35991eb9329f2fb21ce3abc373b5d42/tests/test2.prg:
     annotations:
       linguist: xBase
+      linguist-extension: xBase
       vote: xBase
   github.com/alokhan/ozproject/ddd6592ced6e39f9469b0061ceaac41be268ab9c/GameServer.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/alokmenghrajani/pixlpaste/6b8f1aac2d18ffff345de26e31eabfaf8e41a7fa/amazon_s3.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/alokmenghrajani/riskybird/ec25952187431f3a60940f19aa99702859f5a5ff/parsing/assign_id.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/amalshaji/sorty/e953d47ed187ff4ebc83f3468c66d476ce3f8896/sorty/radix.v:
     annotations:
       linguist: V
+      linguist-heuristics: V
       vote: V
   github.com/amarder/stata-tutorial/8b6d38712b86457556b91f12a00ee24cfa14d8f6/knitr.do:
     annotations:
       linguist: Stata
+      linguist-extension: Stata
       vote: Stata
   github.com/amarsten/Treelight/fdbc752136fa55924c5f317c246ab488a403f402/OSC_recv.ck:
     annotations:
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/amberframework/amber/b0343bbd065e751696c7c063c140bf4ceff6ff62/spec/amber/validations/params_spec.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/ambidexter-unity/Match3Engine/67276f7f13021f56d18a0ba5f15b34132aa3b4e7/ConvertedM3/Level_0019.m3:
     annotations:
       human-smola: JSON
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: JSON
   github.com/amchagas/Flypi/e7d725636b38c346398118e11f229b1fb8726d8f/3D_print_files/v1.0/not_tested_yet/library/tilted_stick.scad:
     annotations:
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/amclain/amx-lib-redis/ad2dd82b8e9f42b02faa62b3a69df633e915f4d8/integration/include/amx-lib-volume/amx-lib-volume-sc.axi:
     annotations:
       human-smola: NetLinx
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/amclain/sublime-netlinx/f4a70bd37a65d4cbd56b7fb4f393ed6c1d4dfbde/templates/Netlinx Include.axs:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/amethyst-framework/amethyst/6551f25c4c8a7b1522e57160f47c312254008c65/src/amethyst/middleware/middleware_stack.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/amitp/mapgen2/4394df0e04101dbbdc36ee1e61ad7d62446bb3f1/mapgen2.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/amlwwalker/got-qt/cd91aa500579bb053a0c9eac13f0b5c8b14ed14e/qt/qml/pages/ButtonPage.qml:
     annotations:
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/ammounce/ConMatNMRPro/bcc4997f135e81caeaa616d3c9028d1043a43dbe/CMNMRP_T1.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/amoblin/gitman/3f88b6845a95b94f8fe20c1a0ba0887fce3cc807/gitdisk-update.applescript:
     annotations:
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/ampl/global-optimization/2fdb82bdfa49efd2ab92b219876921918f3f7001/global/ex8_1_5.mod:
     annotations:
@@ -4015,60 +4950,75 @@ files:
     annotations:
       human-smola: Unknown
       linguist: EQ
+      linguist-extension: EQ
       vote: Unknown
   github.com/amyjzhu/whimsical-backend/e1b99bbf5cbecaaa69b9f0ecb06f9fb918fcb406/main.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/analogdevicesinc/hdl/eab1e86544647be00be2804ea81bed04b268f460/projects/adrv9371x/zc706/system_top.v:
     annotations:
       linguist: Verilog
+      linguist-heuristics: Verilog
       vote: Verilog
   github.com/anamestre/FIB-IA-P2-Museu/6c8aaeac827a68711fc256295f76e3bf214cbef8/museo.clp:
     annotations:
       human-smola: CLIPS
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: CLIPS
   github.com/andrealani/COOLFluiD/cd73fc5e70209808b75c6440df68cd2b01225613/plugins/NavierStokes/testcases/DoubleEllipse/restartRDS.surf.plt:
     annotations:
       human-smola: Unknown
       linguist: Gnuplot
+      linguist-extension: Gnuplot
       vote: Unknown
   github.com/andreaspirklbauer/Oberon-building-tools/c3569afbd75431f0cb2621d3a43b0f8e36b0207e/Sources/OriginalOberon2013/ORG.Mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/andreaspirklbauer/Oberon-experimental/79fb8ff2db11c8675374f3bf421fb395a16d6e7b/Sources/TestSafeModuleUnloading/M1.Mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/andreaspirklbauer/Oberon-fast-access-to-global-module-data/54063165163b1fc06a1573e28874713bbaeae596/Sources/OriginalOberon2013/Variant1/ORL.Mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/andrewgbruce/statistics-for-data-scientists/fe10de8f913103eb3f95fbc5c64a272601fcc7dc/src/chapter4.r:
     annotations:
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/andrewhamili/Bird-Game/111361e91357f9e028cc244954252caa5136d755/Main.eq:
     annotations:
       linguist: EQ
+      linguist-extension: EQ
       vote: EQ
   github.com/andrewjesaitis/cwl-tutorial/e1c4c28dcf173116e38d911df5cf2e9a22b2cfb8/snpeff.cwl:
     annotations:
       linguist: Common Workflow Language
+      linguist-extension: Common Workflow Language
+      linguist-shebang: Common Workflow Language
       vote: Common Workflow Language
   github.com/android/architecture-components-samples/b88adef417583371f3fe5a01e28983fe7170036d/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/db/RedditDb.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/android/architecture-samples/6f21231be28080fda229b8bbd738e962ea4bf95d/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/source/FakeDataSource.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/android/plaid/332ad29e3446043ea95e82a83e451075efebd517/designernews/src/main/java/io/plaidapp/designernews/ui/login/LoginActivity.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/androlo/EthereumContracts/8e6ce108ed3f140ca1cd5b8823ab0d139e89df29/actions/bank/awardsovereigns.lsp:
     annotations:
@@ -4078,36 +5028,44 @@ files:
   github.com/angryip/ipscan/dcf28fc757fe5583ba920485c61a3a5ebd13ab4a/ext/win-installer/NSISPortable/App/NSIS/Include/LangFile.nsh:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/angular/angular.js/060bcdeeb9f5181fb885417f68429c86a8e59eb2/src/ngSanitize/sanitize.js:
     annotations:
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/angular/angular/8c6fb17d2973acebdc4ded5feecbf87c29721aec/packages/zone.js/lib/zone-spec/sync-test.ts:
     annotations:
       linguist: TypeScript
+      linguist-heuristics: TypeScript
       vote: TypeScript
   github.com/animusdev/Old-World-Blue/d89f274094c77cbafc7e7d19eaca8871855c8e12/code/modules/power/singularity/act.dm:
     annotations:
       linguist: DM
+      linguist-extension: DM
       vote: DM
   github.com/anitagraser/QGIS-resources/636c986b5e7b2f99e115da18d085118035f5a84a/qgis1.8/styles/osm_light_polygon.qml:
     annotations:
       human-smola: XML
       linguist: QML
+      linguist-extension: QML
       vote: XML
   github.com/ankane/chartkick/9b0ee5644cb886be77c304647f729c5a2987d063/chartkick.gemspec:
     annotations:
       human-smola: Ruby
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/anko/eslisp/2fca24ae9c0716dac4f8e32aab504b1b2b2d35d2/src/translate.ls:
     annotations:
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/anordal/shellharden/22db5fca5d660c1a01b73736f10a4392310b8300/src/sitvarident.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/anotherkeebler/DiceGen/fc63e355eb881b894984420151d0db3169205508/diceware.wordlist.asc:
     annotations:
@@ -4117,10 +5075,12 @@ files:
   github.com/anpar/oz-project-fsa12/a574d3bd87d59c1d74bb4d46167576c4f7407d5d/35211300-31581300/code.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/ansible/ansible/008a95073dc05d6474a028bc5e078edda0faf4cd/test/units/modules/source_control/gitlab.py:
     annotations:
       linguist: Python
+      linguist-extension: Python
       vote: Python
   github.com/ant-design/ant-design-mobile/e0e94a1bcd274384846f1d57f7906c30ec0d79a5/components/locale-provider/en_US.tsx:
     annotations:
@@ -4134,18 +5094,22 @@ files:
   github.com/antalsz/hs-to-coq/6d75eecc36ad918989f69e2471ffc1e88a76f409/base/Data/Either.v:
     annotations:
       linguist: Coq
+      linguist-heuristics: Coq
       vote: Coq
   github.com/anthem/muun/54599ed16e92a9e34dfba0cdbbbddfdda3436760/Observable.io:
     annotations:
       linguist: Io
+      linguist-extension: Io
       vote: Io
   github.com/anthonymoralez/hello-android-sudoku/85695c81b4293a7281061168d83cfbc8ce1ed92c/src/com/example/sudoku/PuzzleView.mirah:
     annotations:
       linguist: Mirah
+      linguist-extension: Mirah
       vote: Mirah
   github.com/antlr/Antlr4Formatter/bd1b7d8f33aacf5673332bce7ce6dc64e172839a/antlr4-formatter/src/test/resources/CSharpPreprocessorParser.unformatted.g4:
     annotations:
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: ANTLR
   github.com/antlr/grammars-v3/939a374b04e3cf467127b44fc7cddbf75d75151e/ANSI-C/C.g:
     annotations:
@@ -4155,53 +5119,66 @@ files:
   github.com/antoniolg/Bandhook-Kotlin/062e30f1bea041c57b31b2572e36bba2a094230d/app/src/main/java/com/antonioleiva/bandhookkotlin/data/mapper/ImageMapper.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/antonmks/Alenka/0b5ed2ea6cd428fe8aa21d810f494848563c9bf4/select.cu:
     annotations:
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/antononcube/MathematicaForPrediction/f08498dc68c5bc987d1f53763b69cca06f19f7c4/DocumentTermMatrixConstruction.m:
     annotations:
       linguist: Wolfram Language
+      linguist-heuristics: Wolfram Language
       vote: Wolfram Language
   github.com/anychart-integrations/python-flask-mysql-template/7a9d3aeeaea557eca56abaee08f84dfc7056bb8d/database_backup.sql:
     annotations:
+      human-smola: SQL
       linguist: SQLPL
-      vote: SQLPL
+      linguist-heuristics: SQL
+      vote: SQL
   github.com/apache/couchdb/d60551d89100dccb5c649dd6cad3b7c7ec1371e0/src/fabric/src/fabric_dict.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
       vote: Erlang
   github.com/apache/incubator-shardingsphere/69b49b1357e45ab5b4b5827cff89bbe28333a810/sharding-core/sharding-core-execute/src/main/java/org/apache/shardingsphere/core/execute/ShardingExecuteCallback.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/apache/predictionio/d6bae3a725f7d6395d11c73deb5d489296ef2fd9/storage/s3/src/main/scala/org/apache/predictionio/data/storage/s3/package.scala:
     annotations:
       human-smola: Scala
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/apache/spark/5853e8b3301fd7b0bff721d5a47139afb17bfd2b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala:
     annotations:
       human-smola: Scala
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/apache/thrift/596e25f9b07f4eb626e8644b6cc18b93c417b4e5/contrib/zeromq/test-client.cpp:
     annotations:
       linguist: C++
+      linguist-extension: C++
       vote: C++
   github.com/apb2006/graphxq/1080533e6ccf8b00351df26ad80e976dc29ebce2/src/graphxq/views/item1.xq:
     annotations:
       human-smola: XQuery
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/apiaryio/drafter/b7519edf350dd5c81ac109f8356faa3f6a0f0078/ext/snowcrash/test/performance/fixtures/fixture-2.apib:
     annotations:
       linguist: API Blueprint
+      linguist-extension: API Blueprint
       vote: API Blueprint
   github.com/apiaryio/protagonist/514d9be1c6258c55475fc2d7dc4ef4b7fde7535a/test/performance/fixtures/fixture-1.apib:
     annotations:
       linguist: API Blueprint
+      linguist-extension: API Blueprint
       vote: API Blueprint
   github.com/aplteam/APLTreeUtils/3bca98c1b4bc82742ffd0e4d2c7a3aa7382b7076/APLSource/TestCases-11/FindSpecialString-811.aplf:
     annotations:
@@ -4214,41 +5191,50 @@ files:
   github.com/appeonguojun/test0619/5517acf6833a14a622817ace324fd635e6cd8bf6/ws_objects/genapp.pbl.src/genapp.sra:
     annotations:
       linguist: PowerBuilder
+      linguist-extension: PowerBuilder
       vote: PowerBuilder
   github.com/appeonguojun/test11/3e3f559dcc52f0ac2773ac051ef8bcf18e014f65/ws_objects/test11.pbl.src/w_test11_basesheet.srw:
     annotations:
       linguist: PowerBuilder
+      linguist-extension: PowerBuilder
       vote: PowerBuilder
   github.com/appeonteam/gittest1/453b56d4f8aa3f08d33a1737db70003096ced5bb/ws_objects/2.pbl.src/uo_23.sru:
     annotations:
       linguist: PowerBuilder
+      linguist-extension: PowerBuilder
       vote: PowerBuilder
   github.com/apple/foundationdb/ae34999dceece6fa91146f07f0a401dd8c4030c7/flow/serialize.cpp:
     annotations:
       human-smola: C++
       linguist: C++
+      linguist-extension: C++
       vote: C++
   github.com/apple/swift-evolution/065d5c930d0acec341872aecda7abbcd1642dbe6/proposals/0190-target-environment-platform-condition.md:
     annotations:
       human-smola: Markdown
       linguist: Markdown
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/apple/swift-llvm/7ade6a3e01d02275bcc9ee5a39142b5c9269d108/test/Transforms/Inline/inline-invoke-with-asm-call.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/apple/swift-nio/1a9a543b6bb4efb844be09daa55deee35881e192/Tests/NIOTests/AcceptBackoffHandlerTest.swift:
     annotations:
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/apple/swift/069db6e661ebb919414a37e6829d5cd947b1e02c/lib/Frontend/CompilerInvocation.cpp:
     annotations:
       linguist: C++
+      linguist-extension: C++
       vote: C++
   github.com/aquametalabs/aquameta/862efd5680b0b87269f73afd21c0be7887c41e0a/src/pg-extension/meta/test/000-meta.sql:
     annotations:
       human-smola: PL/pgSQL
       linguist: PL/pgSQL
+      linguist-heuristics: PL/pgSQL
       vote: PL/pgSQL
   github.com/araujokth/kth-wsn/e7d6cb37ddfe7864160989ea122f8c6018d2cad9/kth-wsn/apps.crane/MatlabFiles/outputs/data_201102100054.m:
     annotations:
@@ -4259,29 +5245,36 @@ files:
     annotations:
       human-smola: REALbasic
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/arcfide/ChezWEB/4e15a08bda7673ab062e24246d26f09b593792d0/chezweb.w:
     annotations:
       linguist: CWeb
+      linguist-heuristics: CWeb
       vote: CWeb
   github.com/archan937/jsonv.sh/9a448f8a5594f6cea41e79ce6582edcc6a91a29e/utils/json.awk:
     annotations:
       linguist: Awk
+      linguist-extension: Awk
+      linguist-shebang: Awk
       vote: Awk
   github.com/archipaorg/k8s-icl/f1269b8dd3264822af46433c220d608488592cf6/v1.6.6/v1beta1/policyrule.icl:
     annotations:
       human-smola: Unknown
       linguist: Clean
+      linguist-extension: Clean
       vote: Unknown
   github.com/arclanguage/anarki/406e75a50117dd2eb514f384af0f9f05e4b3b3fb/lib/re.arc:
     annotations:
       human-smola: Arc
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/areiman/PFO-ADC-DER-Testbed/2ecc3ef94a995a594e05cafacd58e68d4ea487c3/ADC-DER-Testbed/PythonTest/Python/fncs.zpl:
     annotations:
       human-smola: Unknown
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Unknown
   github.com/ares5221/manifoldAlgorithm/6eae56c92d1ac44c7185139ed6b81ac0233c01a3/increment-learning-multi-manifoldIMM-ISOMAP/IMMORL/swiss2000M5.m:
     annotations:
@@ -4291,23 +5284,28 @@ files:
   github.com/aria2/aria2/9d0a48ac8147c5e56402706d5c17efa8bf6340f2/src/DownloadContext.cc:
     annotations:
       linguist: C++
+      linguist-extension: C++
       vote: C++
   github.com/arinabondarenko/DL_homework_2/dbfde3172fc647e1d00d73a31aa0a26e59558c2a/task_2.txl:
     annotations:
       human-smola: Unknown
       linguist: TXL
+      linguist-extension: TXL
       vote: Unknown
   github.com/arirawr/suchdoge/56046919c026644a179bf6b496ca6f5db539290b/gameoflife.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/arknag/AdvMule/1a9a45a249ec097237496cee2e5e1402f377b7ec/bid-processing/target/test-classes/sample_data/string.dwl:
     annotations:
       linguist: DataWeave
+      linguist-extension: DataWeave
       vote: DataWeave
   github.com/arktools/arktoolbox/d347996e3543e6fb7aeee2febfc36b9be9a57d8d/arktoolbox-scicos/scicos/arktoolbox/navigationEquations.sci:
     annotations:
       linguist: Scilab
+      linguist-extension: Scilab
       vote: Scilab
   github.com/arne-cl/codra-rst-parser/9f39d7f1679ec82f587cb99efa956ed830924d86/Tools/CharniakParserRerank/first-stage/DATA/EN/tt.g:
     annotations:
@@ -4317,30 +5315,38 @@ files:
   github.com/arneg/Pike-SolR/86fb6e6c1c06ed7a8284a0650e43fd1ce4336bf3/lib/SolR.pmod/module.pmod:
     annotations:
       linguist: Pike
+      linguist-extension: Pike
       vote: Pike
   github.com/arneg/SyncDB/dc196fbf1063db2ec420fcaf52325216e0f3e818/stuff/exploration.pike:
     annotations:
       linguist: Pike
+      linguist-extension: Pike
       vote: Pike
   github.com/arnetheduck/nlvm/5f865d8f64f251b3e517a42d18e693eee9f2f2e6/nlvm/lllink.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/arpunk/telex/8f4ac8de45325daf679073f1d0a33ef1695f41b1/src/telex.lfe:
     annotations:
       linguist: LFE
+      linguist-extension: LFE
       vote: LFE
   github.com/arsenm/sanitizers-cmake/99e159ec9bc8dd362b08d18436bd40ff0648417b/cmake/FindUBSan.cmake:
     annotations:
       linguist: CMake
+      linguist-extension: CMake
       vote: CMake
   github.com/arthur-debert/BulkLoader/56c74f4a64b093c09a11ba2f5d984ad58e7c91c5/tests/src/br/com/stimuli/loading/tests/SmartURLTest.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/arvc-5/SuperServ/230ce08acf6a3affa565c483fd27dd6269231bee/bin/apache/apache2.4.9/manual/mod/mod_proxy_connect.html.fr:
     annotations:
       linguist: Frege
+      linguist-heuristics: Frege
+      linguist-xml: XML
       vote: Frege
   github.com/ascherer/cweb/f06867a45e17f15d3a29d04ca132ec82bf242de5/prod.w:
     annotations:
@@ -4349,120 +5355,150 @@ files:
   github.com/ascherer/mmix/f3f5ab5a593a94476321cc2d7e8b5fa59faff019/mmix-config.w:
     annotations:
       linguist: CWeb
+      linguist-heuristics: CWeb
       vote: CWeb
   github.com/ascherer/sgb/6f8b707e3e3b4d60699114fcfdd1aa20512ecf64/gb_roget.w:
     annotations:
       linguist: CWeb
+      linguist-heuristics: CWeb
       vote: CWeb
   github.com/aschn/gnuplot-colorbrewer/e8e4742626e386d5bfbe73ae0bddede9f7af1b56/diverging/PuOr.plt:
     annotations:
       linguist: Gnuplot
+      linguist-extension: Gnuplot
       vote: Gnuplot
   github.com/ashalkhakov/atscntrb-as-getopt/d166d50cecf116df4cb54cc1bdfdd2595d066437/SATS/getopt.sats:
     annotations:
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/ashishv197/Time_inc_Mulesoft/3d33f19ad6f946a8c3d733d0df0dd7587bceed93/TimeInc-EscoEloquaTMK-Services/src/test/resources/sample_data/list_Marketing_Communication_Items_Temp__c.dwl:
     annotations:
       linguist: DataWeave
+      linguist-extension: DataWeave
       vote: DataWeave
   github.com/askme765cs/Wine-QQ-TIM/89624a7d4174dade71b949cbb55a2ba46cfb3072/Wine-QQ8.9.3/qq/drive_c/windows/mono/mono-2.0/etc/mono/4.5/DefaultWsdlHelpGenerator.aspx:
     annotations:
       linguist: ASP.NET
+      linguist-extension: ASP.NET
       vote: ASP.NET
   github.com/askn/progress/5eb8c5985cb7811662dbc847070f685a16eae065/src/progress.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/askucher/nixar/d8678dde570de36fbd7221c8026fdc0927f70ba4/nixar.ls:
     annotations:
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/asmundg/yesbina/30aa30394dd6a7b7bccadeedbb650ea02880310c/yesbina/app.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
       vote: Hy
   github.com/aspire-fp7/annotation_extractor/0879c455d8df46b71d97823d5962de4beb91c26a/src/Txl/readAnnot.txl:
     annotations:
       linguist: TXL
+      linguist-extension: TXL
       vote: TXL
   github.com/aspnet/AspNetCore.Docs/f32db24cc8995bce69a531158f6b2278de3b834b/aspnetcore/migration/1x-to-2x/samples/AspNetCoreDotNetCore2App/AspNetCoreDotNetCore2App/Data/Migrations/00000000000000_CreateIdentitySchema.cs:
     annotations:
       linguist: C#
+      linguist-heuristics: C#
       vote: C#
   github.com/aspnet/AspNetCore/81379147e69864bf841c2953b50bb0849ceb830e/src/Mvc/Mvc.Razor/test/DefaultTagHelperFactoryTest.cs:
     annotations:
       linguist: C#
+      linguist-heuristics: C#
       vote: C#
   github.com/aspnet/Blazor/269c686b10f883dbe13bb0018fc493496d359540/eng/common/darc-init.ps1:
     annotations:
       linguist: PowerShell
+      linguist-extension: PowerShell
       vote: PowerShell
   github.com/aspnetboilerplate/aspnetboilerplate/49b802f1e718b94d79069d979f77f0cbbc13a603/test/Abp.Tests/Events/Bus/MySimpleTransientAsyncEventHandler.cs:
     annotations:
       linguist: C#
+      linguist-heuristics: C#
       vote: C#
   github.com/assaflavi/peptalk/daf63f1768449854e814ddce656a1d302c8fbe07/data/peptiDB/unbound/MotifAnalysis/data/1DKX/1DKX.mat.hb:
     annotations:
       human-smola: Unknown
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Unknown
   github.com/astatide/chpllog/ae97df2a3f7a95212a4f76bdac6d07ef264b3956/test/LoggingTest.chpl:
     annotations:
       linguist: Chapel
+      linguist-extension: Chapel
       vote: Chapel
   github.com/astaxie/build-web-application-with-golang/606abd586a7270d0e48762cf0454ba0fac330698/en/build.go:
     annotations:
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/asvarga/alloy-algebra/cf7561435ae7133532544aef1b33c90c1fe0ff9a/old/groups.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/atech/postal/634d3af59d392e84bdcd2b843b427f3a79d3ff4c/app/controllers/organizations_controller.rb:
     annotations:
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/atilaneves/cerealed/48834c2976a26120ff7892aa18f104f9e17e3f8c/src/cerealed/decerealiser.d:
     annotations:
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/atlarge-research/opendc/7d9ab456a54674112760af1b0cbc6a1b2e587ba1/database/schema.sql:
     annotations:
       human-smola: SQL
       linguist: SQLPL
+      linguist-heuristics: SQL
       vote: SQL
   github.com/atlas-engineer/next/eeea0838ec02b9363efbab50f5ece7890c0212d3/next.asd:
     annotations:
       linguist: Common Lisp
+      linguist-extension: Common Lisp
+      linguist-modeline: Common Lisp
       vote: Common Lisp
   github.com/atom/apm/34b9a38c329dba8fa89bbb40e8c0c18720099f6e/src/unlink.coffee:
     annotations:
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/atom/atom/323a006c41b463edd8cf24d59034af0a5fd33388/src/config-file.js:
     annotations:
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/atomAtomovich/AMX-smart-home/55968b9110a09ceeff16803117e19335f2eb1d06/GlobalMacros.axs:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/aturley/advent-of-code-2018/7936e359ece19e5dd5735e478837164dc408e53e/day3/main.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/aturley/pony-workshop/d9a3498331e3feefe81e015c9930ec06e0f6f901/steps/04/main.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/aturley/strange-loop-2019-pony-unsession/0c2656544bacfd607f4e46720fb6080bd60dbbcc/box/main.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/atuttle/Taffy/64553fdb2ceb43872ec03b17260c8b0e7f338f3b/dashboard/asset.cfm:
     annotations:
       linguist: ColdFusion
+      linguist-extension: ColdFusion
       vote: ColdFusion
   github.com/atyao/ECS140A_HW2/c3d441d06c7d48742dceb79a709b8a5031c23beb/Given/part13/t019.e:
     annotations:
@@ -4471,125 +5507,155 @@ files:
   github.com/aummn/weather_service/67f4777b6527613569bfb2b85d0312b57d6bfa39/src/test/resources/sample_data/string_6.dwl:
     annotations:
       linguist: DataWeave
+      linguist-extension: DataWeave
       vote: DataWeave
   github.com/aureliojargas/sedsed/431cc80f2f6de5f477b2e56e28faf146bc514d86/test/dumpdebug/tolower.sed:
     annotations:
       linguist: sed
+      linguist-extension: sed
       vote: sed
   github.com/austincain22/CSCI-117/31f0c44b64d8fe02f384ae25e5bb1b2ec20ffab2/lab9.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/autodidaddict/ponymud/dddb9ff0bb4f82720c6510cc7295e0bcd56b17d0/std/collector.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/avais25/Lustre-examples/2dd06a0bed855bba1a1aa0e5685d9fbc8cfae4a9/Question2/ROADS.ec:
     annotations:
       human-smola: Unknown
       linguist: eC
+      linguist-extension: eC
       vote: Unknown
   github.com/avelino/awesome-go/11ec240b27e3facf3e0612cee425f25dd0d8e739/repo_test.go:
     annotations:
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/aviaryan/Clipjump/6777987212bd8404c73ec27c81af4b55b4059a6f/lib/multi.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/aviaviavi/legion/32a8cacebd57ab97761907b23d1396b9a8700c2d/src/Server.hs:
     annotations:
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/avikalpg/POPL/bab092a525e6c049d1cf252f725e553df55ee158/hw4/3-5.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/avt-its-simple/amx-device-library/767a2e35791da13a626f3c19d796a2eb76b0e2f4/amx-controlports-api.axi:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/avt-its-simple/amx-snmp-library/956bfc595de250af8789a80cc7cb635eb13a8151/prime-connman-server.axi:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/avt-its-simple/amx-util-library/a6d1e8a7346dcfb82e7989835533000f25e46a20/uri.axi:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/avtaspay/commandfusion/76d654456e4abe0798937e94640afde04548c131/amx_modules/REV02/M_CommandFusion,iViewer,REV01.axs:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/aw/picolisp-nanomsg/3e05d54eee41b2a55cecbd87474e893ec6197b1f/nanomsg.l:
     annotations:
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
       vote: PicoLisp
   github.com/aw/picolisp-unit/113109890822648a31abba810e5e8538c1a25ed1/reporters/default.l:
     annotations:
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
       vote: PicoLisp
   github.com/aws-samples/aws-microservices-deploy-options/d226d554f9de93e48d6872027bb5b2dbf3c327fe/apps/k8s/ksonnet/myapp/components/params.libsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/aws-samples/ecs-refarch-cloudformation/a257e226b33bd9d2a721e5afd9d7e8b66dbacfdc/services/website-service/src/Makefile:
     annotations:
       linguist: Makefile
+      linguist-filename: Makefile
       vote: Makefile
   github.com/aws/aws-fpga/c9dcecbbdf324feae4a810a0057de264fb33b759/hdk/common/shell_v04261818/design/ip/ddr4_core/bd_0/ip/ip_0/sim/bd_bf3f_microblaze_I_0.vhd:
     annotations:
       linguist: VHDL
+      linguist-extension: VHDL
       vote: VHDL
   github.com/awwx/amacx/53ffbd7a729597f396bee13ccf70704a5f92b31a/src/findfile.arc:
     annotations:
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/awwx/arc/f01d3f9c661eed05511711a0f3388ca2a1d34fa2/html.arc:
     annotations:
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/awwx/lib/5fdb435fb5e0009d05954e2019d6368c64ed87f9/srv-misc2.arc:
     annotations:
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/awwx/match/ec1128d9b690b3900ec71e4a42975ccb70506ce2/arc.arc:
     annotations:
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/axoloti/axoloti-contrib/c3321956a3a6ab26dfdb6856e2934d2e22b45f9f/objects/sptnk/osc/vosim FM.axs:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/ayoul3/Privesc/96c5f6554cb4c6902302781ef0c971bd24f6c5ad/ELV.SELF:
     annotations:
       human-smola: REXX
       linguist: Self
+      linguist-extension: Self
       vote: REXX
   github.com/ayuryshev/config/c00693a20028eb72c7541e12159576a0b1ffc3fb/i3/src/A-main.i3:
     annotations:
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Modula-3
   github.com/azac/cobol-on-wheelchair/6bce149786c3d4d29b4440be21e7695892f1ce42/cow.cbl:
     annotations:
       linguist: COBOL
+      linguist-extension: COBOL
       vote: COBOL
   github.com/azim4gvm/fantastic-train/6b6f92775f260e3e7dc9d375962b0170fc5fb085/ci.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/b-cakir/hecke-operator/6d6b57400ed54ef637c2b49550448000e999eab2/optimized.mg:
     annotations:
       human-smola: Unknown
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Unknown
   github.com/b4b4r07/manyawk/fcc3ba31c0331165545152ccd5cb524ed82cd48f/path/filepath.awk:
     annotations:
       linguist: Awk
+      linguist-extension: Awk
       vote: Awk
   github.com/b4winckler/macvim/fd916f58a3723000b9d7b2e0d5657d050e4af962/src/pty.c:
     annotations:
       linguist: C
+      linguist-extension: C
       vote: C
   github.com/ba-st/Willow/fcdc80ceba43f6a10136d069a4ef40144eb63209/source/Willow/ComponentRemovingCommand.class.st:
     annotations:
@@ -4602,157 +5668,195 @@ files:
   github.com/babluboy/bookworm/9446717f97b59214a5d50e369a3eaf02eaa8091f/src/headerbar.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/badocksbi/BADock/c79e1be5e23f254d64414ddfe342c1b75336536a/db/AffinityBenchmark/2B4J_l_b.pdb.HB:
     annotations:
       human-smola: Unknown
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Unknown
   github.com/baedert/corebird/28f866f833a2e5956644e7c9b88ba8f880e36a5f/tests/tweetmodel.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/bagwaa/intellij-settings/3cfc420abc95ad1d7b66a410add277ecb4ad67dc/colors/Fleure_0.icl:
     annotations:
       human-smola: XML
       linguist: Clean
+      linguist-extension: Clean
+      linguist-xml: XML
       vote: XML
   github.com/baidu-research/warp-ctc/6d5b8fac130638862d97dc48ef43a8d7b5a503bb/include/contrib/moderngpu/include/device/ctascan.cuh:
     annotations:
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/bailicangdu/node-elm/42629186e2e0b7ec75839c096135f8f44cd79b4f/controller/v1/captchas.js:
     annotations:
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/bakerjd99/jacks/0f15042dbc814f36453003e9b7f1ee9c8ddf26c3/phones/jPhoneBlogExamples.ijs:
     annotations:
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/bakkdoor/amorphic/e2000c417d41bca2169d633ce16ef9e1ee83a802/lib/amorphic/point.fy:
     annotations:
       human-smola: Fancy
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Fancy
   github.com/bakkdoor/fancy/fee34a828006adba003f9d2225ba239aa1b7ecaa/lib/html.fy:
     annotations:
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Fancy
   github.com/bakkdoor/fancy_irc/182a6ecb276861b36834aa2ed0773821bf52315f/tests/client.fy:
     annotations:
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Fancy
   github.com/bakkdoor/fancywiki/61cd15e2ac8e6eb90ffa9d115fe90997f8448104/lib/template.fy:
     annotations:
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Fancy
   github.com/bakkdoor/fsm.fy/bdde760ff91055a6f19265328c1daca64015ca46/tests/fsm.fy:
     annotations:
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Fancy
   github.com/bakkdoor/fyzmq/6f377eadca65826381f00e2b4974bf269bb1873c/tests/socket.fy:
     annotations:
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Fancy
   github.com/bakkdoor/msgpack.fy/4a4abbc7342f5df23b7d069e615ce46e9a749d12/lib/msgpack.fy:
     annotations:
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Fancy
   github.com/bakkdoor/redis.fy/9b121b878cc1be48f2fcc68aa8cddc7e326746af/lib/redis/client.fy:
     annotations:
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Fancy
   github.com/bakkdoor/ripple.fy/10ca698ee95ff3f03d4c69de2a4f8be20a506e7b/tests/ripple.fy:
     annotations:
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Fancy
   github.com/bakkdoor/shortefy/67531a29d27d3996d6a565c284a9b60d46eacda6/app.fy:
     annotations:
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Fancy
   github.com/bakpakin/Fennel/d3620b369a6d16f55f98d939a3b47b56d97b9f19/fennelview.fnl.lua:
     annotations:
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/ballerina-attic/connectors/ff19ae1c77ddf59deae9b3ab9a9ffb4a63a40040/salesforcerest/samples/salesforcerest/samples.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/ballerina-guides/ballerina-demo/86f4c95bc24d6fa5b464714e77c1d1b990d91898/2_demo_annotations.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/ballerina-guides/ballerina-with-istio/dabbf6d36e6c6ec842c54dbad4b3034841a05221/src/time_service.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/ballerina-guides/messaging-with-kafka/275cea5444a0587c3e8a80152263eb8294f1a557/guide/franchisee2/franchisee2.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/ballerina-guides/playground-hello-service/40a2939c5a26c9adf5546cbc0db705fd98984d53/src/hello_service.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/ballerina-guides/restful-service/82ba3d286638f089c50319d083689442e606c13d/guide/restful_service/tests/order_mgt_service_test.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/ballerina-guides/service-composition/afee04fbd736231642c5ec89414c5215a45e4e2d/guide/car_rental/car_rental_service.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/bambenek/block-doh/57e3698b959b8eda5df6b8698a0187b4ad1df074/db.doh:
     annotations:
       human-ajnavarro: Unknown
       linguist: Stata
+      linguist-extension: Stata
       vote: Unknown
   github.com/bamboo/boojay/37c4e3f2ecb869d0dac34ef37786e9c934739c27/src/Boojay.Compilation/Steps/BoojayEmitter.boo:
     annotations:
       linguist: Boo
+      linguist-extension: Boo
       vote: Boo
   github.com/bamboo/unityscript/73099e73252bfbd2595c960775b85bc739c9180a/src/UnityScript/Scripting/SimpleEvaluationDomainProvider.boo:
     annotations:
       linguist: Boo
+      linguist-extension: Boo
       vote: Boo
   github.com/banneker-aztlan/intro-to-python/a2633812d2591c036d629265579b4b7b88ed001a/data/seds/Sc_A_0.sed:
     annotations:
       human-smola: Unknown
       linguist: sed
+      linguist-extension: sed
       vote: Unknown
   github.com/baron42bba/aws-snippets/9cb1edaaa86609b51a7fbf39ec643cc5ae80eaa1/snippets/json-mode/aws-autoscaling-group-vpc:
     annotations:
       linguist: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/baroquebobcat/shatner/c8f1ce080a1cc1ddae4e663b587693f44889a9d2/test/test_shatner.mirah:
     annotations:
       linguist: Mirah
+      linguist-extension: Mirah
       vote: Mirah
   github.com/basecamp/trix/695c2e655badc6c2807b8f0e15a06dcf6549a0b2/test/src/test.coffee:
     annotations:
       human-smola: CoffeeScript
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/bast/cmake-example/43929f949a51220368b610b7e0fe99bad5c39d5a/cmake/safeguards.cmake:
     annotations:
       linguist: CMake
+      linguist-extension: CMake
       vote: CMake
   github.com/bastos/vuvuzela-mirah-android/38559b1f34038cf9c1d09893050f3b3ba269bb02/src/bastos/vuvuzela/Vuvuzela.duby:
     annotations:
       linguist: Mirah
+      linguist-extension: Mirah
       vote: Mirah
   github.com/bayandin/awesome-awesomeness/c9be27cb307f12e9dff644d99fc8e54af9d16b1a/Dangerfile:
     annotations:
       human-smola: Ruby
       linguist: Ruby
+      linguist-filename: Ruby
       vote: Ruby
   github.com/bazelbuild/bazel/bd0a40254697ec7e0cd9a522cf5ba282ea76389c/src/main/java/com/google/devtools/build/lib/skylarkinterface/SkylarkCallable.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/bbc/bbplot/82af5952230c695bd317d7786587cfffea7f7621/R/finalise_plot.R:
     annotations:
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/bburns/Lantern/0eb8c9e880eae2592c78e0c7ccd5a99984d60832/data/lisp/zork.lisp:
     annotations:
@@ -4767,61 +5871,76 @@ files:
   github.com/bcbio/bcbio_validation_workflows/a297e87e014de998b8df9c90700c29173ec09932/wes-agha-test/wes_chr21_test-workflow-arvados/wf-alignment.cwl:
     annotations:
       linguist: Common Workflow Language
+      linguist-extension: Common Workflow Language
       vote: Common Workflow Language
   github.com/bcbio/test_bcbio_cwl/d675318396ddf17fb886c058f5f17f8b0414f4cd/prealign/prealign-workflow/main-prealign.cwl:
     annotations:
       linguist: Common Workflow Language
+      linguist-extension: Common Workflow Language
       vote: Common Workflow Language
   github.com/bcit-ci/CodeIgniter/f40d86c54fbbc3adc8c901fa4580dbcb5d89a3b4/system/language/english/migration_lang.php:
     annotations:
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/bdcuck/PISSBALLS_COBOL/6b6bc7034b8bb55b6c25c92acafd9c9b7c9bd7ae/PISSBALLS.CBL:
     annotations:
       linguist: COBOL
+      linguist-extension: COBOL
       vote: COBOL
   github.com/bdina/birdy/6a84f7ebd67969feb3d423beefafa437161a94c6/src/view/signin.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/bdrister/AquaticPrime/4d7d521f288234fb2a91b14e530b3b82b8ce114d/Source/RealBasic/TT's SmartPreferences/MacOSLib (partial)/CoreFoundation/CFDictionary.rbbas:
     annotations:
       human-smola: REALbasic
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/beaker-project/zpxe/55fd1d704220756403402ba705c71c472a10f744/zpxe.rexx:
     annotations:
       linguist: REXX
+      linguist-extension: REXX
       vote: REXX
   github.com/beanstalkd/beanstalkd/0fcf38b1782b10cbdb2ee03a79a401812c612663/sd-daemon.c:
     annotations:
       linguist: C
+      linguist-extension: C
+      linguist-modeline: C
       vote: C
   github.com/beeyev/Mikrotik-Firmware-Auto-Updater/a7734dfcf945e8709a6d70be6b423a458633bdb8/firmware-updater.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/begoon/acm/05472eaa0fff7abb6679826085da5e0c990df4cb/ch24.org/2011/Pre-round, 2011.02.12/R/text05.tst:
     annotations:
       human-smola: Unknown
       linguist: Scilab
+      linguist-heuristics: Scilab
       vote: Unknown
   github.com/bekkopen/jasmineio/4988aadfa028bdaa3c11c9431eb4277dcecbf88d/io/spy_spec.io:
     annotations:
       linguist: Io
+      linguist-extension: Io
       vote: Io
   github.com/belaban/pluscal/1c7430f2ee2b8099b5d14db6bf1341e698a0cfba/Hello.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/bellenuit/subtitler/32faeddc7088533ad24a4640267e127a6cfbb966/ImportFolder/Converters/FCPXMLConverter.rbbas:
     annotations:
       human-smola: REALbasic
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/ben-manes/gradle-versions-plugin/bafd707be0504f7bda7bad073ebe5e49a0b3aa4d/src/main/groovy/com/github/benmanes/gradle/versions/updates/VersionComparator.groovy:
     annotations:
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/benahm/TDF/664cf1d1ee1b45aea122d0e4899f94b6ff1b2aef/classes/TDFTest.cls:
     annotations:
@@ -4830,62 +5949,76 @@ files:
   github.com/bencord0/blogposts/dd4efcc0cf94899a60f941f490e5bcdc59bb0735/templates/entry.html.hb:
     annotations:
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Harbour
   github.com/bendmorris/krit/c95a910d0d6a8b8696070355518b76a3cc333adc/backend/sdl/shaders/shader.kit:
     annotations:
       linguist: Kit
+      linguist-extension: Kit
       vote: Kit
   github.com/bendmorris/neskit/609133a5055e30189d12ac79d87f7df797882479/src/neskit/audio/triangle.kit:
     annotations:
       linguist: Kit
+      linguist-extension: Kit
       vote: Kit
   github.com/benlau/qtandroidexamplecode/2097b031d0b173fdc714659d0ab73e5b371a325a/qtandroidrunner/qtandroidrunner.pro:
     annotations:
       linguist: QMake
+      linguist-heuristics: QMake
       vote: QMake
   github.com/benlau/quickandroid/364c32e710f1c88d3d30db4342a69a873099df44/QuickAndroid/drawable/ArtShadowDepth2.qml:
     annotations:
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/benmurphybaum/AT/c89e2396331050d3cc52e2e27752ba240a94cc55/atControls_v1.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/bennofs/etc-nixos/5fe80d256d0101b1e73c9036d0a7ae6cee2c4267/expr/softwarechallenge-gui/2014.nix:
     annotations:
       linguist: Nix
+      linguist-extension: Nix
       vote: Nix
   github.com/benoitletondor/Android-Studio-MVP-template/8ac7252bd93aaeda3a3f6d9d3c4b8ec21945599b/MVPBoilerplate/root/src/app_package/classes/BasePresenterImpl.java.ftl:
     annotations:
       linguist: FreeMarker
+      linguist-extension: FreeMarker
       vote: FreeMarker
   github.com/benweet/stackedit/2fdbb67c67159c4ccfddbe51fc9303c6c799dbe0/src/services/providers/helpers/zendeskHelper.js:
     annotations:
       human-smola: JavaScript
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/bernerdschaefer/sgheme/5007b2763c8280668d3bb72b9e50c17a057bc8ee/sicp.lisp:
     annotations:
       human-ajnavarro: NewLisp
       human-smola: Scheme
       linguist: NewLisp
+      linguist-heuristics: NewLisp
       vote: NewLisp
   github.com/bfad/Lasso-HTTP/9f3b55820e5f2c1837c614cc00723f831165e23f/http_response.lasso:
     annotations:
       human-smola: Lasso
       linguist: Lasso
+      linguist-extension: Lasso
       vote: Lasso
   github.com/bgeraghty/RunProcessAsUser-ScreenConnect/bdb5cfbaffe558019aa902096373a2a87cb29062/Source/rpau.pb:
     annotations:
       linguist: PureBasic
+      linguist-extension: PureBasic
       vote: PureBasic
   github.com/bigtweekx/h2pc_installer/697b698ecb5bd7679e3dbb8c8281df0893fb9869/setup_complete.nsi:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/bill-auger/chuck-song-builder/f9a0bfac3fe88b0e9d128ce504593893f8418a8e/Modalbar.ck:
     annotations:
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/bingoogolapple/BGAQRCode-Android/0b10eb95021bd183140d12ecc4bf33559ee152cb/zbar/src/main/jni/libiconv-1.15/lib/canonical_sysaix.h:
     annotations:
@@ -4895,10 +6028,13 @@ files:
   github.com/binux/pyspider/3fccfabe2b057b7a56d4a4c79dc0dd6cd2239fe9/tests/test_task_queue.py:
     annotations:
       linguist: Python
+      linguist-extension: Python
+      linguist-shebang: Python
       vote: Python
   github.com/biokoda/actordb/cf48f819c6cd1a5d4d50ff977db1617b3cece460/test/dist_test.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
       vote: Erlang
   github.com/birgander2/RAT/361336e1988f9998a00f1bd3c6bb5ecb0ec7c270/polinsar/polin_opt_mb_esm.pro:
     annotations:
@@ -4907,77 +6043,97 @@ files:
   github.com/bishless/static-tpa/587eb692b618fda0063824408a389dca17bcbd7a/_kit/_svg-icon_act-svcs.kit:
     annotations:
       linguist: Kit
+      linguist-extension: Kit
       vote: Kit
   github.com/bitcoin/bitcoin/224c19645fa0478112ea0129a75ba0097caa55ad/src/qt/bitcoinstrings.cpp:
     annotations:
       human-smola: C++
       linguist: C++
+      linguist-extension: C++
       vote: C++
   github.com/bitcoinops/scaling-book/dfa8d912e3e0e3d32797c214c335f3df6eaec8ac/x.payment_batching/img/batching.plot:
     annotations:
       linguist: Gnuplot
+      linguist-extension: Gnuplot
+      linguist-shebang: Gnuplot
       vote: Gnuplot
   github.com/bitcraze/bitcraze-mechanics/db5f8ebf2911eae3328c265b1a21facba39dccef/motor-mounts/cf2-mount-openscad/7mm_motor_new_holder_param.scad:
     annotations:
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/bitemyapp/learnhaskell/daeb6e4fa71a2fa423a6d1563b3f5cd6793bec0b/Makefile:
     annotations:
       linguist: Makefile
+      linguist-filename: Makefile
       vote: Makefile
   github.com/bitnami/kube-prod-runtime/06a262883b607b0c30d58269316fb0e1ed9c155e/manifests/lib/kube.libsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/bitnenfer/sat-monkey/77a90770bf049dc5080ba43f87270a17b8caff17/rectangle.monkey:
     annotations:
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/bitwalker/distillery/b7805d2147140f1517152cd88dcdb6911498d7cd/lib/distillery/releases/assembler.ex:
     annotations:
       linguist: Elixir
+      linguist-extension: Elixir
       vote: Elixir
   github.com/bitwalker/swarm/4aee63d83ad5ee6ee095b38b3ff93a4dbb7c3400/lib/swarm/tracker/crdt.ex:
     annotations:
       linguist: Elixir
+      linguist-extension: Elixir
       vote: Elixir
   github.com/bjansen/gyokuro/a3f0db80f7029ae350bc97e33eaf7882a9182d00/source/net/gyokuro/view/api/templates.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/bjorncole/kerml_alloy/ede944e45a84f1845d2c64563c8fdb11c7e08e9c/kerml_m1_aircraft.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/bjourne/playground-factor/3f5ae1845e7050696c4f8e754f7e8d7f7a10b992/http-sync/tests/ap.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/bkiers/pcre-parser/6bf809a18e423bebd6548dd418075eebe655d15a/src/main/antlr4/nl/bigo/pcreparser/PCRE.g4:
     annotations:
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: ANTLR
   github.com/bkiers/rrd-antlr4/6b40ff9f613127fea205c3b7092f2065efc44a01/src/test/resources/IRI.g4:
     annotations:
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: ANTLR
   github.com/bkiers/sqlite-parser/9adf75ff5eca36f6e541594d2e062349f9ced654/src/test/resources/tkt3493.test_1.sql:
     annotations:
       human-smola: SQL
       linguist: PL/pgSQL
+      linguist-heuristics: PL/pgSQL
       vote: SQL
   github.com/blackcata/1D-RANS/cdf7efa59778749b0f492cfa1cabda342327ec6f/DATA/CHANNEL_0180_mean_prof.plt:
     annotations:
       human-smola: Unknown
       linguist: Gnuplot
+      linguist-extension: Gnuplot
       vote: Unknown
   github.com/blackjack3186/Vault-113-Restoration./ebd889c8e5dd22777af400e26bd8ec862b8bbb4b/code/game/objects/items/weapons/airlock_painter.dm:
     annotations:
       linguist: DM
+      linguist-extension: DM
       vote: DM
   github.com/blakemcbride/APLComponentFiles/17349d9d95f357a9771ae4f72de9902bad7980f6/ComponentFiles.apl:
     annotations:
       linguist: APL
+      linguist-extension: APL
+      linguist-shebang: APL
       vote: APL
   github.com/blanton144/kcorrect/dcad853bb362de5d346c52590906879756e8949e/pro/utils/galex_to_maggies.pro:
     annotations:
@@ -4986,14 +6142,17 @@ files:
   github.com/blitz-research/monkey2/349651c9fc4ed0e7b387861c3a54d000eae46096/bananas/PromptInvasion/vector.monkey2:
     annotations:
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/bloc97/Anime4K/638e8cb63fc5a055d32647dbb22c367d3039674b/glsl/Anime4K_Adaptive_v1.0RC2_UltraFast.glsl:
     annotations:
       linguist: GLSL
+      linguist-extension: GLSL
       vote: GLSL
   github.com/blockstarter/blockstarter/2814ec4bcd33aec24347ec69a4dd1f8db0d84ec0/src/main/new-addr-hide/new-addr-hide.ls:
     annotations:
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/blox-org/blox-cfg/8a7b024e88ce27e1b468766c3fa1bd880ea1ead6/opensips/blox-register.cfg.m4:
     annotations:
@@ -5002,22 +6161,27 @@ files:
   github.com/blueimp/jQuery-File-Upload/2efdf5352138c5752354424466b6b3925bc12bd1/server/php/UploadHandler.php:
     annotations:
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/bluejay77/ANN-with-Shen-3/a83006d12d19480374b02b3dc888cdb5f0fb9be2/BAM.shen:
     annotations:
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/bluejay77/ANN-with-Shen-4/f93c9c32bd161f7467a635f6f62d7dc0c2d6ebf7/array.shen:
     annotations:
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/blueriver/MuraCMS/ddb85336690e3ea63d57f485a4e258ccc53e417a/admin/core/views/cdashboard/topsearches.cfm:
     annotations:
       linguist: ColdFusion
+      linguist-extension: ColdFusion
       vote: ColdFusion
   github.com/blueskythlikesclouds/SkythTools/97cb5304000e7f24ebed543478f691fad7d4a8cd/Sonic Forces/Path Scripts/PathExporter.ms:
     annotations:
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: MAXScript
   github.com/bluewolf-beyond/selector/b16eeb6fec13fb578f6482fb341ac4a7172aac97/src/classes/Filter.cls:
     annotations:
@@ -5026,80 +6190,100 @@ files:
   github.com/bm181354/CS320/fdf4b6ae747a48f30612505c8fd962714bb3849d/assigns/03/assign3.dats:
     annotations:
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/bmatzelle/gow/c033136df2532a7573bea6fd9403e0403faa1211/setup/Gow.nsi:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/bmrf/tron/d20dbdcd475444216736a71bbba7d100efc36eec/resources/stage_5_patch/7-zip/7-Zip Installer.bat:
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/bmx-ng/bcc/dbc11c5d6e0f009786f98f42cffbe7abd50a25bd/tests/framework/language/try_04.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/bmx-ng/bmk/b228fd41c203b7fad066275230cfd0b7757bfed0/bmk_cores_macos.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/bmx-ng/bmx-ng/4df5080d7c20c759ed5b08f3fbf066f33919bcb4/src/makedocs/docstyle.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/bmyerz/rappl/d10d8fb1f2696f67672101de3610239fd7440d1e/hashjoin.chpl:
     annotations:
       linguist: Chapel
+      linguist-extension: Chapel
       vote: Chapel
   github.com/bobthecow/psysh/9aaf29575bb8293206bb0420c1e1c87ff2ffa94e/src/ExecutionLoop/RunkitReloader.php:
     annotations:
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/bodil/purescript-signal/58e44e7f8c20e9d057bcaffbd231893935548bb5/src/Signal.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/bolovsky/php-htmlfilter/fda863f7c688a46c46b2abeceb8f76185a0b84fd/htmlfilter/htmlfilter/htmlparser/model/htmlelement.zep:
     annotations:
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/boo-lang/boo-extensions/cb4c0b93ab11a5359f9b42cd13509ae1454170b1/GenerateBooParserTestFixture.boo:
     annotations:
       linguist: Boo
+      linguist-extension: Boo
       vote: Boo
   github.com/bots-squad/indybot/5a2fa4da1c274e5d3b47951153ec494c59612b73/adapters/adapter.rocket.chat.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/boughtonp/qpscanner/42b7b883bd39ca90d3f8d1f950834fb65251cacd/Application.cfc:
     annotations:
+      human-smola: ColdFusion CFC
       linguist: ColdFusion
-      vote: ColdFusion
+      linguist-extension: ColdFusion CFC
+      vote: ColdFusion CFC
   github.com/bp2014n2/i2b2-db/652d43307d8ca337cf8529105ba5f0196a011680/setup/ecl/indices/create_indices_for_provider_dimension.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/bquistorff/synth_runner/38d18ae94121ae5d5475d2108a51c874c0c455ca/code/ado/parallel_clean_setclusters.ado:
     annotations:
       human-ajnavarro: Stata
       linguist: Stata
+      linguist-extension: Stata
       vote: Stata
   github.com/brancz/kubernetes-grafana/539a90dbf63c812ad0194d8078dd776868a11c81/grafana/grafana.libsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/brandonlw/Psychson/4522989aac27aada5f522675b33a2bde63a13b30/EmbedPayload/EmbedPayload/Properties/AssemblyInfo.cs:
     annotations:
       human-smola: C#
       linguist: C#
+      linguist-heuristics: C#
       vote: C#
   github.com/brendangregg/FlameGraph/1a0dc6985aad06e76857cf2a354bd5ba0c9ce96b/stackcollapse-aix.pl:
     annotations:
       linguist: Perl
+      linguist-heuristics: Perl
       vote: Perl
   github.com/brentp/nim-plotly/ec536af399d3deb125fdec31c17d302def5b314a/src/plotly/api.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/breuleux/quaint/8c538dfde32183f1116f6c661835f35f6c249d21/scaffold/index.q:
     annotations:
@@ -5109,71 +6293,89 @@ files:
   github.com/brexis/qml-bootstrap/27d6b87c25f8afcd8836f7a587797e50c140f51d/src/styles/AvatarListViewStyle.qml:
     annotations:
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/briandunnington/Roact/8b6fd69e4355c6e9ee7cb039460a4a4c5eeb5766/Roact.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/briangu/chearch/69d795d9c3f095a72a83cdf651471e9a6b34ac17/test/helloworld.chpl:
     annotations:
       linguist: Chapel
+      linguist-extension: Chapel
       vote: Chapel
   github.com/briangu/chord/ab1f7819eb292da7515727722c06462342797e9e/src/word2vec_dsgd.chpl:
     annotations:
       linguist: Chapel
+      linguist-extension: Chapel
       vote: Chapel
   github.com/briatte/awesome-network-analysis/b355b3bbb5b7a7202957f9312a8d04f8e1656784/check.r:
     annotations:
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/brightsign/BrightAuthor-Plugins/383e0f21e7cf3740f541b3fca98b8f6d15924e06/Telnet-Enable/telnet_enable.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/broodplank/APKtoJava/d4074316853add180ffe27dd5b112f66180ab574/ExtProp.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/brown-uk/dict_uk/85e45677987e690360872f0a09b4b26f2c1fa963/src/test/groovy/org/dict_uk/expand/ExpandTest.groovy:
     annotations:
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/brunoruviaro/SCLOrkSynths/00d7f33c2c04b0b4f5b464f2921ae0cd4407860e/pbind-demos/FMRhodes1-demo.scd:
     annotations:
       linguist: SuperCollider
+      linguist-extension: SuperCollider
       vote: SuperCollider
   github.com/bryanedds/Nu/d0f532daf17f6fbbe459d2878434070a008f10af/Nu/Nu/Program.fs:
     annotations:
       linguist: F#
+      linguist-heuristics: F#
       vote: F#
   github.com/bryanjenningz/25-elm-examples/fb15917a33785bef18864a25648938e45dd74122/04-hello-world.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/brzozi/harbour-commander/3071c772fcb7b5a9b4a8674017becfe9cd492bd7/hc.hb:
     annotations:
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Harbour
   github.com/btreut/a2/48dcfc1f1a6ed2bec110ca3af3674657d4229d16/source/X509.Mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/buggins/dlangui/1822edb88d5f06a6d3398f9c251255673f5f4dac/3rdparty-extra/win32/regstr.d:
     annotations:
       human-smola: D
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/buggins/hibernated/d7fc8dae97982084fd90639ed6dff198628406da/hdtest/source/htestmain.d:
     annotations:
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/buildersbrewery/linden-scripting-language/eddb08ceabbf47a922ff6eb145c9913095d3dfe8/emacs/yasnippet/snippets/lsl-mode/HTTP_MIMETYPE.yasnippet:
     annotations:
       linguist: YASnippet
+      linguist-extension: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/bumptech/glide/e733e9c8662b1397f08f7530ba727865e34e143c/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/AttributeStrategy.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/byackee/jarvis-rivescript/f89853fb359083cf6c8b4ddcd7b363986fadb6ce/eg/brain/fr/cerveaudebase.rs:
     annotations:
@@ -5183,22 +6385,27 @@ files:
   github.com/byte-physics/igor-code-browser/3ae3748ccb5031ab47fc2fa2129d1f135ac29c20/procedures/CodeBrowser_gui.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/byxb/Whack/09ee587afd6acff6a9c7c18799bb16b0fa25705d/src/de/polygonal/ds/BitVector.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/c-cube/datalog/b6ddfbe98e5ccee595731e33ac067d47a50a4af5/tests/induction500.pl:
     annotations:
       linguist: Prolog
+      linguist-heuristics: Prolog
       vote: Prolog
   github.com/c02y/dotfiles/869c30324b15c82e721db81b677b241a9df08555/spacemacs/.spacemacs.d/snippets/bibtex-mode/inproceedings:
     annotations:
       linguist: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/caerwynj/acme-sac/f4f9fd5288517911b74cc19f21a73260fc3ab754/module/math/geodesy.m:
     annotations:
       linguist: Limbo
+      linguist-heuristics: Limbo
       vote: Limbo
   github.com/cagataycali/awesome-brainfuck/1d7e330e7f9bb441a98bad94df4c0569ea94580e/self-interpreters/by-adam-domurad.bf:
     annotations:
@@ -5207,18 +6414,22 @@ files:
   github.com/calavera/mirah.hpi/7c9253dbacf550875e624c54dd24bda50955d737/src/main/mirah/mirah_command_interpreter.mirah:
     annotations:
       linguist: Mirah
+      linguist-extension: Mirah
       vote: Mirah
   github.com/calvinjuarez/SVG-Awesome/956c6f3cc6f50762ecab49ffc9c3357c6a3083da/svg-awesome.chars.kit:
     annotations:
       linguist: Kit
+      linguist-extension: Kit
       vote: Kit
   github.com/cameronbwhite/CS420-Project-2/5a898efc7ab0cedf433c9bfbe9b657e5c16a92fc/dictionaryTest.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/camptocamp/puppet-haproxy_c2c/588a386c69a74b634e1fb42b7df26224c91bd16b/files/test_haproxy.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
       vote: Augeas
   github.com/cappelnord/BenoitLib/e3743d839beee746e7075700ea5305670ad85a12/patterns/Pkr.sc:
     annotations:
@@ -5227,10 +6438,12 @@ files:
   github.com/cappelnord/CNToolsSC3/452eb734e1ad5624d0ef6d2306dfdd234c7e370e/ReChorder.sc:
     annotations:
       linguist: SuperCollider
+      linguist-heuristics: SuperCollider
       vote: SuperCollider
   github.com/carlbennett/BNRBot/77befad560d0770f7ee5fd40b5ec17a0bb535f37/src/Modules/Globals.rbbas:
     annotations:
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/carloop/hardware/7fe80cc13adf8100ad54f4a6c7fb054c739a4806/CarloopXL.v3/CarloopXL-v3.1.pro:
     annotations:
@@ -5239,6 +6452,7 @@ files:
   github.com/carlosedp/cluster-monitoring/cdc33631f480815065ef472e751d3761c7a04cce/k3s-overrides.jsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/carlosrojasquiroz/Macro-Models-Workshop/41e378e9b0d3da8c51ee488b04d9539ad5229757/RBC04.mod:
     annotations:
@@ -5247,76 +6461,96 @@ files:
   github.com/carolineschnapp/ajaxify-cart/63262eff5df7fb52d7d93968d6109ca690c17457/ajaxify-cart.liquid:
     annotations:
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/casperschipper/ChucK-Tools/ccaa46079a4f8a0fada873ff0b034f0003187229/streams/ST_stateMachine2.ck:
     annotations:
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/cassidyjames/ephemeral/7a1f348430c9545a4f4a5de6c2b7c79bccb9de6f/src/Views/ErrorView.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/catalindragan/minivoting-privacy/78ac6620463627fa14e5ff686adb62db6b2ea51f/proof/core/ProofSystem.ec:
     annotations:
       linguist: eC
+      linguist-extension: eC
       vote: eC
   github.com/catb0t/21-game/ce2a44f1e6b7f1413156d998283b65bf5676b2a5/21-game/21-game.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/cayleygraph/cayley/a2350a910ae30d6989664dc1ed7d06d1cc26fd74/internal/lru/lru.go:
     annotations:
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/ccamacho/tripleo-kb/8df43a8ec79a2a612a72c265dbf1a5671bc5cc7b/nits/2016-07-29-the-referenced-attribute-ControllerServiceChain-role_data-is-incorrect.nit:
     annotations:
       human-smola: YAML
       linguist: Nit
+      linguist-extension: Nit
       vote: YAML
   github.com/ccgus/fmdb/65036d66e9698c24698bfc120450cf033bbbbdb2/src/fmdb/FMDatabase.h:
     annotations:
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/cckpg/autoproxy2privoxy/e01e16910e938e4e865bafbf6d3d1b3a92015395/autoproxy2privoxy.awk:
     annotations:
       linguist: Awk
+      linguist-extension: Awk
+      linguist-shebang: Awk
       vote: Awk
   github.com/ccondrup/mage-reset/1f0894be655a45e0fbcb85f539a89d3f1f3af245/reset_increment_ids.sql:
     annotations:
       linguist: SQLPL
-      vote: SQLPL
+      linguist-heuristics: SQL
+      vote: Unknown
   github.com/ccrisan/motioneyeos/1b59951d9b5b645c873312ca46acef6c64a98973/package/tk/tk.mk:
     annotations:
       human-smola: Makefile
       linguist: Makefile
+      linguist-extension: Makefile
       vote: Makefile
   github.com/ccrma/music220a/ed6435bb4aa1cb8b3ce9d3c0be13856c66fc2772/chuck-examples/special/LiSa-munger1.ck:
     annotations:
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/cdcarter/backpacking/12dd19a8857a99d392de34f6a7798631ee9faf19/lib/db.io:
     annotations:
       linguist: Io
+      linguist-extension: Io
       vote: Io
   github.com/cdr/code-server/cee0ac213cf80c20537a77b26ea842091b421dc7/src/browser/client.ts:
     annotations:
       linguist: TypeScript
+      linguist-heuristics: TypeScript
       vote: TypeScript
   github.com/cedricss/opa-meteor-spark/2bcebe0838fea0e38437230adbfba7bb2f9b6c0c/reactive.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/cedricss/server-monitor/ba8e4bb0d00a0449aa0250644b2c83819cb57804/main.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/cellar-wg/matroska-specification/73f24242b91edd85686c9f9b80b9e3cd4702b747/transforms/ebml_schema2clean.xsl:
     annotations:
       linguist: XSLT
+      linguist-extension: XSLT
+      linguist-xml: XML
       vote: XSLT
   github.com/cemulate/the-mlab/32a17500b5bed2eca831a545f887bf4737b685f5/src/grammar/noun-literals.ne:
     annotations:
       linguist: Nearley
+      linguist-extension: Nearley
       vote: Nearley
   github.com/cesanta/mongoose/dce60c6dbb096f3b96e1a45cbfdfd55e18b38bb6/src/common/platforms/platform_stm32.h:
     annotations:
@@ -5326,117 +6560,145 @@ files:
   github.com/ceylon/ceylon-examples-spark/6ecf93917b09e6373b7c435386753e0b0103f2bc/source/todo/sparky/velocityContext.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/ceylon/ceylon-examples/d979f6413603f96d69aaafe7e96e3e7ae558df28/GameOfLife/source/ceylon/examples/gameoflife/Cell.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/ceylon/ceylon.ast/653c1f78979f864b6bf2b97e10bb55bbec3d148d/source/test/ceylon/ast/redhat/SequentialType.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/ceylon/ceylon.build/80652528c69acb89e5bc6086c5a81271f8ffb913/test-source/test/ceylon/build/engine/build.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/cfobel/vpr_placement_parser/bcf576d8321b4dfea33c4271893f7c01ef601b29/grammar.rl:
     annotations:
       linguist: Ragel
+      linguist-extension: Ragel
       vote: Ragel
   github.com/cfoster/xqrs/28a71cfc25025bfa633aafd0a13054888e63f46e/test-suite/xqy/marklogic/session-testing.xq:
     annotations:
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/cfsimplicity/lucee-spreadsheet/29e35aba2d9eb57b8f876f9660b981c29f06b20f/test/specs/read.cfm:
     annotations:
       linguist: ColdFusion
+      linguist-extension: ColdFusion
       vote: ColdFusion
   github.com/cfwheels/cfwheels/82d0a82941ec68bda9197a1618e3960b4828380f/wheels/public/layout/_footer.cfm:
     annotations:
       linguist: ColdFusion
+      linguist-extension: ColdFusion
       vote: ColdFusion
   github.com/chai2010/awesome-wasm-zh/76b252458b6af51c14adda62f37fd324dbed9ab4/simple.wat:
     annotations:
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/chall32/LDWin/f1c30a3311ae6767b4c881954d1a2ddc249333da/LDWin.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/chameco/snapshot/f31049ee90291b88e61726203a602868631cfccd/scripts/snapshot.ash:
     annotations:
       linguist: AGS Script
+      linguist-extension: AGS Script
       vote: AGS Script
   github.com/chapel-lang/chapel/a74978b9a65a672f8ef873c87b61f50208969857/test/functions/iterators/vass/multi-yield-symbols/11-oneLocalSymbol.chpl:
     annotations:
       linguist: Chapel
+      linguist-extension: Chapel
       vote: Chapel
   github.com/charliekramer/ChucK/e397590910d79237b805ed491e5f6b8c461d0863/Rhizome rundown.ck:
     annotations:
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/charliergi/SugarPicker/3eb54629cfaa898063a678fda5fcbbb53a3c2287/code.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/charly-lang/charly/5955c910f9546d8b8dd628a96989b83f453bf1f9/src/charly/interpreter/internals/file.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/charonn0/BSLib/8eff1e7c8c9931a27f26e1c0e687745ae8913e3d/BSLib/Modules/Networking.rbbas:
     annotations:
       human-smola: REALbasic
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/charonn0/GameOfLife/0e8098c110282fad74bef0c56ef2ea6f92851960/RLEStream.rbbas:
     annotations:
       human-smola: REALbasic
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/charonn0/RB-FTP/f2d1efcf886e39307616116942c0b41fbbca9a7b/FTP/Client.rbbas:
     annotations:
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/charonn0/RB-Scintilla_OLD/d0969daa2415ca7cca35c633505b106eb8194d69/App.rbbas:
     annotations:
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/charonn0/RB-libcURL/b8c8ba701dd13cb33d579637e50b1637c9c1c074/libcURL/ShareHandle.rbbas:
     annotations:
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/charonn0/Updater/de12062bcc1c83cc1bcfefabdd24b912e6c9c822/App.rbbas:
     annotations:
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/charonn0/VT-Hash/e76a2b2b3d0ade3b4724c6fd957d16f1a93c84b7/libcURL/MultiHandle.rbbas:
     annotations:
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/chatgris/be_fancy/c3ab57de0240e81c0ba513f9e2a4f933c8a02d3b/actor.fy:
     annotations:
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Fancy
   github.com/chatopera/conversation-sampleapp/0e7928b2cf846cfd7c82987450f9ace5c522d4fa/app/zh_CN.weather.ms:
     annotations:
       human-smola: Unknown
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: Unknown
   github.com/cheat-engine/cheat-engine/3d0f184e817c1345de36ad2952336ea3f021af7c/Cheat Engine/formChangedAddresses.pas:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/chenchengyin/android-studio-template/c096bc8fb9f987e00aa0518d7d84682388d72a9f/activities/MarshonSlideTabActivity/root/src/app_package/SimpleFragment.java.ftl:
     annotations:
       linguist: FreeMarker
+      linguist-extension: FreeMarker
       vote: FreeMarker
   github.com/chenenyu/img-optimizer-gradle-plugin/fc1ba8e14a65e01f33a47d84e357dd5499a33784/buildSrc/src/main/groovy/com.chenenyu/imgoptimizer/ImgOptimizerPlugin.groovy:
     annotations:
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/chengdazhi/Deformable-Convolution-V2-PyTorch/2f57c5db49161bd6c899670a5e4fba50e6b8fd26/src/deform_conv_cuda_kernel.cu:
     annotations:
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/chiaxin/MayaAPI101/9c43df063e68ea68de3920019e074b8be1dc1b65/Qt/example/example.pro:
     annotations:
@@ -5445,22 +6707,27 @@ files:
   github.com/chinkei/zephir-symfony-asset/a9ffb1ccd8e982723c8e1d6ec46ba26bee6b00c6/Component/Asset/UrlPackage.zep:
     annotations:
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/chochos/script-bowl-chat/7675f917822a1247440e44e3dbdcc429d5aa75e5/jsclient/source/scriptbowl/chat/client/users.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/chocolatey/boxstarter/17c0e9f6539ea607b4f0f080ca87dda98d219d40/Boxstarter.Chocolatey/Enable-BoxstarterClientRemoting.ps1:
     annotations:
       linguist: PowerShell
+      linguist-extension: PowerShell
       vote: PowerShell
   github.com/chr15m/blender-hylang-live-code/51effef64be85d2bdab1ad9f1888309af19ce691/helpers.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
       vote: Hy
   github.com/chris-martin/home/5317ec2acce017218ff3a0eb242ea3d91ec5aa72/.emacs.d/emacs.nix:
     annotations:
       linguist: Nix
+      linguist-extension: Nix
       vote: Nix
   github.com/chrishwiggins/orly/990dc81d1b7cb228f57929a0b62c76de5b354cb2/screendump.asc:
     annotations:
@@ -5471,46 +6738,57 @@ files:
     annotations:
       human-smola: Assembly
       linguist: Assembly
+      linguist-extension: Apollo Guidance Computer
       vote: Assembly
   github.com/christianguenter2/sitFRA_2016/b6fadfbda61033d70b6b3d19ca10c15cf1bec4fa/z_sitfra_2016_.prog.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/christopheradams/elixir_style_guide/f421e3485d8a152de8f3535f4ac7fe1ee7aaf23d/mix.exs:
     annotations:
       linguist: Elixir
+      linguist-extension: Elixir
       vote: Elixir
   github.com/chtaylo2/Roku-GooglePhotos/72f942a122abc7f5f26f761d78783c6e9365c6bc/components/Screensaver/Screensaver.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/chuckdee68/IEDLCDEditor/566692090e16b908b7af2872b38bdebd76084d5e/bin/DATA/tk/xmfbox.tcl:
     annotations:
       linguist: Tcl
+      linguist-extension: Tcl
       vote: Tcl
   github.com/chucknorris/roundhouse/f278dcfdaa582f3b2d5a1fc403c702e1b5c80acc/product/testdatabase/MySql/sakila-db/sakila-schema.sql:
     annotations:
       linguist: PL/pgSQL
-      vote: PL/pgSQL
+      linguist-heuristics: SQL
+      vote: Unknown
   github.com/chumo/Schroedinger_SOLVER-IgorPRO/213cf6ef19fffb5aca329deac5a141b229faa056/Schroedinger_SOLVER.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/chunquedong/EasyMapReduce/ef4e2bb012cc92056de97693ffdbab80d2fec369/src/test/UtilTest.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/chunquedong/axdb/e233b7306c650aa8f75523de9111da4101f241cb/store/fan/log/Recover.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/ciasia/http/701632408d2fec769a985e2ecc118bc3d5745fdd/http.axi:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/ciasia/jsmn/a34c5063ecbd5e2c89d4a02e43d939878f40b985/jsmn-util.axi:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/cirosantilli/x86-bare-metal-examples/62ed931615ca33002431726d4b1e59f4aba21dd6/segmentation.S:
     annotations:
@@ -5521,6 +6799,7 @@ files:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
       vote: Scheme
   github.com/cjdelisle/cjdns/45cdd8b3eebb18b6239feeef3b787e40d773edfb/node_build/dependencies/cnacl/crypto_stream/salsa20/e/sparc/salsa20.s:
     annotations:
@@ -5530,30 +6809,39 @@ files:
   github.com/cjharris02892/dwGUI/323958d5563002f44d44b4a52de80498e467a8d2/w_dwgui_response.srw:
     annotations:
       linguist: PowerBuilder
+      linguist-extension: PowerBuilder
       vote: PowerBuilder
   github.com/cjk8zb/CSEE5590-BigData-Labs/d8fa436083f4d5f632fcadf60950559bff507a0d/Lab2/Hive_Commands.q:
     annotations:
       linguist: HiveQL
+      linguist-heuristics: HiveQL
       vote: HiveQL
   github.com/cjkvi/cjkvi-dict/9b6e0a88bcccdfa36c6b96327a88fc900867276c/lsyj.xsl:
     annotations:
       linguist: XSLT
+      linguist-extension: XSLT
+      linguist-xml: XML
       vote: XSLT
   github.com/ckgyarmathy/debian_config/ca5f883bfe5e57218f6c62aa8528a53e011ffbcc/config_.i3:
     annotations:
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Modula-3
   "github.com/ckjbug/Hacking/89a9b9c6fe8a0ab58550d0030d33d76e86deef7d/Windows-hosts\u6587\u4EF6\u7FFB\u5899\u811A\u672C\u4F7F\u7528\u8BF4\u660E\u7B49/Google\u7F51\u7AD9hosts/0114/windows\u7528\u6279\u5904\u7406/Windows\u81EA\u52A8\u66FF\u6362\u811A\u672C.bat":
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/cl21/cl21/c36644f3b6ea4975174c8ce72de43a4524dd0696/src/stdlib/abbr.lisp:
     annotations:
       linguist: Common Lisp
+      linguist-heuristics: Common Lisp
       vote: Common Lisp
   github.com/clacks-overhead/clacks-protocol/4e395ec9a9cd272e7401172ef3559884dd343b37/transform.xsl:
     annotations:
       linguist: XSLT
+      linguist-extension: XSLT
+      linguist-xml: XML
       vote: XSLT
   github.com/clarkzjw/one-two-three...infinity/6e51f4a16cb62ad9e60f6fbc2fed710d7dc8bbb4/sum.b:
     annotations:
@@ -5562,189 +6850,239 @@ files:
   github.com/clarus/coq-chick-blog/beaf50f3cd949a830ddd665e2600f4fd822f5b46/src/Render.v:
     annotations:
       linguist: Coq
+      linguist-heuristics: Coq
       vote: Coq
   github.com/clarus/falso/11ba1e990f1b6b1a7c3fa7f48dcb7841ffed6386/All.v:
     annotations:
       linguist: Coq
+      linguist-heuristics: Coq
       vote: Coq
   github.com/clawpack/pyclaw/eaec7888b0aa02c6e44aa715a63c85d54d5353d9/src/pyclaw/sharpclaw/reconstruct.f90:
     annotations:
+      human-smola: Fortran
       linguist: Fortran
+      linguist-extension: Fortran
       vote: Fortran
   github.com/clfm/Book-Notes/9ad086c1206e73bbb0e6a96b068d6b8ec55fb874/Code Complete.md:
     annotations:
       linguist: Markdown
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/cliffordwolf/picorv32/46aa89c13f51c2963019be5e9b6af40d64dceb62/picosoc/icebreaker_tb.v:
     annotations:
       human-smola: Verilog
       linguist: Verilog
+      linguist-heuristics: Verilog
       vote: Verilog
   github.com/clojure-cookbook/clojure-cookbook/1b3754a7f4aab51cc9b254ea102870e7ce478aa0/02_composite-data/2-22_multiple-values/src/clojure_cookbook/multiple_values.clj:
     annotations:
       human-smola: Clojure
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/clojure/clojurescript/df1837048d01b157a04bb3dc7fedc58ee349a24a/src/test/cljs/clojure/walk_test.cljs:
     annotations:
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/cmcaine/nearley-ts-demo/cfc6be8ccfb91e9a4667402d4f7801ff6c8c21b0/src/bracketexpr.ne:
     annotations:
       linguist: Nearley
+      linguist-extension: Nearley
       vote: Nearley
   github.com/cmoylan/Elements-of-Computing-Systems/9f169843689048006b2c9aae358a1f39ea09efe1/project03/a/Bit.tst:
     annotations:
       linguist: Scilab
+      linguist-heuristics: Scilab
       vote: Scilab
   github.com/cmusatyalab/openface/cff4f882f2db647671004c2bb6d60bdc4aff75f5/models/openface/nn4.small2.def.lua:
     annotations:
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/cnjackchen/my-chrome/ad45f41f146039e08ce61d69081f3ddcb69cc6a9/AppUserModelId.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/cocos-creator/tutorial-dark-slash/05cd71e3b1c815274d50e60cb1889284f89296c2/revive_atlas.tps:
     annotations:
       human-smola: XML
       linguist: PL/SQL
+      linguist-extension: PL/SQL
+      linguist-xml: XML
       vote: XML
   github.com/codebybrett/r3-scripts/fb75fb620d0ce9a7c9d6fe8125ad56d416e87cb2/tests/test-rowsets.reb:
     annotations:
       linguist: Rebol
+      linguist-extension: Rebol
       vote: Rebol
   github.com/codecombat/codecombat/60fb4224401c52e4b93383eaf2872980dd4a472a/app/lib/world/Grid.coffee:
     annotations:
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/codeneomatrix/multics-history/09daeb08947c07f2be770e2da3db0a72a3541c70/source/Multics/ldd/system_library_tools/object/generate_cmf.ec:
     annotations:
       human-smola: Unknown
       linguist: eC
+      linguist-extension: eC
       vote: Unknown
   github.com/codeneric/hack2php/17692899f099e7d01aad210a9822f6439600905d/tests/HackToPhpTest.php:
     annotations:
       linguist: Hack
+      linguist-heuristics: Hack
       vote: Hack
   github.com/coderlifex/Igor_DataProcessingPackage_IOP/a550a2f23510b1a9a5c1c9238ff21318da7d80bf/02_Simulation/PBogdanovSimulation/Dispersions.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/codeschool/sqlite-parser/a50aabea6b1289aa85a88fc7664de1753f4d034e/test/sql/official-suite/tkt1449-1.sql:
     annotations:
       human-smola: SQL
       linguist: PL/pgSQL
+      linguist-heuristics: PL/pgSQL
       vote: SQL
   github.com/codez/ImportPhotoFolders/4c4c611970e9d275fef0abdb0559262757ee7eeb/ImportPhotoFolders.applescript:
     annotations:
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/coding-robots/iwl/bf13ab3f75aff0fe63c07555a41574e919bb11db/crc32.rkt:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/coding442/sud/9918aa4d77a7fdfdf5c4df84e94276396045734d/src/com/example/sudoku/Sudoku.mirah:
     annotations:
       linguist: Mirah
+      linguist-extension: Mirah
       vote: Mirah
   github.com/coding442/sudoku/d423c3cde77888cec02bd4d8d64329f9909b27ce/src/com/example/sudoku/Prefs.mirah:
     annotations:
       linguist: Mirah
+      linguist-extension: Mirah
       vote: Mirah
   github.com/codito/gnome-pomodoro/9b927300d3930596fe402977a0533136d0036728/lib/entry.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/colah/ImplicitCAD/c54929328ddae304118d8466df8d18708e6979a2/Graphics/Implicit/Export/DiscreteAproxable.hs:
     annotations:
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/collectordave/PureBasic-Password-Database/39d60108a6dd0c8933a76ff368c40298943cce69/Locale.pbi:
     annotations:
       linguist: PureBasic
+      linguist-extension: PureBasic
       vote: PureBasic
   github.com/commanded/commanded/fd3b8a4937a0c45f00e2bca90577ddd205a3104e/lib/mix/tasks/commanded.reset.ex:
     annotations:
       linguist: Elixir
+      linguist-extension: Elixir
       vote: Elixir
   github.com/commercialhaskell/stack/e57c0154f3a272702db515cc3520d0394231697c/src/Stack/Options/SDistParser.hs:
     annotations:
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/common-workflow-lab/wdl2cwl/c9aff7c54deb4cf962bec21c6788f773ad77c81a/wdl2cwl/expression-tools/read_tsv.cwl:
     annotations:
       linguist: Common Workflow Language
+      linguist-extension: Common Workflow Language
       vote: Common Workflow Language
   github.com/common-workflow-language/common-workflow-language/9a23706ec061c5d2c02ff60238d218aadf0b5db9/draft-3/draft-3/cat3-tool.cwl:
     annotations:
       linguist: Common Workflow Language
+      linguist-extension: Common Workflow Language
+      linguist-shebang: Common Workflow Language
       vote: Common Workflow Language
   github.com/common-workflow-language/cwldep/fd481c56b576c2835fb2e38539b9b5a57b93d11e/sample.cwl:
     annotations:
       linguist: Common Workflow Language
+      linguist-extension: Common Workflow Language
       vote: Common Workflow Language
   github.com/common-workflow-language/cwltool/4642316a30a95d4f3d135c18f98477886b160094/cwltool/schemas/draft-2/draft-2/binding-test.cwl:
     annotations:
       linguist: Common Workflow Language
+      linguist-extension: Common Workflow Language
+      linguist-shebang: Common Workflow Language
       vote: Common Workflow Language
   github.com/common-workflow-language/cwlviewer/fc9d51d4897ed3f89275ebdc6d857548205739e7/src/test/resources/cwl/lobstr-v1/lobSTR-workflow.cwl:
     annotations:
       linguist: Common Workflow Language
+      linguist-extension: Common Workflow Language
+      linguist-shebang: Common Workflow Language
       vote: Common Workflow Language
   github.com/compomics/colims/4936195068337ba0c5236830f7f5f84e05d73ae5/colims-distributed/src/test/resources/data/maxquant/maxquant_SILAC_integration/combined/andromeda/allSpectra.CID.ITMS.iso_2.apl:
     annotations:
       human-smola: Unknown
       linguist: APL
+      linguist-extension: APL
       vote: Unknown
   github.com/composer/composer/4e4c38795a0814db2b9222871a63714f674fd1d9/tests/Composer/Test/DependencyResolver/RuleSetIteratorTest.php:
     annotations:
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/comptech/Igor-Pro-procedures/d565b7222eecdae735d404382cc7955fcb9ae635/igorutils/waveutils.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/computerquip/hsp/d92c7a9e68a13038d94bc374d3d2ced5a6eec9ad/src/lexer/rules/definitions/Keywords.rl:
     annotations:
       linguist: Ragel
+      linguist-extension: Ragel
       vote: Ragel
   github.com/computmaxer/roku-hdhomerun/a92c1f9fae46f9ee212ee00614250de972d3812e/source/gridScreen.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/comses/intro-to-abm/0138451b48c0a23ca6ca19378bf5c3bb25ddcc3e/assets/netlogo/resourceharvest.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/conanite/rainbow/aa37d65548d5658aa3608cfe40a1a388d793b575/src/arc/rainbow/tests/string-interpolation-test.arc:
     annotations:
       human-smola: Arc
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/concrete-mixer/concrete-mixer/2bca2ce512349b95534008de5b9c1e418b20dd1d/lib/Fx/FxReverb.ck:
     annotations:
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/congdm/Patchouli-Compiler/8ce70218b06a6bf41490a291f271654ff93f13e8/source/Scn.mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/connectedworkers/dsl.adapters/c6aa7a72c9e201df14495630222c24872f711712/io.connectedworkers.dsl.adapters.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/container-storage-interface/spec/4731db0e0bc53238b93850f43ab05d9355df0fd9/Makefile:
     annotations:
       linguist: Makefile
+      linguist-filename: Makefile
       vote: Makefile
   github.com/copumpkin/categories/36f4181d751e2ecb54db219911d8c69afe8ba892/Categories/Support/PropositionalEquality.agda:
     annotations:
       linguist: Agda
+      linguist-extension: Agda
       vote: Agda
   github.com/coreos/kube-prometheus/ce5fe790ee9f1772ad52d935b320d545c8f88722/example.jsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/corkami/pics/3cb08bc92e6c7508a30ca0d9f5f8a3319a300591/binary/macho101/simple64.asm:
     annotations:
@@ -5754,6 +7092,8 @@ files:
     annotations:
       human-smola: NewLisp
       linguist: NewLisp
+      linguist-heuristics: NewLisp
+      linguist-shebang: NewLisp
       vote: NewLisp
   github.com/corywalker/expreduce/0a346d0d4ef1800bf7762f4cba0fb7e9cee0101a/expreduce/resources/time.m:
     annotations:
@@ -5763,22 +7103,28 @@ files:
   github.com/couchbase/geocouch/92def13f6b049553da1aa1488ce0bde6b7d0f459/vtree/src/vtree_io.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
       vote: Erlang
   github.com/coursier/coursier/0bf1c4f364ceff76892751a51361a41dfc478b8d/modules/tests/shared/src/test/scala/coursier/test/ResolutionTests.scala:
     annotations:
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/covert-code/KoL-MineVolcano/a18a2c75462160a0b5aca052760e25a2d1d76af7/scripts/minevolcano.ash:
     annotations:
       linguist: AGS Script
+      linguist-extension: AGS Script
       vote: AGS Script
   github.com/cpp-frug/materials/433c7d24a2c7de7758f867610784a8f47403324f/scripts/round-floating-to-integer.sed:
     annotations:
       linguist: sed
+      linguist-extension: sed
+      linguist-shebang: sed
       vote: sed
   github.com/craigbarnes/showdown/9448e32cf61a96709d227b520680e3b22ea8df74/src/window.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/cran/boot/07ba70f8a27e323f428a1017d68b0ff809453abf/R/bootpracs.q:
     annotations:
@@ -5788,75 +7134,93 @@ files:
   github.com/crocodile2u/zhandlersocket/226018a2cd1393a629dca2f968918d1c9010acfa/zhandlersocket/Command.zep:
     annotations:
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/crossminer/scava-deployment/c4e9501f8758ebd47773fce552b487819eaa3d2c/KB/src-rascal/org/maracas/Maracas.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/crossoverJie/JCSprout/60440b61560f71e862163caa6a041af587b06aff/src/main/java/com/crossoverjie/concurrent/VolatileInc.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/croton/nyttig/4bc0db3c90df6f35304c873ce40c2c540635d036/builder/newproj.rex:
     annotations:
       linguist: REXX
+      linguist-extension: REXX
       vote: REXX
   github.com/crucialfelix/API/4bab7b5513082c8c9cca9be7391f657d6c1ecbb1/deprec-2.0.sc:
     annotations:
       linguist: SuperCollider
+      linguist-heuristics: SuperCollider
       vote: SuperCollider
   github.com/crystal-community/cossack/0fba91ebc1a73a1f1aff87d7cfe79928ca186c0d/spec/acceptance/client/head_spec.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/crystal-community/icr/93108126bd3b74badb23c365364ec0258dc178a3/src/icr/console.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/crystal-lang/crystal-mysql/dbb300f9b3ff86aff2c20d5dd2a4b024c5bd5176/spec/spec_helper.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/crystal-lang/crystal/e1db6c90b0060216729ff97a739a877e3a760287/src/compiler/crystal/program.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/crystal-lang/shards/43ae0adbad8d07776139b55ac69a3819008518cb/test/dependency_test.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/ct-clmsn/CHIUW2017/dfb65716d1ce5f31afad75239211d5e49e9fc0a7/heavyhitter.chpl:
     annotations:
       linguist: Chapel
+      linguist-extension: Chapel
       vote: Chapel
   github.com/cth/banpipe/ea146d588eeb4a4fb9446e5ceaf24360ee60b3c2/banpipe.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/cubesatlab/cubedos/4300107f39f7af539499c9f678abe668d8b2bb54/src/cubedos-file_server-messages.adb:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/cubesql/cubeSQLAdmin/46599149fc417f1e63c46908c3c7bcd0098965e8/Components/FGSourceList/FGSourceListItem.rbbas:
     annotations:
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/cullum/dank-selfhosted/de7708c08f1f02782df717bfc886fff2da232d3a/roles/dank/files/dankctl.pl:
     annotations:
       linguist: Perl
+      linguist-heuristics: Perl
       vote: Perl
   github.com/culturekings/shopify-json-parser/dd0d2edc9f11be9f2f238e131ea08865f69a628c/json_decode.liquid:
     annotations:
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/culturekings/shopify-shortcodes/8f35774558b1ef0b1bc3a1fc568a6f2d4935b459/shortcode.liquid:
     annotations:
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/cure-honey/Mandel/6c5c98e5dd4a2365b1df9d9957e1e9c3aac6dc7b/mandel.chpl:
     annotations:
       linguist: Chapel
+      linguist-extension: Chapel
       vote: Chapel
   github.com/cuu/STM32duino_LED_Matrix/720d3790e4b53ebc7802d4c0bac3b0d28559921a/zh_font/monaco15px.lsp:
     annotations:
@@ -5866,40 +7230,49 @@ files:
   github.com/cvgit/vhdlParser/35869f79fdd25a9c9ffe83a654b4c377ccad500d/vhdl.g4:
     annotations:
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: ANTLR
   github.com/cwi-swat/allealle/5516dd2ea360f2d13b30e8b0923772574ffa2f44/src/translation/theories/integer/SMTInterface.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/cwi-swat/bacata-rascal/c66e69e78fdc36b408dd4a5fb85c81e048601244/src/bacata/CodeMirror.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/cwi-swat/php-analysis/90f153f13c809d9a76a4ca752d681a201cded715/src/lang/php/ast/System.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/cwi-swat/rascal-discover-ide/4ee2bb6973ad812aac44f7bde5d83fd4abbc656b/src/util/DiscoverIDE.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/cwi-swat/rascal-ecore/c36c05c73142f9f991016c9175b46da795d0a2d1/src/lang/ecore/hutn/Model2HUTN.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/cycyustc/isotracks/3d1f71b58af375db67f5cb8a77c879b50c702911/isotrack/mesa/MESA_KS_DB/ptcri_ovh0.20.ovhe0.50.z0.00555.y0.25409.HB:
     annotations:
       human-smola: Unknown
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Unknown
   github.com/cypress-io/cypress/7ef3078f6a394c4e041a9e484ff80808ffd74298/packages/server/lib/controllers/xhrs.coffee:
     annotations:
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/d-widget-toolkit/dwt/66b84b401e44c010168fd579bca056eb0f73fc3d/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/internal/mozilla/nsIEventTarget.d:
     annotations:
       human-smola: D
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/dabdala/ABLPDF/6a8822eb18eb794f5e78b3b42e5c56bb11a6313c/src/pdf/utiles/MarcaDeLectura.cls:
     annotations:
@@ -5908,26 +7281,33 @@ files:
   github.com/daeken/Dotpack/dd74a2255f710d00601bd8e8cfca640e9fc64039/Dotpack.boo:
     annotations:
       linguist: Boo
+      linguist-extension: Boo
       vote: Boo
   github.com/dagda1/hornget/8eee220c9438750cc5b128fde9e576752947b991/orm/nhcontrib/nhibernate.validator/nhibernate.validator-2.1.boo:
     annotations:
       linguist: Boo
+      linguist-extension: Boo
       vote: Boo
   github.com/dahlbyk/posh-git/89dafc1f37d9a44917d5ce6a84e889e54c6f98b9/profile.example.ps1:
     annotations:
       linguist: PowerShell
+      linguist-extension: PowerShell
       vote: PowerShell
   github.com/daijifeng001/R-FCN/94797e0e8d15998a9ab0a76cbac3281ad907f04a/functions/rfcn/rfcn_prepare_image_roidb.m:
     annotations:
       linguist: MATLAB
+      linguist-heuristics: MATLAB
       vote: MATLAB
   github.com/dair-iitd/OpenIE-standalone/d04c5618a1a27b98e0e0dc7f840fb76725ed0bed/WordNet-3.0/doc/ps/wnutil.3.ps:
     annotations:
       linguist: PostScript
+      linguist-extension: PostScript
       vote: PostScript
   github.com/daisy/xprocspec/7617513997658dc35034fb337e9baf7811d397b6/src/test/xprocspec/steps/error.xpl:
     annotations:
       linguist: XProc
+      linguist-extension: XProc
+      linguist-xml: XML
       vote: XProc
   github.com/dalehenrich/filetree/d7eee41d8a083180557d00e270f279f47105a565/repository/MonticelloFileTree-Tests.package/MCFileTreeFileUtilitiesTests.class/instance/testDirectoryFromEntry.st:
     annotations:
@@ -5936,46 +7316,56 @@ files:
   github.com/damir-majer/ABAPKoans/38ec9b76f42e126897dfd6e46c9d118cc1b8a749/zcl_koans_about_abapunit.clas.testclasses.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/damonmiller/esapi4cf/8674e6bd4dfa9dc425bad902c5e47bb349f7f71d/org/owasp/esapi/crypto/KeyDerivationFunction.cfc:
     annotations:
       human-smola: ColdFusion CFC
       linguist: ColdFusion
+      linguist-extension: ColdFusion CFC
       vote: ColdFusion CFC
   github.com/dan-atilio/AdvPL/f96a7fee50841e6d466978ffb846215e61a705fc/Fontes/zCmbDesc.prw:
     annotations:
       human-smola: xBase
       linguist: xBase
+      linguist-extension: xBase
       vote: xBase
   github.com/danielflira/advplayl/0cb048fd72ac0dbb2eab8e981770b87cad7a45be/runtime.prw:
     annotations:
       linguist: xBase
+      linguist-extension: xBase
       vote: xBase
   github.com/danielgindi/Charts/a5fda8febb1aa66769e8029d35eeb6d41af158cf/ChartsDemo-iOS/Swift/Demos/SinusBarChartViewController.swift:
     annotations:
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/danielgtaylor/aglio/0cef09ab83d680689bcadf53aa45fc7bca3b5af3/example.apib:
     annotations:
       linguist: API Blueprint
+      linguist-extension: API Blueprint
       vote: API Blueprint
   github.com/danielmiessler/SecLists/a627b78566970abf1c4fa2c8df6f5168e631cfd2/Web-Shells/FuzzDB/up.php:
     annotations:
       human-smola: PHP
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/danschultzer/pow/56488b6d53e0b75509b19fd51f64d2f2bb6653a5/lib/pow/ecto/schema/password.ex:
     annotations:
       linguist: Elixir
+      linguist-extension: Elixir
       vote: Elixir
   github.com/danslapman/BackedProperties/be871e3470f487a0375b214190d1eea3498257e5/BackedPropertiesMacro/Properties/AssemblyInfo.n:
     annotations:
       linguist: Nemerle
+      linguist-heuristics: Nemerle
       vote: Nemerle
   github.com/danvratil/kde-sdk-images/ae9e971354debf8ddc58496f42ea130b5737e65d/packages/SOURCES/html.dcl:
     annotations:
       human-smola: Unknown
       linguist: Clean
+      linguist-extension: Clean
       vote: Unknown
   github.com/daoo/brainfuck/2eec4e077c240bc7b3dc2f0544c87ac4effe0da3/brainfuck/rot13.bf:
     annotations:
@@ -5984,22 +7374,27 @@ files:
   github.com/dapphub/dappsys/933fb468f72f1a81ee8b6d90b17ffdf25d8e1067/default.nix:
     annotations:
       linguist: Nix
+      linguist-extension: Nix
       vote: Nix
   github.com/darius/awklisp/90e38228b1f98174b62a2f76a6a21520382acdf9/awklisp:
     annotations:
       linguist: Awk
+      linguist-shebang: Awk
       vote: Awk
   github.com/darkhorsesports/getsporty-Old/dc74220ec7f100641c27489d1fff3b739835dadd/Darkhorse/src/main/java/com/darkhorse/getsporty/domain/Job_Roo_JavaBean.aj:
     annotations:
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/darklife/darkriscv/71f132f37c457aff29a0352058164bdd998354f8/rtl/darkriscv.v:
     annotations:
       linguist: Verilog
+      linguist-heuristics: Verilog
       vote: Verilog
   github.com/darold/pgFormatter/9c274906e7f1d696819bc5c5693758e624964c41/pg-test-files/sql/create_procedure.sql:
     annotations:
       linguist: PL/pgSQL
+      linguist-heuristics: PL/pgSQL
       vote: PL/pgSQL
   github.com/darrenjw/smfsb/3bc38adcea5097812322599dd41d1d9511c62270/models/autoreg-3-1.mod:
     annotations:
@@ -6008,39 +7403,49 @@ files:
       vote: Unknown
   github.com/datacharmer/test_db/0b66c2338736779e3b150c7d125b1012d95a961f/sakila/sakila-mv-schema.sql:
     annotations:
+      human-smola: SQL
       linguist: PL/pgSQL
-      vote: PL/pgSQL
+      linguist-heuristics: SQL
+      vote: SQL
   github.com/dataduke/mac-taskpaper/47a3c1362274156596c7cdaf4c65295c3d842660/Scripts/Due in next 3 Days.scpt:
     annotations:
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/datanoise/mongo.cr/5224e653e34e2c13055568741ea054e797ffbf14/src/bson/code.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/dav0/fanbar/bc24de666a0d884e8f76aeb9cfda55b4c7532f0e/src/main/java/org/fanbar/cw/domain/Fan_Roo_ToString.aj:
     annotations:
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/davazp/eulex/347e22cf75f18152b54e84746a568e009a1aa400/structures.fs:
     annotations:
       linguist: Forth
+      linguist-heuristics: Forth
       vote: Forth
   github.com/dave-newson/ninja-ripper-ms/58cfc935a379a9bc5e9096dc8ae19e55a3e4e597/src/ui/main.ms:
     annotations:
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: MAXScript
   github.com/davestewart/maxscript/4d1621346e1d966dd172be080d1b5320b0263577/Animation/After Effects Tracker/worldToVpt 06.ms:
     annotations:
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: MAXScript
   github.com/david-hoffman/Igor-Data-Analysis/e51d73d2b75819eac7f42a93f1bb895046e04ced/FitTimeSeries.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/davidbenja87/Test/af6d11981c1d575771826c3ae7a3fbb328e8d8d3/Tests.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/davidebasile/routingproblem/8599d3a1b1fa0aec1299546f231f8c7f5f366524/routeplanning.mod:
     annotations:
@@ -6049,54 +7454,67 @@ files:
   github.com/davidfestal/Ceylon-Osgi-Examples/9451f319f18f783789697d0645bc2b5ab780f1a3/ceylon_osgi_samples.servlets.httpservice/source/ceylon_osgi_samples/servlets/httpservice/servlet.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/davidfstr/idris-insertion-sort/bf1c39a8eb4cdbd6d6b8d9fda8797703c2082e4c/InsertionSort.idr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/davidgriffo/ClarionScroll/2a8c3ec9162c0108cf223edc79b040a7c09e120c/Mod.app.clw:
     annotations:
       linguist: Clarion
+      linguist-extension: Clarion
       vote: Clarion
   github.com/davidgriffo/SimpleClarionList/969f646ad2d73250245b29fd047b1a1db3ec24a8/scrollTest.clw:
     annotations:
       linguist: Clarion
+      linguist-extension: Clarion
       vote: Clarion
   github.com/davidlpotter59/axis-version7_ars/7b6cd4d3bfce567baceb9fdbac593ff63af2c413/arspr517.eq:
     annotations:
       linguist: EQ
+      linguist-extension: EQ
       vote: EQ
   github.com/davidlpotter59/axis-version7_bop/19aa5dd3ef05d8f87acefd0c4f8cf04d3e525e89/boppr400.eq:
     annotations:
       linguist: EQ
+      linguist-extension: EQ
       vote: EQ
   github.com/davidlpotter59/axis-version7_cpp/f8cbb04d78857664e9b05c71db679e94d55513fa/cpppr400ab.eq:
     annotations:
       linguist: EQ
+      linguist-extension: EQ
       vote: EQ
   github.com/davidlpotter59/axis-version7_lrs/83a4d9cffe1a971d7e2e03e4029631a53eb1b2c4/lrspr703.eq:
     annotations:
       linguist: EQ
+      linguist-extension: EQ
       vote: EQ
   github.com/davidlpotter59/axis-version7_sfp/a4d1f41382ad1081777456e3236389e045144128/sfprenew2000imp.eq:
     annotations:
       linguist: EQ
+      linguist-extension: EQ
       vote: EQ
   github.com/davidlpotter59/gsn-version7_agt/b74e8be2a3b108f72d8865f3f1bcbbef1f2c486b/agqpr700.eq:
     annotations:
       linguist: EQ
+      linguist-extension: EQ
       vote: EQ
   github.com/davidlpotter59/gsn-version7_ars/b948ff2b371eed3fbc23d218fab30520b618d259/arspr01a.eq:
     annotations:
       linguist: EQ
+      linguist-extension: EQ
       vote: EQ
   github.com/davidlpotter59/gsn-version7_other/19773dab402c0dab9e2ecf25ef419e7f5591a217/userreporttranssummary.eq:
     annotations:
       linguist: EQ
+      linguist-extension: EQ
       vote: EQ
   github.com/davidmarble/virtualenvwrapper-win/10a0f0f437dd28f9ca5ef08fafd14a608cbb6bcf/tests/test_mkproject.bat:
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/dawhite/MCTK/f8c11f7aeba42ea42ab73de5c3ca63deaed2f948/mctk_user_guide_api_examples.pro:
     annotations:
@@ -6105,78 +7523,97 @@ files:
   github.com/day8/re-frame/e4a02251b8ba51994b7463a9897340851711e9d5/src/re_frame/events.cljc:
     annotations:
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/dbeecham/argsparser/62ec99247775c663c68af9666bc27f5ec2219446/args_parser.c.rl:
     annotations:
       linguist: Ragel
+      linguist-extension: Ragel
       vote: Ragel
   github.com/dbeecham/d/c8660e85b555590f06d8f81d41d6632865dd1c44/d.c.rl:
     annotations:
       linguist: Ragel
+      linguist-extension: Ragel
       vote: Ragel
   github.com/dbeecham/mini_monit/dc449c2d5deefd71ea235b6e5d36b7b8f344e0e3/dockersub/test.rl:
     annotations:
       linguist: Ragel
+      linguist-extension: Ragel
       vote: Ragel
   github.com/dbgarlisch/glyph-InterpolatedEntity/f1452191b66378b74a27ad6b3a1e8f048ad0a283/InterpolatedEntity.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/dbgarlisch/glyph-pwoo/108ef6d8bde1be394727a00ab023c156c1b10920/pwoo.glf:
     annotations:
       human-smola: Glyph
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/dbgarlisch/glyph-thicken2d/fcbec4b48c1e944097121a4ee824d6b6f2b0283c/Thicken2Dto3D.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/dbohdan/sqawk/67a5507beb491990d9851f231ef0fd606bd3cd23/tests.tcl:
     annotations:
       linguist: Tcl
+      linguist-extension: Tcl
+      linguist-shebang: Tcl
       vote: Tcl
   github.com/dbyler/omnifocus-scripts/f85728cf2644beb9b14170e49f73e42225f6048e/Shift.applescript:
     annotations:
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/dcsil/CSC491/5e3b303c8b75f3e9fad97bed1832429409c42d7a/policies/plagiarism.md:
     annotations:
       linguist: Markdown
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/dda/stegano-fs/cab4d51ac7cc26f17119c8d893da5aa1a12939ac/Window1.rbfrm:
     annotations:
       human-smola: REALbasic
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/dda/tc-rb/b9ca7ec5ac392eabbcc7cbcd8376cf3d5443aa70/Window1.rbfrm:
     annotations:
       human-smola: REALbasic
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/ddoRotolo/antarc.tk/e48e5bab076e8bfc6f9a1207189c241cd19bb008/classes.l:
     annotations:
       human-smola: PicoLisp
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
       vote: PicoLisp
   github.com/debinix/openjensen/481949c46b1c7d75ea75401b06a6757597f63b49/src/test-utf8.cbl:
     annotations:
       linguist: COBOL
+      linguist-extension: COBOL
       vote: COBOL
   github.com/debois/elm-mdl/20020469a6efa964754a79a58e4d585b1639ad90/src/Material/Menu/Geometry.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/deech/ATS-Strange-Loop-Talk/b79d2d72934e04cf35ddc267d163d268e2ecb998/stream.dats:
     annotations:
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/deech/lambdaconf-shen-talk/39978fcd9164662a9352c8ab4b60e4fd78e0e38f/Forall.shen:
     annotations:
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/defunkt/ike/d8f94ee10bfdf5dfff7467a151a36349ab0b4010/ike.io:
     annotations:
       linguist: Io
+      linguist-extension: Io
       vote: Io
   github.com/defuse/crackstation/53c1747c6d3fdf1be8089cd4344559d5b2c6544d/src/pages/legal-privacy.php:
     annotations:
@@ -6186,128 +7623,161 @@ files:
   github.com/dekz/augeas_nginx/93386177e017c9498d352fa28e1ee9b731043b00/tests/test_nginx.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
       vote: Augeas
   github.com/deltaluca/nape/a4d43daa8a8a83ddd0ee05a0bf893625be358575/chxdoc/src/mtwin/templo/Template.hx:
     annotations:
       human-smola: Haxe
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/deltaray/bawk/4458bc3ff3f386fb89bc82c2e350ed430221db4c/lib/address-type.awk:
     annotations:
       human-smola: Awk
       linguist: Awk
+      linguist-extension: Awk
       vote: Awk
   github.com/denandz/lpc_sniffer_tpm/6ad062ff57612e771d3e82bb226f40ccf75db900/uart_tx.v:
     annotations:
       linguist: Verilog
+      linguist-heuristics: Verilog
       vote: Verilog
   github.com/denise-amiga/dns.mod/b1916beeb6da48ba33d0ec120c6a8ac9f89f6291/bigz.mod/examples/ex_01.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/deniseyu/dogebuzz/87b7679b9589e787269a793ceaeec29c0df7c1a2/lib/dogeBuzz.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/denizyuret/Knet.jl/55c01f454d75720363449af9cdb0d5f0adde895c/test/.deprecated/testcolops.jl:
     annotations:
       linguist: Julia
+      linguist-extension: Julia
       vote: Julia
   github.com/denoland/deno/92b8674162aff30a9552b1a07855b685d305830a/std/log/test.ts:
     annotations:
       linguist: TypeScript
+      linguist-heuristics: TypeScript
       vote: TypeScript
   github.com/depify/depify-client/75cb32af94fcc49b6e2381fd37b127bf244679c4/test/xprocspec/xprocspec/src/test/xprocspec/xproc-test-suite/test.xpl:
     annotations:
       linguist: XProc
+      linguist-extension: XProc
+      linguist-xml: XML
       vote: XProc
   github.com/deploymentking/oberon/fc710a6d50f6251fb3c794a200e7f481430b3c6d/SAMPLES/TICTAC/T3.MOD:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/derele/Eimeria_Lab/f98fbfd96a65bfd1c25cca068d36d2452b73c70c/data/3_recordingTables/E7_112018_Eim_RT-qPCRs/E7_112018_Eim_RT-qPCR_template.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/derele/Mouse_Eimeria_Databasing/1ce069d2b596e7ab037d44e07b070948df4fee65/data/Eimeria_detection/raw_qPCR/bavariaqPCR2015/raw/template0509plate2.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/derf/Travel-Routing-DE-VRR/6d7126e170a4295347cf050023c4790455227669/t/in/e_hbf_b_hbf.ice:
     annotations:
       linguist: Slice
+      linguist-heuristics: Slice
       vote: Slice
   github.com/descala/haltr/f1112554c6f2300df127f9c57c4d39297662e685/lib/haltr/xml_validation/EUGEN-UBL-T14.xsl:
     annotations:
       linguist: XSLT
+      linguist-extension: XSLT
+      linguist-xml: XML
       vote: XSLT
   github.com/deseven/icanhazshortcut/8eed8b47b9d3b17139cc279e07b72fd5be1cd5bf/proc.pb:
     annotations:
       linguist: PureBasic
+      linguist-extension: PureBasic
       vote: PureBasic
   github.com/destroytoday/destroytwitter/853f42e40d89cf981f90156e674aecc9b941a9b2/src/com/destroytoday/destroytwitter/view/drawer/Compose.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/devkitPro/installer/1982d1a7825edf251c041dc51eced7c503d8d5f9/nsis/devkitPro.nsi:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/devolonter/flixel-monkey/442c661dbde0e36ab03d7c31cb8f67ccc4c8df61/system/tweens/motion/quadmotion.monkey:
     annotations:
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/devtimi/TPSF/0edab3ebba85a0becc66db42f8d29bc2e77b2aed/TPSF.xojo_code:
     annotations:
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/dfdragon/kcptun_gclient/b862f31dc7cd6bfa7c7dad600135931644fce918/JSONFormatter.pas:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/dfkt/win10-unfuck/58cc546c14fad948889b8d318c05fa762fd5062d/4chan-g-scripts-UNTESTED/Debloat-Windows10.ps1:
     annotations:
       linguist: PowerShell
+      linguist-extension: PowerShell
       vote: PowerShell
   github.com/dgageot/Kata-Lags-ioke/f1b24f750b587507812000f50222fdb6916cc150/lags_spec.ik:
     annotations:
       linguist: Ioke
+      linguist-extension: Ioke
       vote: Ioke
   github.com/dgageot/Kata-Misc-ioke/42ffa41c000aad73ee8e122e18f09e629d2cebd5/rpn/rpn.ik:
     annotations:
       linguist: Ioke
+      linguist-extension: Ioke
       vote: Ioke
   github.com/dgageot/Kata-Sierpinski-ioke-/d788d1c0ed8bddb69d3c1fbccc8c9ac82fe30f67/kata_spec.ik:
     annotations:
       linguist: Ioke
+      linguist-extension: Ioke
       vote: Ioke
   github.com/dgageot/Kata-Weights-ioke/772fd1e8b25c5deba5ed621978527cb977178888/mastermind_spec.ik:
     annotations:
       linguist: Ioke
+      linguist-extension: Ioke
       vote: Ioke
   github.com/dgl/protocol-redis-xs/ea7cc21202eb6095472627e5a6966a4828d18642/XS.xs:
     annotations:
       linguist: XS
+      linguist-extension: XS
       vote: XS
   github.com/dhis2/dhis2-identity/e190b73105d5c3f01883f299ec64e436ef6e523e/fonts/METADATA.pb:
     annotations:
       linguist: PureBasic
+      linguist-extension: PureBasic
       vote: PureBasic
   github.com/dhumphreys/cfwheels-coldroute/e85d3a9e64199a09be90cede3ef156f65d44955e/src/index.cfm:
     annotations:
       linguist: ColdFusion
+      linguist-extension: ColdFusion
       vote: ColdFusion
   github.com/diaspora/diaspora/1cbb3f9a7c1696b6088373cbf9e48f40390a5f4e/spec/models/profile_spec.rb:
     annotations:
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/diazmaria/HotelOasis/0999ba849dd1574cccfa56afdedfa2c6ba516a4e/src/main/java/es/uca/iw/hoteloasis/domain/Rol_Roo_Finder.aj:
     annotations:
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/diegodorado/3d-audio-rotator/8962d413486e110cbbd8ec967e62b073c35e01af/process_bulk.ck:
     annotations:
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/diegomb86/OpenEdgeABL-util/e958c878543f3af79d1be93974162499256c522f/Csv.cls:
     annotations:
@@ -6316,116 +7786,144 @@ files:
   github.com/diesel-rs/diesel/a8b52bd05be202807e71579acf841735b6f1765e/diesel_migrations/migrations_macros/src/util.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/digiajay/LogAnyLabVIEWdata/86e25f0ff5614e9b05e3a8b20532b3eb19ea5d8a/TableLogger.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/digoal/blog/338a9027ea3bd0058c1977974d1705c3c3411417/201611/20161123_01_sql_001.sql:
     annotations:
       human-smola: PL/pgSQL
       linguist: PL/pgSQL
+      linguist-heuristics: PL/pgSQL
       vote: PL/pgSQL
   github.com/dillonkearns/mobster/2ad66f514579a09a9679b75b6c1b2956e7879b46/src/View/Roster/Chip.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/dino/dino/0acbe4855d1cfb42832aae1d18b668e2ceb18d2c/plugins/signal-protocol/tests/common.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/dirixmjm/pikeathome/ef208fc1d3a8405e0d09b50e63179a4614d8a259/server/Domotica.pike:
     annotations:
       linguist: Pike
+      linguist-extension: Pike
       vote: Pike
   github.com/disconcision/fructure/515b3673834612f03a14d569729f243e8c49697b/src/fructure.rkt:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/discordia-space/CEV-Eris/763844e7018aec66e2866d10b7060cdb190fd960/code/modules/mob/new_player/login.dm:
     annotations:
       linguist: DM
+      linguist-extension: DM
       vote: DM
   github.com/discourse/discourse/b869ef8a7648a677adc19ecb720869ce0fafa041/spec/models/directory_item_spec.rb:
     annotations:
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/distributedio/titan/ac9e9df9fde88415f9e4fca68e3b7259edb8e3e9/tests/redis/cluster/tests/00-base.tcl:
     annotations:
       linguist: Tcl
+      linguist-extension: Tcl
       vote: Tcl
   github.com/divipp/frp_agda/a90b3bb12609f9db2c3e7bbbcbab28c63adfe2d0/Reactive.agda:
     annotations:
       linguist: Agda
+      linguist-extension: Agda
       vote: Agda
   github.com/dkandalov/live-plugin/690675fb29d814967ebbad24a1e9b2f8269263f4/plugin-examples/groovy/project-files-stats/plugin.groovy:
     annotations:
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/dkarv/goblint-web/eb85f9907445af5473a212afd3dcacdecfa9f088/src/controller/controller.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/dkhamsing/open-source-ios-apps/907f2ffaa3450d8bad39913f057243d615007048/.github/Hi.swift:
     annotations:
       human-smola: Swift
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/dlang/dmd/1ca6a1cc0e4c0f2dff3969894b152e4e8a146fff/test/runnable/sctor.d:
     annotations:
       human-smola: D
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/dlang/dub/1bb989e978e183c3fa302ab2db460a1d3deb288b/source/dub/internal/vibecompat/inet/url.d:
     annotations:
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/dlang/phobos/e70d86b75d82f756ceec3b1398b77d1c1e9248bd/std/typetuple.d:
     annotations:
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/dlang/tools/2e3b6866015a009274c08a84fdcfc4deee86e8be/dman.d:
     annotations:
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/dluksza/FanLink/654fd7b0d0769b9d0ca06779fc6d8b7fcc3d325d/fanlink/test/objects/TestObj.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/dmccuskey/shopify-modern/c2376887e2ccbcd9c3abe4253dfb186d549c82a9/src/core/shopify/snippets/icon-pinterest.liquid:
     annotations:
       human-smola: Liquid
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/dmoonfire/kolmafia/4af2d95c3ea1a58f9839a7143caba5425caf7928/cake/CakeLevel.ash:
     annotations:
       linguist: AGS Script
+      linguist-extension: AGS Script
       vote: AGS Script
   github.com/docker/dockercraft/4be6b595d2b965da8e6af10f83f1a53b0c2a0dee/Docker/log.lua:
     annotations:
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/dockimbel/cheyenne/3069722b0e66a46a3f4aa01127ac5047546ced84/UniServe/services/logger.r:
     annotations:
       human-smola: Rebol
       linguist: Rebol
+      linguist-heuristics: Rebol
       vote: Rebol
   github.com/dodo/node-slug/85ded30a95760b19cd223abe668eade0279a21f2/test/slug.test.coffee:
     annotations:
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/dogescript/dogescript-loader/b6217b89b1dfc517e29ca686372496c4824a4620/test/run.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/dogescript/grunt-dogescript/82813059cadf304bf4174b3d3bfc384ab8ecb75c/test/cases/basic/doge.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/dokku/dokku/3d1ab2677785436cfdeeb0ac3cca199668621581/plugins/storage/subcommands/mount:
     annotations:
       human-smola: Shell
       linguist: Shell
+      linguist-shebang: Shell
       vote: Shell
   github.com/dolphinsmalltalk/Dolphin/1444c854e9fa57527ec69c27b8b7a49f17d36749/Core/Object Arts/Dolphin/MVP/Presenters/Collection/SequenceableCollectionPresenter.cls:
     annotations:
@@ -6434,47 +7932,59 @@ files:
   github.com/dom96/jester/90add2db1f18f193b0ec3514da3df5f1c6e4db4f/jester/private/utils.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/dom96/nimkernel/23da4fd370fb53a69ff0b6aa59ac58ab5fbfd30c/nakefile.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/domangep/pbtoolsnutilities/939d477e109df16faeff604df1a1740487b85ec0/Wizard/w_wizard_test.srw:
     annotations:
       linguist: PowerBuilder
+      linguist-extension: PowerBuilder
       vote: PowerBuilder
   github.com/domdere/fp-in-idris/3ce58d2a8a6c9788b1bb71328f1fcef9c8f4d192/src/PurelyFunctionalState.idr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/domenkozar/augeas_bacula/3eabf328ad732aaec601a04d8a23654fa1995e78/bacula.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
       vote: Augeas
   github.com/domnikl/DesignPatternsPHP/04acce6759580e6744c2ee619adf795c6a101663/Behavioral/Mediator/Tests/MediatorTest.php:
     annotations:
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/donBitscopic/mumps-utils/c8ccf425cc192f8c19892b3a0eec2c03e4ef332c/KIDS/BTP_0.1.KID:
     annotations:
       linguist: Genshi
+      linguist-extension: Genshi
       vote: Genshi
   github.com/donadigo/eddy/0e24b5db5260556418c4cc01139c6984e2ea4105/src/PackageRow.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/donahue2/CS420Assignment2/8c03dc6ae37d2b0905704cb31638b83b6e538314/dictionary.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/donnemartin/system-design-primer/fdba2a2586a30b78249e5daba8a807ee532b0af9/solutions/object_oriented_design/deck_of_cards/deck_of_cards.ipynb:
     annotations:
+      human-smola: Jupyter Notebook
       linguist: Python
-      vote: Python
+      linguist-extension: Jupyter Notebook
+      vote: Jupyter Notebook
   github.com/dopefishh/cleanpeg/5d548d628cace01760cbd6ca2aacb1f6d65afdde/peg.icl:
     annotations:
       human-smola: Clean
       linguist: Clean
+      linguist-extension: Clean
       vote: Clean
   github.com/dorellang/hunter/57ae7bdc60c59ffb83202f5b347c3e0310d08221/src/Hunter.package/HNMetaModelBuilderTests.class/instance/testTryStatement.st:
     annotations:
@@ -6483,64 +7993,79 @@ files:
   github.com/dotnet-architecture/eShopOnContainers/f8084f5953ce87751b4b1dcbd57c8f5989294192/src/Services/Ordering/Ordering.UnitTests/Builders.cs:
     annotations:
       linguist: C#
+      linguist-heuristics: C#
       vote: C#
   github.com/dotnet/core/f2623c96838efdf861b0ab2e570abbdfb4c5bb4e/release-notes/1.0/install-1.0.1.sh:
     annotations:
       linguist: Shell
+      linguist-extension: Shell
       vote: Shell
   github.com/dotnet/corefx/87cf12d7aa74843b7d0a7e710c5dc4845517b758/src/System.Linq/src/System/Linq/Utilities.cs:
     annotations:
       linguist: C#
+      linguist-heuristics: C#
       vote: C#
   github.com/dotnet/fsharp/e0209fec77cf93b6b5f8fc8d1904c41d19c8b40c/tests/fsharpqa/Source/Conformance/InferenceProcedures/ByrefSafetyAnalysis/ByrefInFSI1.fsx:
     annotations:
       human-smola: F#
       linguist: F#
+      linguist-extension: F#
       vote: F#
   github.com/dotnet/roslyn/66dcd8ac86cf0751583e2ec2f1a7377257607c62/src/Compilers/VisualBasic/Test/Syntax/QuickTokenTableTests.vb:
     annotations:
       linguist: Visual Basic .NET
+      linguist-extension: Visual Basic .NET
       vote: Visual Basic .NET
   github.com/dotnet/wpf/df349272c0f461760303a16432cf38626cc8c2f8/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathFigureCollectionConverter.cs:
     annotations:
       linguist: C#
+      linguist-heuristics: C#
       vote: C#
   github.com/doublec/self-vncviewer/358ba1134a1ee0246d251649d940ceaa91f88028/applications/vncViewer.self:
     annotations:
       linguist: Self
+      linguist-extension: Self
       vote: Self
   github.com/doublec/shen-wasp/0792d0e019554b2788f883ac667454ff5ab83088/compiled/toplevel.kl.ms:
     annotations:
       human-smola: Unknown
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: Unknown
   github.com/dougmacdoug/ponylang-2048/2dfee83076eb688c1b612df455361d1d57db92a9/main.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/dovstamler/uvm_agents/5c2852d2553c54a0581bf5fb2b89fb4307201cf5/src/wishbone_b3/wishbone_b3_if.sv:
     annotations:
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/dpavlin/perl-fuse/6becd92d7fce3fc411d7c71bcfd7935bd9dc66dc/Fuse.xs:
     annotations:
       linguist: XS
+      linguist-extension: XS
       vote: XS
   github.com/dphang/roku-lib/e3c5a71d2466b6dce08f1b7d25fcd1ae0de5dbd4/RokuLib/ui/RlBorder.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/dpk/textile/9a8ca40ddb3871c0ea71ee364c31580f02d21b85/textile.arc:
     annotations:
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/dragonwasrobot/learn-prolog-now-exercises/2d09a035f094a8d635c51e51c656733b4883e19f/chapter-05/practical-session.pl:
     annotations:
       linguist: Prolog
+      linguist-heuristics: Prolog
       vote: Prolog
   github.com/drb1972/Number1_Share/792548e18317051c7259db38d2bc84999fd232a9/cntl/rexxn1.rex:
     annotations:
       linguist: REXX
+      linguist-extension: REXX
       vote: REXX
   github.com/dreamhouseapp/dreamhouse-sfdx/29b464cca01e3eec929868af27849139aa5ad951/force-app/main/default/classes/SampleDataController.cls:
     annotations:
@@ -6549,10 +8074,12 @@ files:
   github.com/dressupgeekout/pike_redis_client/6e166477b63b60cb1cdee8435fb3a54e751a982c/redis_client.pmod:
     annotations:
       linguist: Pike
+      linguist-extension: Pike
       vote: Pike
   github.com/drforr/perl6-ANTLR4/ffa588bd94ccf02660a5b05c16b2199f9d58cf89/corpus/redcode.g4:
     annotations:
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: ANTLR
   github.com/dritchie/quicksand/94310db9447642f33776027914f29adfdc264b30/qs/lib/hashmap.t:
     annotations:
@@ -6561,18 +8088,22 @@ files:
   github.com/dropbox/zxcvbn/67c4ece9efc40c9d0a1d7d995b2b22a91be500c2/src/main.coffee:
     annotations:
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/drsimonmiles/sourcesource/8421dffc817675511e79383cce4659b3530dd01d/src/main/txl/3-1-declaration.txl:
     annotations:
       linguist: TXL
+      linguist-extension: TXL
       vote: TXL
   github.com/drslump/Boo.Hints/a65ce29d25b9c167395bda0a0d3a829ee1a11e3c/src/Boo.Hints/Commands.boo:
     annotations:
       linguist: Boo
+      linguist-extension: Boo
       vote: Boo
   github.com/drslump/BooBinding/889e712fbf87c3ec8cab2d01873ad6957ec2aa56/Editor/BooTextEditorExtension.boo:
     annotations:
       linguist: Boo
+      linguist-extension: Boo
       vote: Boo
   github.com/drupke/ifsred/31e43dda335180d9d81c526b8b42e60b4cd9f350/osiris/osiris_mosshift.pro:
     annotations:
@@ -6581,10 +8112,13 @@ files:
   github.com/drzwz/qbitmex/9d0d362bba1ce246dc4a1bd0f7166622254cecdf/q/qbitmex.q:
     annotations:
       linguist: q
+      linguist-heuristics: q
       vote: q
   github.com/dsanson/Pandoc.tmbundle/d397a5fb5203b8ab21d3264ac3a1a929cc9de8f4/Support/mellel2mmd.xsl:
     annotations:
       linguist: XSLT
+      linguist-extension: XSLT
+      linguist-xml: XML
       vote: XSLT
   github.com/dsidavis/RCInterface/f62515e35180ab0c2bf852cceb3f2990e3a02e2a/CompileSteps/simpleMath.E:
     annotations:
@@ -6598,182 +8132,229 @@ files:
   github.com/dsully/perl-crypt-openssl-pkcs12/7eed293cced197e7b1397a91f457e608999d902c/PKCS12.xs:
     annotations:
       linguist: XS
+      linguist-extension: XS
       vote: XS
   github.com/dsully/perl-crypt-openssl-x509/c59560e73a431f65ab8a84ff2f0c8ebff2c35933/X509.xs:
     annotations:
       linguist: XS
+      linguist-extension: XS
       vote: XS
   github.com/dt2/werebol-scratch/480bf52b5d078e7fd30e12c659c4982382e6f8b8/partner.r3:
     annotations:
       linguist: Rebol
+      linguist-extension: Rebol
       vote: Rebol
   github.com/dumblob/mysql2sqlite/3cedfa614f44c6132de66108fa6b18c9a0998f0c/mysql2sqlite:
     annotations:
       linguist: Awk
+      linguist-shebang: Awk
       vote: Awk
   github.com/duncansmart/less.js-windows/fab2060cbd54a9126e88a92f4c25b493a92cf9bf/lessc-watch.cmd:
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   "github.com/dunitian/LoTDotNet/ef2164ab4f5dfbc83c20560b5af9c120edb43a0c/\u9006\u5929\u7ECF\u9A8C\u88E4\u5B50/05.\u6570\u636E\u5E93\u7B49/SQLServer/\u57FA\u7840/1.\u9006\u5929\u5E38\u7528SQL/08.\u5B58\u50A8\u8FC7\u7A0B\u7684\u7EFC\u5408-\u5E94\u7528.sql":
     annotations:
       linguist: SQLPL
-      vote: SQLPL
+      linguist-heuristics: TSQL
+      vote: Unknown
   github.com/dutc/code-or-die/446559bf598fbc1e5a9392987d2325498115863c/dummy.sql:
     annotations:
       human-smola: PL/pgSQL
       linguist: PL/pgSQL
+      linguist-heuristics: PL/pgSQL
       vote: PL/pgSQL
   github.com/dvanarkel/Clyde/8fec41dd6ee03f863643aa958425c8bb4a6673ae/Cocoa/tabview.dcl:
     annotations:
       human-smola: Clean
       linguist: Clean
+      linguist-extension: Clean
       vote: Clean
   github.com/dwichan0905/telegram_bot/20fdf19e8ec0b678aa0370d3a509d6a2aaa56ec6/telegram_bot.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/dwyl/hapi-socketio-redis-chat-example/7a0f82b8dba4bb2dbf4d617e4c416b149bcaf74d/tests/TestSpec.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/dwyl/learn-elixir/60c0f3a372332734e1423dcde7a546273e273102/codecov_example/mix.lock:
     annotations:
       linguist: Elixir
+      linguist-filename: Elixir
       vote: Elixir
   github.com/dylan-foundry/csv/c6cbb98991e96dd10bc083c984a0e51baff8286e/reader.dylan:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylan-foundry/deft/f725bf1f2f7e62ce5430f2fcc0dc0b231b5d5165/deft-test/deft-test.dylan:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylan-foundry/gir-dylan/efb4c8eb264e826a00d7ed86ede5d01f5d6eacf7/gir-generate-c-ffi/library.dylan:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylan-foundry/nanomsg-dylan/657d9e04cbed63e93da67e897fc6e8a6c75889b0/library.dylan:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylan-foundry/posix-sockets/78548c6a2688350f20f5d1d0efd26942e6b74ec6/posix-sockets/raw-posix-sockets.intr:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylan-foundry/postgresql-dylan/403781d40827b43d8c45bc835e2eb14c596cce57/tests/postgresql/connection-test-suite.dylan:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylan-foundry/python-dylan/7407f4ef3b6339dc6e8cc9c87cc146e5a1af05ec/dict.dylan:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylan-foundry/tracing/452944da837c587b123dc0989a8544099d4f6f45/tracing-core/time.dylan:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylan-foundry/z3-dylan/332d2d05c955828b93eb9ad3c4ed4b90a2b6e193/z3/raw-z3-api.intr:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylan-hackers/mindy/d4a5820bb0b2924476fc8a6eec0d91fb19b04d11/tests/stream/stream-test.dylan:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylan-hackers/network-night-vision/a4c2ec13c9a2414b7c9258615fd764522062b82f/network/ip-stack/layers/media-access/802-1q/802-1q.dylan:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylan-lang/binary-data/967f7484eeba5da442efc07409aa8bd8668b56e6/binary-data.dylan:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylan-lang/collection-extensions/c2b9472618f364721b4c3dce40153540bcfbd86c/strsearch.dylan:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylan-lang/command-interface/3702932b2cfe6b2688e90ca0bfa20a51e30665e1/command-interface/completion.dylan:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylan-lang/http/2ceb0463d5bb93e81ea409dd3a712270467e86ca/server/core/static-files.dylan:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylan-lang/melange/5dad03819333135e5109477f1f90e5f74cd50d7c/melange-core/c-decl.dylan:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylan-lang/mime/581e83f7806f0341a2aa5c707ac8d036c07281f9/library.dylan:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylan-lang/opendylan/291379597028230287bc4279a542238d899bf9ea/sources/system/operating-system.dylan:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylan-lang/wiki/41f158e078d23d3649befedb7ef58cd5f615b911/dylan/tag.dylan:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/dylanaraps/pure-bash-bible/f0788ed4b0a591d59a468090fc24e7657120dedc/build.sh:
     annotations:
       linguist: Shell
+      linguist-extension: Shell
+      linguist-shebang: Shell
       vote: Shell
   github.com/e36freak/awk-libs/1cafe643cbee33a4f7881323aba2966ed50633e5/psort.awk:
     annotations:
       linguist: Awk
+      linguist-extension: Awk
+      linguist-shebang: Awk
       vote: Awk
   github.com/eBay/tsv-utils/98d6dfca45a21305a5d4b34d6cabf8d61761fa0b/tsv-uniq/src/tsv_utils/tsv-uniq.d:
     annotations:
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/eagle2com/matrix/db41f4aef0889d232ea504fa8dbb96db36bf265c/FNumber.ooc:
     annotations:
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/ebladrocher/scriptinstall/c11dce8abf84246ad9c12975bd65f654ad392948/i3/ihotkeys.i3:
     annotations:
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Modula-3
   github.com/ecere/chess/08db7b73bc05007bad593d42ce97c25c58edbd03/src/promotion.ec:
     annotations:
       linguist: eC
+      linguist-extension: eC
       vote: eC
   github.com/ecere/ecere-sdk/a63b166fd5eb476104f489e4fe1d0afd1f37973a/ecere/src/gfx/bitmaps/RGBFormat.ec:
     annotations:
       human-smola: eC
       linguist: eC
+      linguist-extension: eC
       vote: eC
   github.com/ecere/fractals/57a06513c8148a069c0de69e556819e75eb0834e/GradientDesigner.ec:
     annotations:
       linguist: eC
+      linguist-extension: eC
       vote: eC
   github.com/eclipse-theia/theia/0e16fe033a0e59e294891db8997175b31575b56f/packages/java/src/browser/java-client-contribution.ts:
     annotations:
       linguist: TypeScript
+      linguist-heuristics: TypeScript
       vote: TypeScript
   github.com/eclipse/ceylon-ide-intellij/1f228e03a3eac5643c0928c90613c9203cd28c00/source/org/eclipse/ceylon/ide/intellij/integrations/maven/package.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/eclipse/ceylon-sdk/e19b70e4d747426d7c657440f657937fc362dc73/source/ceylon/interop/java/JavaSet.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/eclipse/ceylon.formatter/45574a6aae55e7ddc55d9d568385a712df676017/test-samples/if.ceylon:
     annotations:
       human-smola: Ceylon
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/ecmendenhall/fmj/e2a91619890e4a0225b5063719f601958e9a0858/fmj:
     annotations:
       linguist: Awk
+      linguist-shebang: Awk
       vote: Awk
   github.com/edicl/hunchentoot/f18c0aa0cecf57ea6a0f4a14ae35ad161e91554b/acceptor.lisp:
     annotations:
       linguist: Common Lisp
+      linguist-heuristics: Common Lisp
+      linguist-modeline: Common Lisp
       vote: Common Lisp
   github.com/edips/Minimal_QML_Android/3a73db2c446c973db6d7f07abe19f26af2842147/untitled3.pro:
     annotations:
@@ -6782,22 +8363,27 @@ files:
   github.com/edwinb/Blodwen/9f632be50e2bbabd2d34352bcb9e8c0b33dcc153/src/TTImp/Reflect.idr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/edwinb/Eff-new/e906e2d22a1606de015086bd92acc6f4e0e40ec1/Effect/File.idr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/edwinb/Idris2/ab98b4d3c93a6c1da0a1592ed242a3fc5d700635/src/Core/Env.idr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/effectfully/OTT/3da2a48114dc7d02854049800cdf0f279ff3dd43/Prelude.agda:
     annotations:
       linguist: Agda
+      linguist-extension: Agda
       vote: Agda
   github.com/effectfully/STLC/3826d7555f37d032d07cf414c7f6770fc32918f1/src/STLC/Lib/MaybeElim.agda:
     annotations:
       linguist: Agda
+      linguist-extension: Agda
       vote: Agda
   github.com/efratcdn/e_type_min_max/f1c17e02e980753b2f29ea7618635f1b9a81409b/type_min_max_usage_ex.e:
     annotations:
@@ -6810,15 +8396,18 @@ files:
   github.com/egeOzpinar/csm/aab3d8ddc4accad9d8c294b7819186544bd7f592/src/csm.chpl:
     annotations:
       linguist: Chapel
+      linguist-extension: Chapel
       vote: Chapel
   github.com/ehmicky/Notes/87f31d2174d51f765a659b515449a741a1ceae42/Repository_helpers/Index/create_index.sed:
     annotations:
       linguist: sed
+      linguist-extension: sed
       vote: sed
   github.com/eholk/harlan/3afd95b1c3ad02a354481774585e866857a687b8/build-benchmarks.scm:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
       vote: Scheme
   github.com/eiffelhub/json/9c1c66ee3da0c69c7e5c8731274cc2f17f79141a/library/serialization/deserializer/basic/json_basic_serialization.e:
     annotations:
@@ -6827,84 +8416,105 @@ files:
   github.com/ejrh/cpu/e53a2b9c23831921494a8ae9e80d3f21036ec309/testbench/instr_fetch_tb.v:
     annotations:
       linguist: Verilog
+      linguist-heuristics: Verilog
       vote: Verilog
   github.com/elastic/elasticsearch/3ce7a37f1ff2ff4c24c97c60ce619f840ed1b7fb/x-pack/plugin/security/src/test/java/org/elasticsearch/integration/SecurityClearScrollTests.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/eleanormurray/CausalSurvivalAnalysis/d752c332cb0840d667d73b562bc9dc077c548438/workshop_v4.sas:
     annotations:
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/electricimp/reference/4e1ba8789f02477fd66507c4ee56258816279e66/hardware/stm32/UART/examples/stm32uart-nor.agent.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/electron/electron/d91cc257f9f309ac974a766b41d2af231b58dc0b/shell/common/node_bindings.cc:
     annotations:
       linguist: C++
+      linguist-extension: C++
       vote: C++
   github.com/elefevre/BattleLanguageIoke/811a77189b58c9aa7d4b5fdb0255a67afc2c006b/basic.ik:
     annotations:
       linguist: Ioke
+      linguist-extension: Ioke
       vote: Ioke
   github.com/elementary/music/7e62dae2127d358b61412e88a338aca2ecf63f3d/core/GStreamer/Equalizer.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/eliranwong/OpenGNT/2b09bb954185d4bb838a43d895bbe9bc2ea545b2/Script/OTLA_abb2bkNo.sh:
     annotations:
       human-smola: sed
       linguist: sed
+      linguist-extension: Shell
+      linguist-shebang: sed
       vote: sed
   github.com/elixir-ecto/ecto/28e7d36d5d495cff2fea3f27f1a5ae457c960091/lib/ecto/adapter/transaction.ex:
     annotations:
       linguist: Elixir
+      linguist-extension: Elixir
       vote: Elixir
   github.com/elixir-lang/elixir/9a145026ebb2a08a60133ad259f3db083721b465/lib/mix/lib/mix/tasks/app.start.ex:
     annotations:
       linguist: Elixir
+      linguist-extension: Elixir
       vote: Elixir
   github.com/elliott1796/lolcode/cd40ddfaaf4d067935cef645d06aaa0f27f5f918/calculator.lol:
     annotations:
       linguist: LOLCODE
+      linguist-extension: LOLCODE
       vote: LOLCODE
   github.com/elm-community/builtwithelm/5e063fe4d0a6f574c4cacb424873bc5fba2a4eb4/src/Stylesheets.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/elm/compiler/9fc8f7bd61d2ba84498f4553fd02aa3921fb6eb6/compiler/src/Canonicalize/Environment/Dups.hs:
     annotations:
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/elm/core/9df0dda8b5169fb193c1dfafe53e138476f75059/tests/tests/Test/Bitwise.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/elm/elm-lang.org/0632a75356c86c73c1af940f4f061dc3409705c9/pages/news/elm-and-bekk.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/elmish/elmish/12648f57092ac6c3dca383e1c25995882a646447/src/cmd.fs:
     annotations:
       linguist: F#
+      linguist-heuristics: F#
       vote: F#
   github.com/elpopisencio/.dotfiles/bdc87cc9b769e877b33712d3cdf1df642aced340/.i3:
     annotations:
       human-smola: Unknown
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Unknown
   github.com/elsassph/haxe-modular/7548e5faf39aefcc07dba470a24382748343cb77/src/Require.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/emacs-elsa/Elsa/b43236e5e183249726b93f13e09c56a081817804/elsa-reader.el:
     annotations:
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/emanueljoivo/using-alloy/373a7dd5f223b7c6a213f2ff8051b340a6dc7cd6/EmpresaTelecomunicacoes.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/emcrisostomo/semver-utils/4f635f950ea2f6926f9640a91829a757bf36804c/m4/ax_cxx_have_thread_local.m4:
     annotations:
@@ -6913,56 +8523,70 @@ files:
   github.com/eme64/Hobby-Projects-Archive/91b6ca78a6e710955c6266fba16d79cedf01e22b/BlitzMax Projects/Simulations/cellular automaton - water and life/simulation/water_1.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/emeryjdk/TeachX-2019/0d09ca6d8941f30ee41cf3e2334644104c2260d5/RandomWalkCarbonChain.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/emilybache/GildedRose-Refactoring-Kata/f322e6eb1b27fdf8e92cd553c23dab21d4088ddd/xslt/xsltunit-0.2/xsltunit.xsl:
     annotations:
       linguist: XSLT
+      linguist-extension: XSLT
+      linguist-xml: XML
       vote: XSLT
   github.com/emina/rosette/efe22c924b93e11ff607428b148901be9a739e57/sdsl/bv/examples/reference.rkt:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/emmawinston/learningchuck/6c6dee428cd83c5f6a511ffff20dc2ad3decf2ce/chapter5/ascendingfrequencysweep.ck:
     annotations:
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/emqx/emqx/a186ee71df2b404d0718a2613303395a7d026a4f/test/emqx_frame_SUITE.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
       vote: Erlang
   github.com/emscripten-core/emscripten-fastcomp/8b09281ba5e9e309fe8e5dbb4d87329e93f7d056/test/Transforms/LoopStrengthReduce/AArch64/lsr-memcpy.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/endo64/mockup/40018ff768093095beb362aa33fa269fa2215a22/MockupDesigner.red:
     annotations:
       linguist: Red
+      linguist-extension: Red
       vote: Red
   github.com/endobson/racket-llvm/3eb557b0fe4bddfdfce8e8f4659d218535daa061/private/simple/predicates.rkt:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/endstation/EasyGL/7f7296c3dc13cb9008ad8be5ff8cc9763b2fe172/src/Sprite_sheet.pmod:
     annotations:
       human-ajnavarro: Pike
       linguist: Pike
+      linguist-extension: Pike
       vote: Pike
   github.com/engor/Ted2Go/e1f6d469335575a17bc45d71333f989968a0629e/document/PlainTextDocument.monkey2:
     annotations:
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   "github.com/eni-causer-a/m.m2l/f91ef418c1fc379f57d9c84cb5f7ecdd74fcdcf1/analyse-projet/diagrammes et modeles/D\xE9finition de cas d'utilisation RESERVATIONS.moo":
     annotations:
       human-smola: XML
       linguist: Mercury
+      linguist-xml: XML
       vote: XML
   github.com/enigma0x3/Generate-Macro/a8e2004ba9eabebb46bec839e8ffe2d85dd364ed/Generate-Macro.ps1:
     annotations:
       linguist: PowerShell
+      linguist-extension: PowerShell
       vote: PowerShell
   github.com/eodg-code/mie/67856daf66fa58a2aa95d391dfc9a6aca13d1ca9/mie_single.pro:
     annotations:
@@ -6971,22 +8595,27 @@ files:
   github.com/eoshackathon/eos_dapp_development_cn/0c5652b2ce13f5c438b7648466ee2f91b4e4c7cc/contract/hello.wast:
     annotations:
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/epeterson320/ABAP-Logger/dd89f85ab6739774548ea1ae576a5904016dd598/zcl_logger.clas.locals_imp.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/ephsec/llvm-forth/1ade0853f8f26bf70ef2121bf148803a894ea360/experiments/forth.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/eproxus/meck/9753464ac1ebc0fc1a6777322bc871eaed82be35/src/meck.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
       vote: Erlang
   github.com/eqela/jkop-eq/edfae7801e0c113c3d2758c661383a0fbdf50019/src/sympathy.httpserver/HTTPRequestHandlerContainer.eq:
     annotations:
       linguist: EQ
+      linguist-extension: EQ
       vote: EQ
   github.com/eratosthenesia/lispc/a88bb2544652b6a3b287f239cc591dfe84a3f2c5/myls.cl:
     annotations:
@@ -7001,31 +8630,39 @@ files:
   github.com/erdg/preact-pil-image/e95ee07310665e0601014b48944494ccee2c343c/http.l:
     annotations:
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
       vote: PicoLisp
   github.com/eregon/mozart-graal/ca762ad12d505647a8a872b4993ff76b92ea643a/lib/main/base/Port.oz:
     annotations:
       human-smola: Oz
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/ericscharff/ProjectOberon/383ab65985d992d3f5a8825c924af48abf0569d1/Oberon.Mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/erkal/kite/15785e7382fa33eb308f5f10d99d887bfda77459/src/Algorithms/Dijkstra.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/erkin/ponysay/67d18d957d8c66185418679e238c5c15cfb1fa26/ponies/strawberrycream.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/erlang/otp/a3f605f99b352dacdd34aa7f942f7fbf38651c18/lib/common_test/test/telnet_server.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
       vote: Erlang
   github.com/erlcloud/erlcloud/5e0831f9f33c2396193e2dcda1d2d3ddfdeddb6d/src/erlcloud_ddb_streams.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
+      linguist-modeline: Erlang
       vote: Erlang
   github.com/ernell/ABB-RAPID-UTILITY-LIBRARY/8577ae71073b8547c7fc0cec620c92a1e5e37621/Contributions/LeeJustice/LEERULZ.mod:
     annotations:
@@ -7035,15 +8672,18 @@ files:
   github.com/ernw/ss7MAPer/5f9e784380b0fcb4fc85c96aab3161890388b443/src/tcap.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
       vote: Erlang
   github.com/ersatzavian/ei-fw-tom/0dc33eb88980fe082c5dff48298ce5d1178b567e/dev/chimpee/chimpee.agent.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/ertdfgcvb/CMYK/a8100c0678f09c78624ac151e1395b898a615c82/cmyk/PDF.pde:
     annotations:
       human-smola: Processing
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/erwijet/BrainF.Net/20bbce54e838640427861792d95a4656fecd8b0f/BrainF_Test/bin/Debug/script.bf:
     annotations:
@@ -7053,6 +8693,7 @@ files:
     annotations:
       human-smola: Handlebars
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Handlebars
   github.com/esa/SpaceAMPL/3d1ed5fb2a6fb7e08bdf94712e67dc26d855a458/lander/hs/main_thrusters.mod:
     annotations:
@@ -7062,44 +8703,55 @@ files:
   github.com/escuela-tecnica-21/repo-eclipse/0e3c95f8461f90b45bfcd736cfb334f1215ecffd/Autos.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/escuela-tecnica-21/repo-yerba-mate/0457641cc3a480f18b52214c70298a6f0ee86e53/Ajedrez/src/Ajedrez.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/espruino/EspruinoBoard/b3ce57473e81ca4cbea8e0deba098d93311d9d23/boxes/pico_box.scad:
     annotations:
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/esquiloio/lib/a55bfda5f587a05ee6a39627f8caefebeeba56bf/sensors/tsl2561/tsl2561.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/essandess/etv-comskip/5167670162a234831fe6f9aba09190c106e213fd/src/scripts/Install.applescript:
     annotations:
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/essentialkaos/rwk-ek-theme/e8b708ac5473995e5d8366ff94af39bb9ca80e84/package.kid:
     annotations:
       human-smola: Genshi
       linguist: Genshi
+      linguist-extension: Genshi
+      linguist-xml: XML
       vote: Genshi
   github.com/essteban/CHmUsiCK/a8a8ccbb302574f07eb3dfced03bfa95d1314fa8/Library/Deelay.ck:
     annotations:
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/essteban/CQenze/fe61490318978e5d91a5024286ffa686eb3e2fc7/Chmusick/Library.ck:
     annotations:
       human-smola: ChucK
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/estimpson/Fx.PB2017/35a34eb97a44241dd6c06cd7a7e0e87f41d4527b/ws_objects/PFC/pfcmain.pbl.src/pfc_u_vsb.sru:
     annotations:
       linguist: PowerBuilder
+      linguist-extension: PowerBuilder
       vote: PowerBuilder
   github.com/etalab/taxe-fonciere/152bb1f0ba19827e3509f83a694a25a4aa52240e/src/XCOMBAT.cpy:
     annotations:
       linguist: COBOL
+      linguist-extension: COBOL
       vote: COBOL
   github.com/etienne-napoleone/chalk/6112c916441acc16542e1694aba2b36f0c5a9bcd/chalk.v:
     annotations:
@@ -7108,219 +8760,274 @@ files:
   github.com/etiennepinchon/aframe-fonts/7d1f9c19f53498fb25682bfe05221b093703df33/fonts/rubik/METADATA.pb:
     annotations:
       linguist: PureBasic
+      linguist-extension: PureBasic
       vote: PureBasic
   github.com/euaruksakul/SLRILEEMPEEMAnalysis/67f396f06ec1d7d6ebeda13a22767f153b5a7782/MultiGLAFit_ce20180313a.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/evancz/elm-todomvc/7297d07afbd9bd6cfa2992f0279d23690ca77a7f/src/Main.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/evancz/url-parser/be733367510a4bce885494b7f14c4f748b1757c0/src/UrlParser.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/evanrmurphy/SweetScript/6b4ed26acc9c2df6fde028f57b19ecb4661943fb/arc3.1/strings.arc:
     annotations:
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/everythingwillbetakenaway/DX7-Supercollider/2587045debae9a7125e24161b8e4323082648b90/DX7.scd:
     annotations:
       human-smola: SuperCollider
       linguist: SuperCollider
+      linguist-extension: SuperCollider
       vote: SuperCollider
   github.com/evilmartians/foundry-lib/9ab4ad8a5625c8c852e04adf8ce463b4c9320212/rtl/integer.fy:
     annotations:
       human-smola: Unknown
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Unknown
   github.com/evincarofautumn/kitten/bcaffa109c7f93959b3c2e9e7ae74462f840088d/lib/Kitten/Metadata.hs:
     annotations:
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/evshiron/nwjs-builder-phoenix/e9c26b61669589e599da95ee82ac3bb489c6dd04/assets/nsis/Contrib/Language files/Romanian.nsh:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/ewust/keys/55834a449a52ee0aa24f6a69549d9ba225727f55/custom-models/BEST G.scad:
     annotations:
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/excelsior-oss/xds/88cd0674a22cc66856d17e333fd088bd6696b99e/Sources/Lib/src/xr/x86/xrnX2C.mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/executeautomation/KatalonDocker/70581fdbb7d72e88b904f776c400e3c88eaff7a0/Object Repository/EAOR/Page_Execute Automation/span_User Form.rs:
     annotations:
+      human-smola: XML
       linguist: RenderScript
-      vote: RenderScript
+      linguist-xml: XML
+      vote: XML
   github.com/exercism/lfe/87bd13d9dd979f0081f0774183f154c0507e2393/exercises/clock/src/example.lfe:
     annotations:
       linguist: LFE
+      linguist-extension: LFE
       vote: LFE
   github.com/experimental-dustbin/alloy-models/cc660611a1199933458d8e429ef0056987f29f72/n-queens.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/expo/expo/9170118913cb64164df1dfaf1f5ab23deb7115d3/ios/Exponent/Kernel/AppLoader/EXAppLoader.h:
     annotations:
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/exyte/Macaw/3acbaffa97f0297cde7eb4fce40cdc2e4ca0f56f/Source/render/ImageRenderer.swift:
     annotations:
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/f0rki/mapping-high-level-constructs-to-llvm-ir/08928c73370b61f138618cb901fc8d24f2dfabea/exception-handling/listings/setjmp_longjmp.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/fa32/ps/60a8d801c36f358f567f380231c2db41d9733d2d/colors/Monokai copy - Kopie_0.icl:
     annotations:
       human-smola: XML
       linguist: Clean
+      linguist-extension: Clean
+      linguist-xml: XML
       vote: XML
   github.com/fabienhinault/mmarc/7038b7bc4e0494012d0f8d4005801dcc2132b239/demo0_mm.arc:
     annotations:
       human-smola: Arc
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/fable-compiler/Fable/b70ace6423f68e9fecc9b31a010a9baf4fb6e3fe/tests/Main/ElmishParserTests.fs:
     annotations:
       linguist: F#
+      linguist-heuristics: F#
       vote: F#
   github.com/facebook/Haxl/abf9509481920d7d768f7b238dc3331aae099883/tests/ParallelTests.hs:
     annotations:
       human-smola: Haskell
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/facebook/Shimmer/ddde760011261655b465069a762f8e6210e39ad4/FBShimmering/FBShimmeringLayer.h:
     annotations:
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/facebook/fbctf/4ec9b6be404fce1bed6d1066fccf10c4255767bb/src/controllers/Controller.php:
     annotations:
       linguist: Hack
+      linguist-heuristics: Hack
       vote: Hack
   github.com/facebook/fbshipit/577ad2017c54dbf8bc217ebd699b47502c8f285b/src/shipit/phase/ShipItPhaseRunner.php:
     annotations:
       linguist: Hack
+      linguist-heuristics: Hack
       vote: Hack
   github.com/facebook/flow/6b74ea2435452e0e8081fcbb2ca63581ecc85297/src/services/autocomplete/autocompleteService_js.mli:
     annotations:
       human-smola: OCaml
       linguist: OCaml
+      linguist-extension: OCaml
       vote: OCaml
   github.com/facebook/infer/3b41abfb8824edfd404f684b24d696bc0bace921/infer/src/bufferoverrun/bufferOverrunModels.ml:
     annotations:
       linguist: OCaml
+      linguist-heuristics: OCaml
       vote: OCaml
   github.com/facebook/pyre-check/d70e62d306b461cd5c157b1d5d27ba796381ce6e/interprocedural/analysisKind.ml:
     annotations:
       linguist: OCaml
+      linguist-heuristics: OCaml
       vote: OCaml
   github.com/facebook/reason/281e433714f9dad72eee7ea7e587a46449a02525/src/reason-parser/reason_location.ml:
     annotations:
       linguist: OCaml
+      linguist-heuristics: OCaml
       vote: OCaml
   github.com/facebookarchive/flint/9fa6fc1c3433587db32163ff52758034cb3c4ddb/CxxTokenize.d:
     annotations:
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/facebookarchive/oss-performance/aa311481c4f6d0c75ceba5685740f923669de979/base/PHP5Daemon.php:
     annotations:
       linguist: Hack
+      linguist-heuristics: Hack
       vote: Hack
   github.com/facebookexperimental/reason-native/60fcd8b9134ba02f1d3215ab880a8c2b8f81958b/src/refmterr/lib/parseWarning.re:
     annotations:
+      human-smola: Reason
       linguist: OCaml
-      vote: OCaml
+      linguist-heuristics: Reason
+      vote: Reason
   github.com/facebookresearch/deepfloat/92e14c3370d955b2fb04adf97070edf42fc314c0/rtl/posit/lut_func/PositLUT.sv:
     annotations:
       human-smola: SystemVerilog
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/factor/factor/715283d11d99f89a3576899d2f2ce43f31f31bd8/basis/unix/stat/macosx/macosx.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/faker-ruby/faker/65a252f36eb445de79bae16a550762d32ffe0d30/lib/faker/default/hipster.rb:
     annotations:
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/fancy-lang/fake/ac017c21ec7efdd665d733859e12fce92c680ca7/lib/fake/task.fy:
     annotations:
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Fancy
   github.com/fancy-lang/fpr/e24b551d9a10ea9b89cc9a40046421b0fb7ccbb5/lib/fpr/http_api.fy:
     annotations:
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Fancy
   github.com/fanx-dev/fanx/06037f3dcbe96a1dd397a25a13c2cd7d8580cc48/src/testCompiler/fan/NamespaceTest.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/fanx-dev/vase/cd4e2d9f44414357337351e133a509c11b6bcac7/graphics/fan/Gradient.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/farcrycore/core/a2b6702ac97087cfdb8752156610cb59d6dacf0b/tags/security/SelectUDLogin.cfm:
     annotations:
       linguist: ColdFusion
+      linguist-extension: ColdFusion
       vote: ColdFusion
   github.com/farshid83/RGB2HSV-Renderscript-in-Android/d8d317ecab13d36e3db950d7e2779929e7f94274/hsv.rs:
     annotations:
       human-smola: RenderScript
       linguist: RenderScript
+      linguist-heuristics: RenderScript
       vote: RenderScript
   github.com/fasterthanlime/bleep/dde9eb3df48c3aad5162fdcfb1502c81c05c5820/source/bleep.ooc:
     annotations:
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/fasterthanlime/inception-engine/4804f6ee74f28e2ccc943700b85dbca68bdb0061/source/gfx/Line.ooc:
     annotations:
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/fasterthanlime/isaac-paper/ffaf8d49fea748d04f16f4a44ae8b39d374deb9a/source/isaac/enemies/swarmer.ooc:
     annotations:
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/fasterthanlime/oc/2ffdec1d344237e1bbc8b43054059c9527f13ebf/test/parsing/imports/import2_77.ooc:
     annotations:
       human-smola: ooc
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/fasterthanlime/ooc-gtk/3057dc1312c546195d0ccd99fecf9b67fd78618a/source/gtk/Menu.ooc:
     annotations:
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/fasterthanlime/ooc-plot/faddbaea22e362fb567f7375956249163a628126/source/plot.ooc:
     annotations:
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/fasterthanlime/ooc-zeromq/82174b9c0d70e1b80643d9c12c06ed79448ec2db/source/zeromq.ooc:
     annotations:
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/fasterthanlime/ultipoly-server/841f26badd0a1e8bac632d50bb258b0ded78b56e/source/ulti/zbag.ooc:
     annotations:
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/fasterthanlime/yajit/f9e029475bb3c3c19f1a4980874b5e3d5d08b4e2/tests/test_partial.ooc:
     annotations:
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/fastlane/fastlane/0c6a6d24098b9f6d7b16e4328a2048c6da4fa8df/fastlane/lib/fastlane/actions/update_project_team.rb:
     annotations:
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/fatedier/frp/adc3adc13bf3a2bc43354377b842944f9cfc6a25/server/control.go:
     annotations:
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/fdbozzo/foxbin2prg/b83a71124d4ae80dbd0e06ef60a9a3e46056346a/TESTS/ut__foxbin2prg__c_conversor_prg_a_bin__insert_AllObjects.prg:
     annotations:
       linguist: xBase
+      linguist-extension: xBase
       vote: xBase
   github.com/feenkcom/gtoolkit/1809c243d4cc570c40a633e8aab48f5074e1a174/src/GToolkit-Scenery/GtSceneryBuilder.class.st:
     annotations:
@@ -7330,32 +9037,40 @@ files:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
       vote: Scheme
   github.com/felixSchl/neodoc/6d314821b2805ac034c9f7054befe350eb65a5ae/src/Neodoc/Error.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/feramhq/transity/a88a25a27e6e21def16cec9dd8922515e8a6640f/src/Transity/Data/Transfer.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/fernandocanizo/newlisp-hin/e2cdea3256298e8351aaca4c30239940d48a8a4d/hin.nl:
     annotations:
       human-ajnavarro: NewLisp
       linguist: NewLisp
+      linguist-heuristics: NewLisp
+      linguist-shebang: NewLisp
       vote: NewLisp
   github.com/fewnew/art74-fall2019/ed0d36ebf696148109dde5746cf1b4b21074b210/readings/reading01/responses/Benjamin_Revell_reading01.mg:
     annotations:
       human-smola: Text
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Text
   github.com/fgeorges/cxan/8c80ade9f20f3d41da0c340975e606420bfc3a60/client/src/tools.xpl:
     annotations:
       linguist: XProc
+      linguist-extension: XProc
       vote: XProc
   github.com/fightingbamboo/cyii2/ad774f0e7a8e5735878ac18cea60ddc9268cdac5/yii/base/Object.zep:
     annotations:
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/financialforcedev/ForceDotComSprintWall/bad7f61a5d57d57570f36cb611be40cf1d6820d3/src/classes/AgileTaskHandler.cls:
     annotations:
@@ -7376,107 +9091,134 @@ files:
   github.com/firemodels/fds/496ba53ea46d0dcfc4a212e22702c67294212fff/Utilities/Structural_Interaction/fds2ftmi/source/fds2lsdyna.f90:
     annotations:
       linguist: Fortran
+      linguist-extension: Fortran
       vote: Fortran
   github.com/firgun/CTMOCP/be4acbe40852a3ba4579b9508dcae0fa65c4422b/Exercises/01/09.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/fischi101/GitTest/e0a972895bba23d4e9d75ebb1001c1829ed49d5e/w_main.srw:
     annotations:
       linguist: PowerBuilder
+      linguist-extension: PowerBuilder
       vote: PowerBuilder
   github.com/fish-shell/fish-shell/ac2eed2ffa71aa6db08dad2ea6f6b0dd89f815d6/share/completions/iex.fish:
     annotations:
       human-ajnavarro: Shell
       linguist: Shell
+      linguist-extension: fish
       vote: Shell
   github.com/fizban-of-ragnarok/cs420/dabd86472e2dbb4483df3594f4437634a49ad632/room_test.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/fjqingyou/PotPlayer_Subtitle_Translate_Baidu/bc51d64d18bf21c0399150e8843253b7a5c585ee/SubtitleTranslate - baidu.as:
     annotations:
       linguist: AngelScript
+      linguist-heuristics: AngelScript
       vote: AngelScript
   github.com/flaiker/abap-log/5e35a5d8b31f6261765c377b0901d17fb37182f4/src/example/zalog_example_file_logger.prog.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/flame-engine/flame/11c37ffbf648dd118d0892e6306b6227f8efcc31/lib/components/mixins/tapable.dart:
     annotations:
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/flaviusb/Byeloblog/4f2de0b5c2e541b72eb422ae2c212f71607b2827/spec/xml_spec.ik:
     annotations:
       linguist: Ioke
+      linguist-extension: Ioke
       vote: Ioke
   github.com/flaviusb/TwitAtom-client/66216a2fcb578edfa0f3db7f2e9abbea4fb855a7/manifest.ik:
     annotations:
       linguist: Ioke
+      linguist-extension: Ioke
       vote: Ioke
   github.com/flaviusb/flaviusb.net/f906c7e3c50d7ff39a3615e4bd1ab337721c3d21/post.ik:
     annotations:
       linguist: Ioke
+      linguist-extension: Ioke
       vote: Ioke
   github.com/flaviusb/my-tweets/b9e7e319c711ee3a9df0a84bea03aff4142a2246/index.ik:
     annotations:
       linguist: Ioke
+      linguist-extension: Ioke
       vote: Ioke
   github.com/flaviusb/whyso.co.nz/400ad32eb4906a0e0a86211575f24bbb586471d9/picturetags-faq.ik:
     annotations:
       linguist: Ioke
+      linguist-extension: Ioke
       vote: Ioke
   github.com/fletcher/Markdown.ooxsl/aecde927425e90153e650f9ed9a3eff8b3aec52f/Contents/Resources/oo2markdown.xsl:
     annotations:
       linguist: XSLT
+      linguist-extension: XSLT
+      linguist-xml: XML
       vote: XSLT
   github.com/flightaware/piaware/0eec6e07db850c59e49fa8579432099b574ab12d/package/fa_adept_codec/fa_adept_schema.tcl:
     annotations:
       linguist: Tcl
+      linguist-extension: Tcl
       vote: Tcl
   github.com/flightaware/speedtables/6db1ee836ebb68ef2ce38ced193890a330c44917/ctables/tests/master_server.tcl:
     annotations:
       linguist: Tcl
+      linguist-extension: Tcl
       vote: Tcl
   github.com/florent37/MaterialViewPager/e2fb22e0ad95b00934c3d73cd1031c1cd5b407c1/materialviewpager/src/main/java/com/github/florent37/materialviewpager/header/MaterialViewPagerImageHelper.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/florian-grond/SC-HOA/fcae2bccba39dd4acaba025f78299e50b8bac511/classes/HOASphericalHarmonics.sc:
     annotations:
       linguist: SuperCollider
+      linguist-heuristics: SuperCollider
       vote: SuperCollider
   github.com/flouc001/Simple-APL-Neural/9274b76d722bbcdeed2484f681e4c95fdda68b5e/src/ANN.dyalog:
     annotations:
       linguist: APL
+      linguist-extension: APL
       vote: APL
   github.com/fluent/fluentd/64a7b2781ca0d22641034f76767ada8ae8c85dd4/test/helper.rb:
     annotations:
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/flutter/flutter/289b4588f4d8d87a6ef4effbec7cb42fa86ffcee/packages/flutter/lib/src/cupertino/text_selection.dart:
     annotations:
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/flutter/plugins/f31d16a6ca0c4bd6849cff925a00b6823973696b/packages/google_maps_flutter/lib/src/ui.dart:
     annotations:
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/flutter/samples/f2ca77008a0b8624133ef0d547317389fbc9a4fa/veggieseasons/lib/data/veggie.dart:
     annotations:
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/flutterchina/dio/c9d9a8fe993b6ee51cda607b41a94c4f4ec09f38/example/response_interceptor.dart:
     annotations:
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/fonqing/Aimo/6d9fe186dcd5dcef14870345956758c06255afa4/aimo/Model.zep:
     annotations:
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/forcedotcom/dataloader/145ad92e72d17db897f7293c608dc35dec109cc5/windows-dependencies/autoit/Examples/Helpfile/InetGet.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/forcedotcom/user-access-visualization/4dcdb5b5084871ab13788cc353a7c6e4570cdcc9/UserAccessVisualization/src/classes/UserAccessDetailsController.cls:
     annotations:
@@ -7485,100 +9227,125 @@ files:
   github.com/fortesit/Game-of-Life/4d0b5490d78121be19d2bfa43ec8f661d6a14ee6/life.cob:
     annotations:
       linguist: COBOL
+      linguist-extension: COBOL
       vote: COBOL
   github.com/forthnutter/6805/cd07a778e23e7bd500a8e5a89855a6fd9d5422c1/6805.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/forthnutter/freescale/e5574381fd1e52a1b2b97614087f5298fab576dc/68000/emulator/memory/memory.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/forthy42/bigforth/0e6cb9f198d97532af94450975d8115be62300da/dragon.fs:
     annotations:
       linguist: Forth
+      linguist-heuristics: Forth
       vote: Forth
   github.com/fossasia/KikiAuth/d9bb7881fd0312fa73e3d515cbaf241f62cd2cc5/luasrc/controller/kikiauth/admin.lua:
     annotations:
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/fossasia/lxlauncher-vala/740c750b6736295d46c7fe95e621a12ee9a7d507/desktopsetting/DesktopSetting.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/fossasia/susi_android/e544a515527e52da8089907a9352da9fe44c314f/app/src/main/java/org/fossasia/susi/ai/device/connecteddevices/adapters/ConnectedDevicesAdapter.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/foundeo/cfdocs/68dad82bf591b522c69a968ee60ef4791205b74d/reports/missing-layout.cfm:
     annotations:
       linguist: ColdFusion
+      linguist-extension: ColdFusion
       vote: ColdFusion
   github.com/fpaxos/fpaxos-tlaplus/b46b0e6e8cfed37119da6545b7a5479677aac2ef/FPaxos.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/fponticelli/thx.core/50572010fb17f1d8bdab0f77516ddecb8eafacbe/src/thx/Arrays.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/fractalide/fractalide-oz/abbeda3dce706e96b249c2d98f1aaf15ed3a3491/components/editor/link/create.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/fractalide/fractalide/9c54ec2615fcc2a1f3363292d4eed2a0fcb9c3a5/modules/rkt/rkt-fbp/hyperflow.rkt:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/frameland/Scope-2D/7c28d945a0d14b68784b529de5d249972d145bfc/source/engine/components/color.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/framework-one/di1/f57ba069a8298d96108e1a124b86c4a1d02a2752/ioc.cfc:
     annotations:
       human-smola: ColdFusion CFC
       linguist: ColdFusion
+      linguist-extension: ColdFusion CFC
       vote: ColdFusion CFC
   github.com/framework-one/fw1/1c946217c1aae1a58e8569b366905f8b08d68c46/tests/stubs/UserOneLevel.cfc:
     annotations:
       human-smola: ColdFusion CFC
       linguist: ColdFusion
+      linguist-extension: ColdFusion CFC
       vote: ColdFusion CFC
   github.com/frankiesardo/auto-parcel/eacd2d42a114655b62607f2782103d464a60930c/src/auto_parcel/extension.clj:
     annotations:
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/franzheidl/alfred-workflows/9e7a6e6e8104cd0aaff97e555ffad7de1d25a214/run-terminal-command-here/src/terminalcommandhere-newwin.applescript:
     annotations:
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/frasermclean/AMX-IP-Socket-Manager/ab60b14c765657d59a0ae5d782a4bea07dbd72d0/IP Socket Manager - Header.axi:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/frc1124/2014/dc29b82575f51cd102530cc756eab7e2311efe5f/2014 Dashboard/2014 UberDashboard.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/freakdesign/Shopify-code-snippets/7dd34e7ed31939f6786e06f61a4a4399a918bfb8/Get a cart json response with compare at price/cart.compare.liquid:
     annotations:
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/fredefox/cat/e7f56486076cc561ceb0529b05725c01d7d1b154/src/Cat/Categories/Cube.agda:
     annotations:
       linguist: Agda
+      linguist-extension: Agda
       vote: Agda
   github.com/fredreichbier/ooc-sfml/f062a5b9ba1289dceaeaf192764a6c8f130e4ec7/sfml/Audio.ooc:
     annotations:
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/fredreichbier/ooc-uuid/cd573a824e65a2dc2af8842bdd6b5692e020d5bd/source/uuid.ooc:
     annotations:
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/fredreichbier/optparse/164faf80561f82ef68ac888903a04afee752d47b/optparse/Option.ooc:
     annotations:
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/fredyouhanaie/etclface/8ab61bb48e8f02d4c4d8a4766177eb8ac60bc4f6/boilerplate.w:
     annotations:
@@ -7590,49 +9357,60 @@ files:
     annotations:
       human-smola: Ruby
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/freered/Code/6a05a27e465d71874e12ed499d7d9065ac7d12e5/scripts/typing.red:
     annotations:
       linguist: Red
+      linguist-extension: Red
       vote: Red
   github.com/fregelab/chinook/8e4ea68f6bc27fb3cde8cb357187d8a541aa96d1/chinook-core/src/main/frege/chinook/Router.fr:
     annotations:
       linguist: Frege
+      linguist-heuristics: Frege
       vote: Frege
   github.com/frida/frida/b730fb11b9fec789b404b3377fb9867cf7bdf18e/Makefile:
     annotations:
       linguist: Makefile
+      linguist-filename: Makefile
       vote: Makefile
   github.com/friendly/SAS-macros/fbb12ee1b4ae6f45a85f3b5310af41c846581916/removewrd.sas:
     annotations:
       human-smola: SAS
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/froggey/Mezzano/344ad0b741b5f84b379eb6d0e309bee9ba2a1594/compiler/backend/x86-64/memory.lisp:
     annotations:
       human-smola: Common Lisp
       linguist: Common Lisp
+      linguist-heuristics: Common Lisp
       vote: Common Lisp
   github.com/frznlogic/ipsysctl-tutorial/0dda94cf007a68cd70d6c886de3e1acb6449d91d/styles/dsssl-stylesheets/dtds/decls/xml.dcl:
     annotations:
       human-smola: Unknown
       linguist: Clean
+      linguist-extension: Clean
       vote: Unknown
   github.com/fsancho/Complex-Networks-Toolbox/01101be05580d57d04c2e720dc1837cf0fa743dd/Complex Networks Model 6.0.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/fsancho/IA/6ff6197032474a68b6c66b0027d4a107203dcb40/05. Adversarial Search/MCTS Quarto Simplified.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/fsavje/math-with-slack/9f785da27455697e351b9051071d383ef6a7a841/math-with-slack.bat:
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/fscheck/FsCheck/da4203184bfde6fc164108340f6eee218cd714f7/src/FsCheck/AssemblyInfo.fs:
     annotations:
       linguist: F#
+      linguist-heuristics: F#
       vote: F#
   github.com/fschutt/xlib-programming-rust/a00066f3c7cf137ffb62452c9618c7bb5693c376/src/gl.rs:
     annotations:
@@ -7642,32 +9420,39 @@ files:
   github.com/fsharp/FAKE/8078b5a499518cc63f838ed034fe7c79157d623d/src/legacy/FakeLib/RoundhouseHelper.fs:
     annotations:
       linguist: F#
+      linguist-heuristics: F#
       vote: F#
   github.com/fsharp/fsharp/24c798bfcee5d6f91ae2c19888baeb9946744c3a/src/fsharp/InternalCollections.fsi:
     annotations:
       human-smola: F#
       linguist: F#
+      linguist-extension: F#
       vote: F#
   github.com/fsprojects/FSharpPlus/649bf19d2c0b70c4d6b2c4123fdf393270ca176d/src/FSharpPlus/Option.fs:
     annotations:
       linguist: F#
+      linguist-heuristics: F#
       vote: F#
   github.com/fsprojects/FsReveal/2995b52d5c076f019a6fb8a2848c44a4e8c634ba/slides/sample.fsx:
     annotations:
       human-smola: F#
       linguist: F#
+      linguist-extension: F#
       vote: F#
   github.com/fsprojects/FsUnit/77a234f23d21c0bed3d58276fc94adb970205b99/tests/FsUnit.Xunit.Test/beEmptyStringTests.fs:
     annotations:
       linguist: F#
+      linguist-heuristics: F#
       vote: F#
   github.com/fsprojects/Paket/49f3c594e45f88ac1430d0a98d6009fcac9cf9ef/src/Paket.Core/Dependencies/NuGetLocal.fs:
     annotations:
       linguist: F#
+      linguist-heuristics: F#
       vote: F#
   github.com/fsprojects/SQLProvider/496b50307199e4bc2e92b7066210ccd81ecd02fe/src/SQLProvider/SqlRuntime.DataContext.fs:
     annotations:
       linguist: F#
+      linguist-heuristics: F#
       vote: F#
   github.com/ftm13/masters/105bd354f23026db0662866675d9516eff7bb698/BlocksGame/cubeturk/examples/0ECjYvl.lisp:
     annotations:
@@ -7676,31 +9461,38 @@ files:
   github.com/ftomassetti/antlr-plus/0160d44f49ad9c1c4df2195704c5b901ef2e2d0e/src/test/resources/me/tomassetti/antlrplus/python/Python3.g4:
     annotations:
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: ANTLR
   github.com/fuhsjr00/bug.n/767596345b2a635c9982223c431574436ca8cd79/src/Config.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/fukamachi/clack/e104b327d9eab3ce26ce1d809f8f5e0efe79864e/v1-compat/clack-middleware-rucksack.asd:
     annotations:
       linguist: Common Lisp
+      linguist-extension: Common Lisp
       vote: Common Lisp
   github.com/fukamachi/fast-http/502a37715dcb8544cc8528b78143a942de662c5a/src/error.lisp:
     annotations:
       human-smola: Common Lisp
       linguist: Common Lisp
+      linguist-heuristics: Common Lisp
       vote: Common Lisp
   github.com/fundamentalslib/fundamentals5/96c19b505e4f21c2366ea1bf19b5235722a46705/Source/Maths/flcMaths.pas:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/furqanZafar/react-selectize/d3f707235cf4f8fca3646421861688678f70f045/public/examples/multi/TagsBasic.ls:
     annotations:
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/fushnisoft/ClarionClasses/857a1fdd2fa582fbbb5d6e7102b41e597246b2cf/SqlCommandApp/SqlCommandApp.clw:
     annotations:
       linguist: Clarion
+      linguist-extension: Clarion
       vote: Clarion
   github.com/fushnisoft/ClarionMetroWizard/7366679ff21eae712692d1ee5c93bc2ec323c13e/_classes/ce_TabList.inc:
     annotations:
@@ -7709,19 +9501,24 @@ files:
   github.com/fylz1125/ShaderDemos/f91bd2fd2df7fdf7e192880b4b0fdb2235d87222/assets/resources/shaders/CircularEffect.glsl:
     annotations:
       linguist: GLSL
+      linguist-extension: GLSL
       vote: GLSL
   github.com/fzaninotto/Faker/81b340016900ccec86a1d4911f7661d14e248c0a/src/Faker/Provider/sr_Cyrl_RS/Person.php:
     annotations:
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/g0v/awesome-g0v/9c3508921feec0a1ac2b6169a257c7d6aa62dde1/parse.ls:
     annotations:
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/gabfl/mysql_generate_series/2258382c45c8ce40a24c3fa41ef9a182112e9850/sql/generate_series.sql:
     annotations:
+      human-smola: SQL
       linguist: SQLPL
-      vote: SQLPL
+      linguist-heuristics: SQL
+      vote: SQL
   github.com/gabsoftware/Progress-ABL-4GL-Regex/a0423268b01b14c5417139679c475ade28627824/Binary.cls:
     annotations:
       linguist: OpenEdge ABL
@@ -7730,30 +9527,37 @@ files:
     annotations:
       human-smola: COBOL
       linguist: COBOL
+      linguist-extension: COBOL
       vote: COBOL
   github.com/gallais/agda-sizedIO/823d5a0a94a4b0c4bbaaac9b23997a6d94741885/src/System/Environment/Primitive.agda:
     annotations:
       linguist: Agda
+      linguist-extension: Agda
       vote: Agda
   github.com/gallais/generic-syntax/d458d7520ad52f8e089691348780caab991a0b2d/src/Generic/Semantics/Elaboration/LetBinder.agda:
     annotations:
       linguist: Agda
+      linguist-extension: Agda
       vote: Agda
   github.com/gamer08/POA/df4ad4ee7f99570b9bd599a5efacb36fd7d573ed/Echec/src/edu/uqac/aop/chess/piece/ValidateMoveAspect.aj:
     annotations:
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/gap-packages/Digraphs/d81d4e1c1e5869148d6cff09f4b777f13924eaae/gap/io.gi:
     annotations:
       linguist: GAP
+      linguist-extension: GAP
       vote: GAP
   github.com/gap-packages/Semigroups/ac1a33aeef354608422d17f510cd81d0d0de3ad2/gap/semigroups/semibipart.gd:
     annotations:
       linguist: GAP
+      linguist-heuristics: GAP
       vote: GAP
   github.com/gap-packages/guava/fdb463d71976d610301187251e41344aa62a9219/tst/hadamard.tst:
     annotations:
       linguist: GAP
+      linguist-heuristics: GAP
       vote: GAP
   github.com/gap-packages/orb/4320969c2f9872bf2e30b2ccecf02e0760ee457b/tst/m22f2d34p443520.g:
     annotations:
@@ -7762,19 +9566,23 @@ files:
   github.com/gap-system/gap/ba30bd40678f3a09cdcafa1b5716bb6382317b31/lib/addmagma.gd:
     annotations:
       linguist: GAP
+      linguist-heuristics: GAP
       vote: GAP
   github.com/garmu/CMPT470a4/59cf2a3fe68da7b8bc142018c89b398a59e31f8c/SuportMaterials/Pascal_PrettyPrinter/makePascalgrammar/12.Txl:
     annotations:
       linguist: TXL
+      linguist-extension: TXL
       vote: TXL
   github.com/garyvidal/xquerrail/2991162cc70037e65c2c4601065af1825f5fd41b/src/application/views/demo/demo.gallery.html.xqy:
     annotations:
       human-smola: XQuery
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/gavinwahl/postgres-json-schema/570e19f5b2b4e6ff1414eebe2191e14c437760d9/tests.sql:
     annotations:
       linguist: PL/pgSQL
+      linguist-heuristics: PL/pgSQL
       vote: PL/pgSQL
   github.com/gazingatnavel/ucf-spring2017-cda3103-spim-project-tests/e132e36f07a3621751cd8981b5bfa717e6e8571c/test-spim-rtype.asc:
     annotations:
@@ -7784,6 +9592,7 @@ files:
   github.com/gbdobson/cyberfit/762294d71fd268d16d499577389405378a71d453/cyberFIT.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/gbrann/EVEProductionSuite/ad3a5abe064973422f8957c57fc53de156a2c2d7/function.gs:
     annotations:
@@ -7792,6 +9601,7 @@ files:
   github.com/gcentauri/sho-pico/de47baa53cb642bfaaa479758b5c34e2a642dbcd/buttons.l:
     annotations:
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
       vote: PicoLisp
   github.com/gchilczuk/BrainFuck/456eb98414e5db03116d2685532d24aba43931fa/src/simple_calc.b:
     annotations:
@@ -7800,64 +9610,79 @@ files:
   github.com/gchiu/RSOChat/e0a4969db169339493b4320d9c02059aaa7044ad/httpd.reb:
     annotations:
       linguist: Rebol
+      linguist-extension: Rebol
       vote: Rebol
   github.com/gchiu/Rebol3/6b1a181e05af1c3b5eabc4d32fda261861f200b9/r3-gui/gui.r3:
     annotations:
       human-smola: Rebol
       linguist: Rebol
+      linguist-extension: Rebol
       vote: Rebol
   github.com/gchiu/rebolbot/089aa02a177977d9ee9e4aff6e428f9ee8a07c23/commands/fetch-command.r3:
     annotations:
       linguist: Rebol
+      linguist-extension: Rebol
       vote: Rebol
   github.com/geb/geb/2c8476ef24b3bb3c13bea46442ed9ae32cc41019/module/geb-core/src/test/groovy/geb/textmatching/TextMatchingSupportSpec.groovy:
     annotations:
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/geekcomputers/Applescript/29e1e61bf4be9112eb7786c63c42286f48c68247/sync_bento.applescript:
     annotations:
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/geerlingguy/ansible-role-jenkins/9bb2b2032c1056212ce5e00099235d86fdabd49e/templates/basic-security.groovy.j2:
     annotations:
       linguist: Groovy
+      linguist-extension: HTML+Django
+      linguist-shebang: Groovy
       vote: Groovy
   github.com/generative-design/Code-Package-Processing-2.x/8f0fbaced94900ea0141cf986fd81127edea336e/01_P/P_4_3_3_01/P_4_3_3_01.pde:
     annotations:
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/geodynamics/aspect/32313782e6d944066c07b2b3140aa19267fdda36/tests/particle_output_multiple_formats/particles/particles-00000.0000.gnuplot:
     annotations:
       human-smola: Gnuplot
       linguist: Gnuplot
+      linguist-extension: Gnuplot
       vote: Gnuplot
   github.com/geometryvn/asymptote/3b0c4283540560ae0d5efc051f90f2cf624a32ce/counttriangles.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/georgejecook/rooibos/6066fd0b344c4efc9aa559a8597007d794350d79/frameworkTests/source/tests/VersionTests.brs:
     annotations:
       human-smola: Brightscript
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/georghe-crihan/arpd/3484202551ce2a793223bdbce7e1c3c4e22ba478/files/patch-arpd.c.self:
     annotations:
       human-smola: Diff
       linguist: Self
+      linguist-extension: Self
       vote: Diff
   github.com/getlantern/lantern/96852c0639bcc5d207a055c5178681248f0f2225/archive/src/golang.org/x/net/ipv4/header.go:
     annotations:
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/ggreer/the_silver_searcher/965f71dcbc9d98da5347f1256f650f8b7dcf4625/src/lang.c:
     annotations:
       human-smola: C
       linguist: C
+      linguist-extension: C
       vote: C
   github.com/ghdl/ghdl/3819515f724ed2ae81a1aa7b467359e26a3fb9e7/testsuite/vests/vhdl-93/billowitch/compliant/tc2390.vhd:
     annotations:
       human-smola: VHDL
       linguist: VHDL
+      linguist-extension: VHDL
       vote: VHDL
   github.com/ghpaetzold/questplusplus/c2e404dc7c57d5215d9cc87f0db0e9c9ee87dd1e/input/target.word-level.ch:
     annotations:
@@ -7866,6 +9691,7 @@ files:
   github.com/giginet/Tekitirs/e32b8beba1462280704547f10082abef12aa79f2/Assets/Fighter.boo:
     annotations:
       linguist: Boo
+      linguist-extension: Boo
       vote: Boo
   github.com/gilbo/ebb/442bdfac36ff9dfdfec5b50de6472507724955bc/tests/simple2.t:
     annotations:
@@ -7874,30 +9700,37 @@ files:
   github.com/gin-gonic/gin/db9174ae0c2587fe1c755def0f88cb9aba9e9641/context_test.go:
     annotations:
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/gingerbeardman/monkey.tmbundle/3a323c057a963a32d1fe002f8b88ce98d6faff2c/Templates/Bare App.tmTemplate/template.monkey:
     annotations:
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/gipert/gedet-plots/1bc80c236f521830adba9895a70d55e8941757d0/gedetplots.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/giraffe-fsharp/Giraffe/e1693b20fdbe6e0f98705a5f50a107dcbe5b56e7/src/Giraffe/ResponseCaching.fs:
     annotations:
       linguist: F#
+      linguist-heuristics: F#
       vote: F#
   github.com/girst/hardpass-passwordmanager/864e3cfc12af374680999cd29e5732e9e21c9ed5/kicad/hardpass-sci-pcb/kicad-ESP8266/ESP8266.3dshapes/ESP-12.scad:
     annotations:
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/git-game/git-game-v2/907c9fb76c6320be2c8ad5e49ec8323ea485f5c8/AllFiles/cleanbuild.mk:
     annotations:
       linguist: Makefile
+      linguist-extension: Makefile
       vote: Makefile
   github.com/gitGNU/gnu_dr-theobold/ce74cd1bc7020831fb946663a22730c36a96c1b2/tree.l:
     annotations:
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
       vote: PicoLisp
   github.com/gitGNU/gnu_gm2/e743eb0703328c4f0a1500a9898d7e30deda8147/gcc-versionno/gcc/gm2/gm2-compiler/P1SymBuild.def:
     annotations:
@@ -7907,10 +9740,12 @@ files:
   github.com/gitbucket/gitbucket/f35ecce3c7b08e9579408252f80674b5b4ae7c43/src/main/scala/gitbucket/core/controller/api/ApiGitReferenceControllerBase.scala:
     annotations:
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/github/semantic/2a1345508029d27151d30b8541ef2c956b7dc554/src/Diffing/Algorithm/SES.hs:
     annotations:
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/githubics/MediaManager/fff2981125e38a6be9a660138eaa68f77ba11575/media-manager.pro:
     annotations:
@@ -7919,72 +9754,89 @@ files:
   github.com/githwxi/ATS-Temptory/3613eb8b03c53d7f591f7b7eec627b346d9b62c1/libats/temp/bucs520/SATS/graph.sats:
     annotations:
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/gitiVebber/Pike-compiler/dbf6228a6de67d3dc2495c436c2a40c24fff8560/pike compiler/exe1_good.pike:
     annotations:
       linguist: Pike
+      linguist-extension: Pike
       vote: Pike
   github.com/gitlabhq/gitlabhq/d15180e00b209d0fbe3d8ce61b3af269aecdf7f5/spec/lib/gitlab/github_import/caching_spec.rb:
     annotations:
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/gitsemere/EthioEHR/8b7b0f46ca79dbdd4370279e248a0c081c3a88b8/Packages/Kernel/Patches/XU_8.0_585/XU-8_SEQ-485_PAT-585.KID:
     annotations:
       linguist: Genshi
+      linguist-extension: Genshi
       vote: Genshi
   github.com/giuliolunati/ren-c-lib/a39ac088115594b44da6df6aaba19a3035e687ab/misc/lest.reb:
     annotations:
       linguist: Rebol
+      linguist-extension: Rebol
       vote: Rebol
   github.com/giulioz/TinyVM/f872c376a6b27e2a0d07672577ba9b1fef41798c/assembler/grammar.ne:
     annotations:
       linguist: Nearley
+      linguist-extension: Nearley
       vote: Nearley
   github.com/gizzidan/hive-practice/1af924443874dc61534cf43e3e43c77f4a4a816a/hive4.q:
     annotations:
       linguist: HiveQL
+      linguist-heuristics: HiveQL
       vote: HiveQL
   github.com/gkossakowski/scalac-aspects/a02604feb13d3392b851cbdd80a0f5bce2f09321/TraceSymbol.aj:
     annotations:
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/gkz/LiveScript/bc1c188f01298567bc689c979147829c6ac57213/test/oo.ls:
     annotations:
       human-ajnavarro: LiveScript
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/gkz/grasp/42de4eab84c51597173e44de88142d5bf45b5721/test/errors-warnings.ls:
     annotations:
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/gkz/prelude-ls/c34e273fe9948f2880b065a9a22b1702663b4fe9/test/index.ls:
     annotations:
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/gl-transitions/gl-transitions/fe88f94886d2b13c9b6b59a4f526f081c488a240/transitions/DoomScreenTransition.glsl:
     annotations:
       linguist: GLSL
+      linguist-extension: GLSL
       vote: GLSL
   github.com/glebovpavel/IR_to_MSExcel/f9ad09dc1bfc98db4c02515412bf1c56462d3338/AS_ZIP.sql:
     annotations:
       linguist: PL/SQL
-      vote: PL/SQL
+      linguist-heuristics: SQL
+      vote: Unknown
   github.com/gleetbone/picolisp-fp/b65c846e193d31f309a267f35e12b1f72cd0c904/inline/fp.l:
     annotations:
       human-smola: PicoLisp
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
       vote: PicoLisp
   github.com/glilly/svsimport/e424023b8b564284105f27824d46edc11cd1f095/archive/KBAIVS_1_0_4_KBAIVS1-ONLY_T2.KID:
     annotations:
       linguist: Genshi
+      linguist-extension: Genshi
       vote: Genshi
   github.com/gmwitz/Substitution_cipher_ECL/06028e73b6457e0ecef0458ef371f82c049eff9e/Substitution_cipher.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/gnunn1/tilix/c20d4f64ad3348fd9e958ad47b73e03fd86f900c/source/gx/tilix/preferences.d:
     annotations:
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/gobo-eiffel/gobo/84ad68be041416460f06dbcf9a8f1b848e346586/library/tools/src/ecf/ast/et_ecf_settings.e:
     annotations:
@@ -7993,80 +9845,99 @@ files:
   github.com/gocomet/snippets/93695148126eccb7b23eff70a36eb8281308bb1d/currency-converter/snippets/currencies.liquid:
     annotations:
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/godiecl/varis/87ac282b4889ab6fbb1d0c999e4c8e4f1e83f543/ZeroIce.ice:
     annotations:
       linguist: Slice
+      linguist-heuristics: Slice
       vote: Slice
   github.com/godlygeek/tabular/339091ac4dd1f17e225fe7d57b48aff55f99b23a/plugin/Tabular.vim:
     annotations:
       linguist: Vim script
+      linguist-extension: Vim script
       vote: Vim script
   github.com/gogameguru/go-problems/eee12b2e39d59dbe81a8b9eaa7d4f103978d9224/weekly-go-problems/intermediate/ggg-intermediate-97.eps:
     annotations:
       linguist: PostScript
+      linguist-extension: PostScript
       vote: PostScript
   github.com/gogs/gogs/260c4e850301abc07ed5c703b66ab974c52b524c/internal/route/api/v1/misc/markdown.go:
     annotations:
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/gohugoio/hugo/c26d00db648a4b475d94c9ed8e21dafb6efa1776/commands/list_test.go:
     annotations:
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/golang/go/0c5d545ccdd01403d6ce865fb03774a6aff6032c/src/runtime/sema.go:
     annotations:
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/golanlevin/ExperimentalCapture/060907cfa231e698282aa06541b1721fce506d84/students/smokey/projects/build/Canon.app/Contents/Data/Managed/etc/mono/1.0/DefaultWsdlHelpGenerator.aspx:
     annotations:
       linguist: ASP.NET
+      linguist-extension: ASP.NET
       vote: ASP.NET
   github.com/golo-vertx/chat-demo/0b00d89f602290adf3ae04b7fdc34593fc70f878/src/main/golo/main.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/golo-vertx/golo_testing/1a78f7333d2f5b22f048c0655be88d8ff1634ee3/interfacing_java_classes/GPoint.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/golo-x/golo-x-mqtt/1dcd1feeed7ca8b9c6752570d98e5304f3109e9f/main.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/golo-x/golo-x-web/668ab8b279490eed607e8b48bed3ddab9a3c8775/imports/json.extensions.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/gongo/emacs-nes/02b8fe34a2b1826837bfa4e55aba887eded38440/nes-cpu.el:
     annotations:
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/google/auto/79c9d15c14a898e1ae2085f265a5396b190d7017/factory/src/test/resources/bad/FinalSupertype.java:
     annotations:
       human-smola: Java
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/google/digitalassetlinks/d893749ee3c84b31f72b552a7ed333789c3235d3/compatibility-tests/v1/4000-query-matching/4300-check-relation.pb:
     annotations:
       human-smola: Unknown
       linguist: PureBasic
+      linguist-extension: PureBasic
       vote: Unknown
   github.com/google/flexbox-layout/d6c186b18f432e65b97214cfe7843ce1d90e62e6/demo-playground/src/main/java/com/google/android/flexbox/FlexItemAdapter.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/google/grumpy/3ec87959189cfcdeae82eb68a47648ac25ceb10b/runtime/super.go:
     annotations:
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/google/iosched/4054aa3f8934b8b1208d5823fdbf531a8eb367af/shared/src/main/java/com/google/samples/apps/iosched/shared/domain/settings/GetAnalyticsSettingUseCase.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/google/jsonnet/cc28a8b4faec40eaa9aa22016d041a6230bd2bb2/case_studies/micromanage/lib/mmlib/v0.1.2/web/solutions.libsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/google/lisp-koans/46fb766618ccc2e10fb7ff398a653d10aeff0a23/koans/macros.lsp:
     annotations:
@@ -8077,75 +9948,94 @@ files:
   github.com/google/protobuf-gradle-plugin/8f78c0f220ace0d460c5320181aaf4a23e5eebf0/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy:
     annotations:
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/google/schism/7981382ae85deaca1c1400029bc7d8ac558c6d25/test/arithmetic-1.ss:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
       vote: Scheme
   github.com/google/yapf/126fc7eb85dec8fe34104ff15ed64c3a23c9534a/yapf/yapflib/identify_container.py:
     annotations:
       linguist: Python
+      linguist-extension: Python
       vote: Python
   github.com/googlehosts/hosts-ipv6/deebc8c196e2e1c1c05f8c027b15ab1abea40a5c/hosts-files/hosts.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/googollee/eviltransform/b911c066225716822e4a5b2cab475edcc6cf11a2/matlab/UTM/deg2utm.m:
     annotations:
       linguist: MATLAB
+      linguist-heuristics: MATLAB
       vote: MATLAB
   github.com/goonstation/goonstation-2016/73bce6a90ce513b6e7751a5b5d60b31836c54b73/code/obj/item/device/timer.dm:
     annotations:
       linguist: DM
+      linguist-extension: DM
       vote: DM
   github.com/gorden5566/padavan/b2a1527042b7ac50c7a8fad3f564c2b37b3568f6/trunk/user/www/n56u_ribbon_fixed/device-map/clients.asp:
     annotations:
       linguist: Classic ASP
+      linguist-extension: Classic ASP
       vote: Classic ASP
   github.com/goreliu/runz/3af89ede4e27541ff9cbc341c043e4f2ff373caa/Plugins/Kanji.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/gosu-lang/gosu-lang/78c5f6c839597a81ac5ec75a46259cbb6ad40545/gosu-test/src/test/gosu/gw/specContrib/generics/Errant_GenericMethodBounds2.gs:
     annotations:
       linguist: Gosu
+      linguist-heuristics: Gosu
       vote: Gosu
   github.com/gothinkster/elixir-phoenix-realworld-example-app/d550c27a33a633a1ff9c35d7fc92c3e06c0675bd/lib/real_world_web/controllers/session_controller.ex:
     annotations:
       linguist: Elixir
+      linguist-extension: Elixir
       vote: Elixir
   github.com/gracelang/minigrace/db1564417d1656f565740442951a9ede852345ab/intrinsic.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/gracelang/objectdraw/b0dfa1f1ae1b8f9f73e023ba6bfcb62a7de7501a/animation.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/gradle/gradle/9cdd5a6d6030de87dc947fec003d5e6ba8d9097d/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/IvySpecificComponentMetadataRulesIntegrationTest.groovy:
     annotations:
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/graemeg/freepascal/39b1a77b7d2937a7fd838f1de07c24c83aa5feb1/tests/webtbs/uw27522a.pp:
     annotations:
       linguist: Component Pascal
+      linguist-heuristics: Pascal
+      linguist-modeline: Component Pascal
       vote: Component Pascal
   github.com/grafana/grafana/54602f16a8b0feb35c873aa048aeda54d0bd927f/public/app/plugins/datasource/elasticsearch/metric_agg.ts:
     annotations:
       linguist: TypeScript
+      linguist-heuristics: TypeScript
       vote: TypeScript
   github.com/grafana/grafonnet-lib/b82411476842f583817e67feff5becf1228fd540/tests/graph_panel/test.jsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/grafana/jsonnet-libs/67ab3dc52f3cdbc3b29d30afd3261375b5ad13fd/prometheus-ksonnet/lib/prometheus-config.libsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/grahamrobbo/building_gateway_services/5d8e70e4118fe199549854c417f1d47f20269157/src/zcl_demo_mpc.clas.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/grain-lang/grain/e2151b78ea8da5afa94daefa647a13e2b8168f28/src/parsing/asttypes.ml:
     annotations:
@@ -8154,79 +10044,99 @@ files:
   github.com/grantrules/articles/79a0e641e2dc0ca4df16e921cce0a310206e2a7a/assets/templates/article.hb:
     annotations:
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Harbour
   github.com/grapefrukt/grapefrukt-export/7406dd75e51279d347b8fd26af834ab1b5b386e6/src/com/grapefrukt/exporter/events/FunctionQueueEvent.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/graphql/graphql-spec/e2a113256dc2aa2e87e1e760240998d938dceaa1/publish.sh:
     annotations:
       linguist: Shell
+      linguist-extension: Shell
+      linguist-shebang: Shell
       vote: Shell
   github.com/gravicappa/js-kl/d4de095f7cec122b0ec71b6e42a353538b9b6dd0/ffi.shen:
     annotations:
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/gravicappa/klvm/b7f851744a4acf66c9ee2d2418be10d9508a4b03/bytecode-bin.shen:
     annotations:
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/gravichandra/plumbagoAirlineFlights/6d3616181bbd6d87d7afc6158d9c6d10239267f0/plumbagoairlines/src/test/resources/sample_data/list_map_1.dwl:
     annotations:
       linguist: DataWeave
+      linguist-extension: DataWeave
       vote: DataWeave
   github.com/greensock/GreenSock-AS3/6019d64044fd5f466038c731cfda39301be02edf/src/com/greensock/plugins/VisiblePlugin.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/greerviau/SnakeAI/81f04a7670a8bf3887b105e9a72d91d779036d58/SnakeAI/Snake.pde:
     annotations:
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/greghendershott/frog/532f6cad6001ba5d5d426b3341524407ebb1b622/frog/private/enhance-body/add-doc-links/doc-uri.rkt:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/gregspurrier/shen-ruby/c20f507151338fd77c5f2dd2bdc6a1a557d3dbed/shen/release/test_programs/metaprog.shen:
     annotations:
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/group-facebook/Group-Facebook.Demo/bd2e61f71ff0ffc793631d60782781a8f8b33623/functions/main.fy:
     annotations:
       human-smola: Python
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Python
   github.com/grpc/grpc-go/2d2f65684c31db528091b6d8cbf81c3ac9e06084/interop/alts/server/server.go:
     annotations:
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/gruenerBogen/Serlo-Asymptote-Commons/f3eb1f463e06154d592f8deeb5f8105450b9cfc5/serlo.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/gsbDBI/ExperimentData/5dc392c3e4dd29ff644d9672befa74549e0ced14/Secrecy/RawData/clean_secrecy.do:
     annotations:
       linguist: Stata
+      linguist-extension: Stata
       vote: Stata
   github.com/gslab-econ/gslab_stata/e148ca63ae532fffc45121fdfe0d9b593f9bed29/gslab_misc/test/test_build_recode_template.do:
     annotations:
       linguist: Stata
+      linguist-extension: Stata
       vote: Stata
   github.com/gtaylormb/opl3_fpga/08764404f4991bf820fc57dc3b6761d34bad8bbf/fpga/bd/opl3_cpu/ipshared/xilinx.com/lib_cdc_v1_0/hdl/src/vhdl/cdc_sync.vhd:
     annotations:
       linguist: VHDL
+      linguist-extension: VHDL
       vote: VHDL
   github.com/guardian/grid/447b2e59983f7fab9bf01de6c6f0b5e3f18c7b80/leases/app/lib/LeaseStore.scala:
     annotations:
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/gugod/App-perlbrew/7c75d9cda01cf3000cda032464631f4b06d30fc0/t/command-info.t:
     annotations:
       linguist: Perl
+      linguist-heuristics: Perl
       vote: Perl
   github.com/guided-hacking/GuidedHacking-Injector/2e3765ad07e595fd3bd3748ebb6507919cc27802/GH Injector GUI/GUI.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/guillep/Scale/8590fcb02889bf5ea9d8e38a7dcf5f548dc656a1/src/ConfigurationOfScale.package/ConfigurationOfScale.class/class/ensureMetacelloBaseConfiguration.st:
     annotations:
@@ -8236,30 +10146,37 @@ files:
     annotations:
       human-smola: CUDA
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/guzzle/guzzle/df36d8dae3979cf927d5bbbed6f0427f39aadfec/tests/ClientTest.php:
     annotations:
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/gvanhavre/ArcheoBM/56436539562b2e054c413654fb072f72aafa4d62/Sampling_v0.1.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/gvegayon/parallel/e8de0a9d1d9c14a38f5685c284e6c68378c55d9d/test files/test_aux_out.do:
     annotations:
       linguist: Stata
+      linguist-extension: Stata
       vote: Stata
   github.com/gxchain/gxb-core/f718d2f3be77f19430bbc56cc6c83274a7f7b52a/libraries/wasm-jit/Test/spec/br_table.wast:
     annotations:
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/h2non/nar/e190d9db00b574f91fd07bc2f6f1639b78f32548/src/install.ls:
     annotations:
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/h2non/siringa/c65b7aeb806e4eb5adb6f52180d4484b407f57a6/siringa/macros.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
       vote: Hy
   github.com/h31h31/H31DHTMgr/e1085dafd23fedfaddeb39c4c61707db8b3a24f9/MainForm.cs:
     annotations:
@@ -8269,72 +10186,90 @@ files:
   github.com/h4cc/awesome-elixir/db02b06ba95c1a623be212cb7effa8e518908488/tests/mix.lock:
     annotations:
       linguist: Elixir
+      linguist-filename: Elixir
       vote: Elixir
   github.com/hacchy1983/CWL-workflows/81f0de7c39c54830ce7ed3dec8d747b9a05bb09e/Tools/bwa-index.cwl:
     annotations:
       linguist: Common Workflow Language
+      linguist-extension: Common Workflow Language
+      linguist-shebang: Common Workflow Language
       vote: Common Workflow Language
   github.com/hachikuji/kafka-specification/0a6adeab002de88016d095b0dbbf4f4b067dda76/Kip320.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/hachiojipm/awesome-perl/d3dcc015bb6a50b717613aa17c779f68a2e68a28/t/format.t:
     annotations:
       linguist: Perl
+      linguist-heuristics: Perl
       vote: Perl
   github.com/hackfoldr/hackfoldr/b3c0cb2bcbda030a5a0c30b470abd10d7a524d0d/test/karma.conf.ls:
     annotations:
       human-smola: LiveScript
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/hackiftekhar/IQKeyboardManager/a911a481b9a031ea6ec949030871cbb851d01111/DemoObjCUITests/DemoObjCUITests.m:
     annotations:
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/hadley/r4ds/ce824d0a33149b34c7b1cacabf8636e132970592/contributors.R:
     annotations:
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/hadrizia/ProjetoAlloy/a9a273abebfb7f0ea8926f9950c42c184839b9e4/Dropbox.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/haetze/DemoLFE/be8c3364566b6bfff63d1b2b65b5366f4950b6e7/rpn.lfe:
     annotations:
       linguist: LFE
+      linguist-extension: LFE
       vote: LFE
   github.com/haggi/OpenMaya/746e0740f480d9ef8d2173f31b3c99b9b0ea0d24/src/mayaToCorona/mayaToCoronaExamples/scenes/simpleShadingNetwork.ma:
     annotations:
       human-smola: Unknown
       linguist: Wolfram Language
+      linguist-extension: Wolfram Language
       vote: Unknown
   github.com/hakank/hakank/fc6ba6444041981c442db4fdddd1bbeb243e5a33/swi_prolog/magic_hexagon.pl:
     annotations:
       linguist: Prolog
+      linguist-heuristics: Prolog
       vote: Prolog
   github.com/hakatashi/kindlegen/0ae251831541b7d51ad60ae8c6571d3d3be05911/index.ls:
     annotations:
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/halirutan/Mathematica-Source-Highlighting/3f9ec387b0a975e580263594acf0fc47bbe88285/resources/NamedCharacters.m:
     annotations:
       linguist: Wolfram Language
+      linguist-heuristics: Wolfram Language
       vote: Wolfram Language
   github.com/halvards/addition-dogescript/03baf3e65ba8eeda3987195088360ce25d3504f9/add.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/hamsternz/FPGA_Webserver/5cd8b05b0a1453a2b57a532a9bcb87a938c50f2e/testbenches/tb_FPGA_webserver.vhd:
     annotations:
       linguist: VHDL
+      linguist-extension: VHDL
       vote: VHDL
   github.com/hankcs/HanLP/12ccffcfe98ba5a81b3101e6adfd804e7099df9b/src/main/java/com/hankcs/hanlp/tokenizer/pipe/LexicalAnalyzerPipe.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/happi/theBeamBook/cf7a4374e7ddbb4a222a6d1e31ab3c935d4d8e52/code/book/src/generate_op_doc.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
       vote: Erlang
   github.com/happynear/AMSoftmax/f57f7a7f4c5c05de095a8c825da3055a6ae21f9e/draw/draw_psi_curve.m:
     annotations:
@@ -8348,34 +10283,42 @@ files:
   github.com/haruyama/CTMCP/d826745f84b8e20b22fc2eb53ea70995030a11db/chap08ex.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/haxiomic/GPU-Fluid-Experiments/20210bd9e64884146a73e6cedc0c696ca50bd0fd/Source/GPUFluid.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/hbbio/opa-tutorial/1ae42fe14529fcf78134be287ef6d0723bef5562/step05.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/hbbio/webshell/99b67c7c0a866e779bb49064981caffeabdaa5e4/src/webshell.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/hchbaw/swank-arc/721831aeec3db248976b75f84b86c04adff38195/swank.arc:
     annotations:
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/hclivess/Bismuth/a296d8da327a24dffc91453a4592685043297405/nuitka/lib/tcl8/8.6/http-2.8.12.tm:
     annotations:
       linguist: Tcl
+      linguist-extension: Tcl
       vote: Tcl
   github.com/hdima/python-syntax/69760cb3accce488cc072772ca918ac2cbf384ba/syntax/python.vim:
     annotations:
       linguist: Vim script
+      linguist-extension: Vim script
       vote: Vim script
   github.com/hecrj/composable-form/a3091d5cac9ec4578e9968b9538e310a20ac15d6/src/Form/Error.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/hectorm/hblock-resolver/97570e4f0ede431027758d1d87918c13bb3c6fe4/Dockerfile.m4:
     annotations:
@@ -8384,6 +10327,7 @@ files:
   github.com/heddwch/WOPO/22de00773352049da589fcb6cd0e4c5607728443/IRC-MSG.COB:
     annotations:
       linguist: COBOL
+      linguist-extension: COBOL
       vote: COBOL
   github.com/henesy/cdc-limbo/e81b500b9f3c9a7504de87e9a28807e21e575040/util.b:
     annotations:
@@ -8396,163 +10340,203 @@ files:
   github.com/hephaestus9/Power_Monitor/3852f9f6993b6d9ce14c6f92602f10bf7407e8ec/v2/AmpAndRHT_IMP/Device.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/hercules-team/augeas-do-not-use/f0757b34efc67861f2d33d76d8f7283eab54ca8b/lenses/passwd.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
       vote: Augeas
   github.com/hercules-team/augeas/686e32fc1016a3e8ec68c0e354ba0ea3d663fab4/lenses/tests/test_pylonspaste.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
       vote: Augeas
   github.com/heuermh/lick/a81ff2a7db409bd0985f6b40f79081502bdb31df/lick/effect/FullDouble.ck:
     annotations:
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/hgourvest/superobject/f1c42db5efbd85ced7acaf8d53c204881fce5fad/tests/test_rpc.dpr:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/hhvm/hack-codegen/df42dc9fe2bb6bf15ffb482637238d8378a7e4a7/src/key-value-render/HackBuilderNativeKeyValueCollectionRenderer.hack:
     annotations:
       human-smola: Hack
       linguist: Hack
+      linguist-extension: Hack
       vote: Hack
   github.com/hhvm/hack-router-codegen/5e27d886eda88700bdffdd76c7a26982a53d7209/src/uriparameters/spec/SimpleParameterCodegenSpec.hack:
     annotations:
       linguist: Hack
+      linguist-extension: Hack
       vote: Hack
   github.com/hhvm/hack-router/2b723b39682b0531914772c600d1442dc1320d2f/tests/UriBuilderTest.php:
     annotations:
       linguist: Hack
+      linguist-heuristics: Hack
       vote: Hack
   github.com/hhvm/hh-clilib/e7a482b6ef82482bbd83eb86853a5b45f7830324/src/TestLib/StringInput.hack:
     annotations:
       linguist: Hack
+      linguist-extension: Hack
       vote: Hack
   github.com/hhvm/user-documentation/9a9e2489b354eafe55b69dabae1e57a7e9389ec8/src/site/controllers/codegen/LegacyRedirectControllerParameters.php:
     annotations:
       linguist: Hack
+      linguist-heuristics: Hack
       vote: Hack
   github.com/hhvm/xhp-js/14db7c56dc0070f11ca878a60dca06522d051e90/src/XHPJSCall.php:
     annotations:
       linguist: Hack
+      linguist-heuristics: Hack
       vote: Hack
   github.com/hhvm/xhp-lib/41cb2eb73d4523a10628bc95e8550ecb880e7214/src/html/tags/c/ConditionalComment.php:
     annotations:
       linguist: Hack
+      linguist-heuristics: Hack
       vote: Hack
   github.com/hilanmiao/NSIS-UI/d3ec4cba0f6a30073fb966420af035fd7fc64a2d/Niuniu_NSIS_SetupSkin/NSIS/Contrib/Language files/Russian.nsh:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/himynameisdave/stardown/ee85666e1435ca7a6fb1899cb8759796f3a2bf97/src/app.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/historicalsource/arthur/0f40a557e944c985c7b7c263798c5cbf70847e37/narthur.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/ballyhoo/9f779e8025e6fcc0b192d7d39dfc953d029d8744/record.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/borderzone/5c80126798adc8c683ff7e03468b284cacb7f5ea/realtime.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/bureaucracy/8907a9fa3a95b009f4676c60b18daec47871d21c/macros.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/deadline/2602bd50e81e41f731de179f2615e62a3a0d774c/dungeon.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/hitchhikersguide/128885503222367dea5cfed81af3ffeeafd173e4/parser.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/hollywoodhijinx/e93d08596db4297d46f3ac0065a546d27f036e74/hijinx.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/infidel/dca8235af85e3d69bd49119cade8fff5ac8eb271/parser.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/leathergoddesses-gold/2b1e08565565f6ad95f6714fd8e0991e6c0e9cc5/phobos.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/lurkinghorror/51d806017f4cc630ede28ca4d92b9c7e9b9f0361/frob.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/nordandbert/91bb67cfcd96b1bfab0fb3a2d0c5d43557ac350b/syntax.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/spellbreaker/6f83ba4c285d665362bbcd254cc52852d848803a/guild.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/starcross/3ceaa9f206b8bc6422e95b5ae7fe257fc123d38f/dungeon.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/suspended/ce4b8edf322227593bb8bb96b9f693ee7fb169ac/globals.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/trinity/16a024ce6bc5b9da85f42e65d7f9fd93b32c808c/macros.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/wishbringer/e46c2ed7467cb98c59e6738f7ef8b897bfcbf7fd/boxes.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/zork/70d16c9c817bc19f393d4f6b42bd59c1b2a8d528/act1.mud:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/zork1-gold/89aea22aaea5be5fccae5296a7b8daf388281793/globals.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/zork1/7d54d16fca7a5dd7c6191c93651aad925f8c0922/gclock.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/historicalsource/zork3/8c30cac360669eca32177a509a4b18448135aac8/verbs.zil:
     annotations:
       linguist: ZIL
+      linguist-extension: ZIL
       vote: ZIL
   github.com/hlissner/doom-snippets/eb26256fe90162912d057ea2a175189aca56f13f/emacs-lisp-mode/x-find-replace:
     annotations:
       linguist: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/hmaesta/simplect-email-template/58942b86c52889844484c2b5f698282bec75aaed/kit/email.kit:
     annotations:
       linguist: Kit
+      linguist-extension: Kit
       vote: Kit
   github.com/hoglet67/AtomBusMon/975ba22848740305a4e106483e7d5fe211f45583/src/AVR8/JTAG_OCD_Prg/JTAGPack.vhd:
     annotations:
       linguist: VHDL
+      linguist-extension: VHDL
       vote: VHDL
   github.com/holgern/sciflt/7df5b8ed173f46093aaa0ffd4ccf5c65d7ff64c3/macros/fcmeans.sci:
     annotations:
       linguist: Scilab
+      linguist-extension: Scilab
       vote: Scilab
   github.com/hollasch/ray4/53a365f3ab6de83e8975e1b1c09d886563502ff0/thesis/PostScript/figures/fig47b.ps:
     annotations:
       linguist: PostScript
+      linguist-extension: PostScript
       vote: PostScript
   github.com/homalg-project/CAP_project/4f958e0b87323bfdc7f47411b88bc683e2253073/ActionsForCAP/gap/CoactionObjects.gi:
     annotations:
       linguist: GAP
+      linguist-extension: GAP
       vote: GAP
   github.com/hominlinx/vim/3308379e70697fb02cff51a17681994f3ebb01cc/vimrc.b:
     annotations:
@@ -8562,35 +10546,45 @@ files:
   github.com/honix/Redraw/7df3ef17886664e58e56cd8b82cc8995dadbfe9d/canvas.red:
     annotations:
       linguist: Red
+      linguist-extension: Red
       vote: Red
   github.com/hoomi/PhotoView_SamsungSmartTv/436e1cb9e5becf28f74a4b7f2c85af8c5898b44f/layout/Scene1.kit:
     annotations:
       linguist: Kit
+      linguist-extension: Kit
+      linguist-xml: XML
       vote: Kit
   github.com/hoosierEE/j/935ece17d78f3936e43118637d970a7d5244fea9/interesting/parens.ijs:
     annotations:
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/hoplon/hoplon/511af8da1deb4f7ec95327f67be9a04c69083bb6/src/hoplon/boot_hoplon.clj:
     annotations:
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/horazont/xmpp-echo-bot/4648d3cd247e89c83829e38009a352f94b0b672d/echoz.sed:
     annotations:
       linguist: sed
+      linguist-extension: sed
+      linguist-shebang: sed
       vote: sed
   github.com/horgh/twitter-tcl/caca55ad90a3282202b831c195636cc5321780f3/twitoauth.tcl:
     annotations:
       linguist: Tcl
+      linguist-extension: Tcl
       vote: Tcl
   github.com/hostilefork/rebmu/f4c94b2a2262f871100fe0c29d6eb8b1b8b4f243/unmush.reb:
     annotations:
       human-smola: Rebol
       linguist: Rebol
+      linguist-extension: Rebol
       vote: Rebol
   github.com/hostilefork/whitespacers/66dd80e214ecf39f8ae7db4975f6552e67754679/rebol/whitespace.reb:
     annotations:
       linguist: Rebol
+      linguist-extension: Rebol
       vote: Rebol
   github.com/howardthomson/gobo-guide-2/a4e853ffd42edabb025a98ef8c9fce41eac5f594/library/lexical/error/lx_incomplete_name_definition_error.e:
     annotations:
@@ -8599,63 +10593,78 @@ files:
   github.com/hpcc-systems/DataPatterns/be9bbbd84692bb3dd47e80caa09fc06dd26c35d7/BestRecordStructure.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/hpcc-systems/ECL-WLAM/00c5fe22fdb44acc45b189190e0455d875793f16/WLAM/WebLogs/IPToCountry.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/hpcc-systems/KMeans/7d0a130fab1cc395900321ae3123a71ebb8f347c/Test/Validation/KMeansValidate.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/hpcc-systems/LogisticRegression/173dfcef1a048852d32076e830dc1eaea93f92fb/Types.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/hpcc-systems/ML_Core/4a15297517a8c2c94e7f5b48cb74e08d7458af10/Tests/test_ModelOps2.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/hpcc-systems/PBblas/f95a5a52cee68f20e2702f3254d93c1fea6a6a73/test/tran.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/hpcc-systems/Solutions-ECL-Demos/00276b99761ae97c85aec987eca9694c995919da/Taxi/Util.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/hpcc-systems/Solutions-ECL-Training/6a2513dc28c598250739a76b5bcd785010977cbe/Taxi_Tutorial/Taxi/09_GLM_Model_Job.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/hpcc-systems/SupportVectorMachines/6a255863860cac9afbacefe2612d437383b3efeb/Performance/PerformanceMyriad_Prep.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/hpcc-systems/Visualizer/8cca6308119604e7f274e768d0049baa219ea651/tutorial/Step01b.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/hpcc-systems/ecl-samples/22bd0613ee139bfd1221883aabb159fed76867c6/MLUsageExamples/Mat/Has/Use_ML.Mat.Has.Stats0.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/hpd/DigitalEmily/8bb2583fb41e40c58ee2da8bb7988732e2031624/maya/scenes/Emily_2_1_Lightstage_Cameras_Animated.ma:
     annotations:
       human-smola: Unknown
       linguist: Wolfram Language
+      linguist-extension: Wolfram Language
       vote: Unknown
   github.com/hq450/fancyss/735a6439a8b69cbef76ec527fd0205b398c86a02/fancyss_hnd/shadowsocks/webs/Module_shadowsocks_local.asp:
     annotations:
       linguist: Classic ASP
+      linguist-extension: Classic ASP
       vote: Classic ASP
   github.com/hs-web/hsweb-demo/cae347fe74c1a6c8227f3d00c92353261f300342/src/main/resources/templates/admin/index.ftl:
     annotations:
       linguist: FreeMarker
+      linguist-extension: FreeMarker
       vote: FreeMarker
   github.com/hsluv/hsluv/04a757f09d5dd8d4f30643cd5eeb55e5daa17f1a/haxe/src/hsluv/Geometry.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/hsoft/collapseos/69daf49920c77821c78b747bb59ea5e3ad0409ac/apps/zasm/util.asm:
     annotations:
@@ -8664,36 +10673,44 @@ files:
   github.com/hszhao/ICNet/b6bd088016164b8986a35ec2ca8463adb97c8061/evaluation/evaluationCode/pixelAccuracy.m:
     annotations:
       linguist: MATLAB
+      linguist-heuristics: MATLAB
       vote: MATLAB
   github.com/huangpujj/cs492_final/a5ad77bc454b67648a6f64325433702e6c0e30a7/test.q:
     annotations:
       human-smola: SQL
       linguist: HiveQL
+      linguist-heuristics: HiveQL
       vote: SQL
   github.com/huangyz0918/TankLogo/44704c398f6a5c1f1bc28d440ceb9690be4e34cb/TankLogo.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/huangz1990/SICP-answers/15e3475003ef10eb738cf93c1932277bc56bacbe/chp2/code/test-manager/mit-scheme-tests.scm:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
       vote: Scheme
   github.com/huextrat/TheGorgeousLogin/ae38af70f36a25bfb78854124382087ba3cf5c46/lib/utils/bubble_indication_painter.dart:
     annotations:
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/hughperkins/coriander/6e69b98df07a7330ab8fc32dfb9f21290619c09f/test/tf/split_lib_gpu-device.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/huginn/huginn/51a0ca9ad3f8413939244451337398c9ac915e7f/spec/controllers/admin/users_controller_spec.rb:
     annotations:
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/hugohiram/OrientDB-Extension/e9b4737e6dfd7501cb3278f34ab50ad89569b9fa/orientdb/DBReload.zep:
     annotations:
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/hugopeixoto/mergesort/6f621dba1831f48ba76d5630728337ab9ad89ddf/brainfuck/mergesort.bf:
     annotations:
@@ -8702,14 +10719,17 @@ files:
   github.com/hugs/tapsterbot/223ad7f289977c99de46f212d672cd4970ad5d36/hardware/tapster-2-plus/scad/top.scad:
     annotations:
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/hui-Zz/RunAny/26f2e0a6783bb07f1b4df20464d5bccc0db8d224/RunPlugins/RunAny_ObjReg.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/hujie-frank/SENet/0262d43d44c561fd53c3dba210cc8bacfc60500d/src/caffe/layers/axpy_layer.cu:
     annotations:
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/hustkisas/UC-Model-AMPL/c603dcbfcab6ec34a6671a319e875b0bd9dc1a69/3375BUS/uc_model-new.mod:
     annotations:
@@ -8719,39 +10739,48 @@ files:
     annotations:
       human-smola: Unknown
       linguist: Factor
+      linguist-extension: Factor
       vote: Unknown
   github.com/huytd/kanelm/99b1d858e8abe18f54adb55a14f3c6cbf3629286/src/Views.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/hwayne/tla-snippets/6fbaee8b411f5444319dfea036c55bc33c3c580c/snippets/sets.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/hww3/pike_modules-public_soap/434f614cded9649d0d5dcaa6a7714ba30d522ae5/module.pmod.in/Encoding.pmod/Boolean.pike:
     annotations:
       linguist: Pike
+      linguist-extension: Pike
       vote: Pike
   github.com/hww3/pike_modules-public_standards_rfc3339/197d40ed3f52b5bf1665e4e2e36cbd8dbfb724a6/upload_module_version.pike:
     annotations:
       linguist: Pike
+      linguist-extension: Pike
       vote: Pike
   github.com/hylang/hydiomatic/a53ca9d808bee419aa092f280f4b91f258f248b9/hydiomatic/rulesets/warningso.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
       vote: Hy
   github.com/hylent/nc/8baf6a53af2593ea8856792704b7f2bf62ea0190/nc/image/imagick.zep:
     annotations:
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/hyperledger/fabric/1ac3f05847279f87da5daf81415a02b89048c2e9/common/grpcmetrics/metrics.go:
     annotations:
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/hzlmn/haskell-must-watch/37fd6cde1a5a642eff618f56897006149fd5f08f/README.md:
     annotations:
       human-smola: Markdown
       linguist: Haskell
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/ianan/demreg/084fb37c75c8303d00f1222a78909cd02dda5914/util/example_making_eps_out.pro:
     annotations:
@@ -8761,31 +10790,38 @@ files:
   github.com/ianfitzpatrick/popuparcade/08e084fa7048d70bdf95d073ac09b2d4585e4501/.attract/layouts/popuparcade/layout.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/iani/tiny-sc/e0bdafe43a8840920a3157d35179c997c4010ae8/Classes/SynthPlayer/Notes/EventPattern.scd:
     annotations:
       human-smola: SuperCollider
       linguist: SuperCollider
+      linguist-extension: SuperCollider
       vote: SuperCollider
   github.com/ibireme/YYKit/4e1bd1cfcdb3331244b219cbd37cc9b1ccb62b7a/YYKit/Utility/YYThreadSafeArray.h:
     annotations:
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/ibmdbbdev/Samples/61a1a20f495203bdb16d4c74a5a076f4fbfc379b/MortgageApplication/cobol/epsmpmt.cbl:
     annotations:
       linguist: COBOL
+      linguist-extension: COBOL
       vote: COBOL
   github.com/icarroll/glyphic/c7faa4d40d953c38e5b3a17b99bc935629100155/water.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/icatalin201/MedicalExpert/47c0e375d3232c6866359b6578a94c9c6df15458/digestiv.clp:
     annotations:
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: CLIPS
   github.com/ice-lang/coldice/9059d06c644bf8b7b7ea5051c548e3ae7b8ce594/IceObject.ice:
     annotations:
       linguist: Slice
+      linguist-heuristics: Slice
       vote: Slice
   github.com/icecapped/ICS2O7/9dffb1fc31d9a03f113d947ab18b6c6f323748ce/October 10th/Assignment5-13.t:
     annotations:
@@ -8794,10 +10830,12 @@ files:
   github.com/id774/scripts/0d1996da7f5c1eeaac07a72e76dc8e91ecb2987f/dot_files/dot_vim/plugin/rainbow_csv.vim:
     annotations:
       linguist: Vim script
+      linguist-extension: Vim script
       vote: Vim script
   github.com/idelsink/qtcreator_sub_dir_example/38f099015a30ff5d63efd04bbe6e4eadafd6cffb/SubTestProject/common.pri:
     annotations:
       linguist: QMake
+      linguist-extension: QMake
       vote: QMake
   github.com/idl-coyote/catalyst/778d0c36f5cd2e848415dd1e9ed1e5860b2dd71b/source/core/catlayer__define.pro:
     annotations:
@@ -8810,139 +10848,172 @@ files:
   github.com/idris-hackers/idris-demos/356a5aa1dbd43f869b0eebd8b8fec15f790cc0dc/Invaders/Starfield.idr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/idris-hackers/idris-koans/23d335932456db74392be03b3750ba2c3ce09b87/Koans/08-HigherOrderFunctions.idr:
     annotations:
       human-smola: Idris
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/idris-hackers/software-foundations/03e178fc616e50019c4168fb488f67fbfb46fafa/src/Tactics.lidr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/idris-industry/ikan/31c326dc441d26da847be80afde297e35a4306db/src/Main.idr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/idrougge/ShapesInfo/b185ef5249cea4bcfea95cbab7cc851d5cd1940d/ShapesInfo.rexx:
     annotations:
       linguist: REXX
+      linguist-extension: REXX
       vote: REXX
   github.com/igler/ESProNa/4245a710ce2aa87dbf7606856091b6074a2336d3/contributions/debug/hooks.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/igor-liferenko/goweb/30cc8ae8821203f2c46ebc0bbb649f7567cbcb40/gocommon.w:
     annotations:
       linguist: CWeb
+      linguist-heuristics: CWeb
       vote: CWeb
   github.com/igorw/reasoned-php/d84eaee1894b03e1d4d425fce1d71fa683d07e1e/clause-and-effect/28-linearising-efficiently.php:
     annotations:
       human-ajnavarro: Hack
       linguist: Hack
+      linguist-heuristics: Hack
       vote: Hack
   github.com/igorwfaoro/keyboard-autocomplete/4117bb813d46ad85f8aa4c1f16ba7f5695731822/data - Copia/keys.ik:
     annotations:
       human-smola: Unknown
       linguist: Ioke
+      linguist-extension: Ioke
       vote: Unknown
   github.com/igromanru/Dark-Souls-III-Cheat-Engine-Guide/826f1beb45637f57373c44208584977367cfe905/AutoUpdater/DS3_Table_AutoUpdater.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/iguana-parser/grammars/d001f904037f7b16da2ca9c1ded9fb0155c2195f/src/scala/specification/XML.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/iina/iina/4720a9e2fc1eabc70ecb87fd8db547bc3998a858/iina/FontPickerWindowController.swift:
     annotations:
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/illuspas/nginx-rtmp-win32/e6ff80e0b8673514541e34a4846ff4d59d330267/html/stat.xsl:
     annotations:
       linguist: XSLT
+      linguist-extension: XSLT
+      linguist-xml: XML
       vote: XSLT
   github.com/iluwatar/java-design-patterns/50986fa15b312d95e86717259bafca7aeaddf1e8/flux/src/test/java/com/iluwatar/flux/view/ContentViewTest.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/im-tomu/tomu-hardware/10878e4cca6baaf682bfb324b2a22bd5c8029819/releases/v0.4.6/pannelized/tomu-drl_map.ps:
     annotations:
       linguist: PostScript
+      linguist-extension: PostScript
       vote: PostScript
   github.com/impress/impress.js/d5bbbc40aef1f30eeda3b7a94023b172a456ea59/src/plugins/navigation/navigation_tests.js:
     annotations:
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/imshuhao/ICS3U1/a2a10e9ec78ea696fc7512021bb56f846f96295e/Final Project/Sudoku/Main.t:
     annotations:
       linguist: Turing
+      linguist-heuristics: Turing
       vote: Turing
   github.com/imsys/JSON-ADVPL/c91040a2a382824371c72533db1c54f2a5731983/lib/SHash.prg:
     annotations:
       human-smola: xBase
       linguist: xBase
+      linguist-extension: xBase
       vote: xBase
   github.com/imsys/Protheus-Include/7b56abf9727694f6d91eb3e0be42104d184a1f83/include/olecont.ch:
     annotations:
       human-smola: xBase
       linguist: xBase
+      linguist-heuristics: xBase
       vote: xBase
   github.com/imurray/chol-rev/35aa4ac441b4a639fc26b6de0b106505fbbd1295/dpo2ft_ilp64.f:
     annotations:
       linguist: Fortran
+      linguist-heuristics: Fortran
       vote: Fortran
   github.com/influxdata/influxdb/bb6aa1df3bef661353961814dc75b6719d0f9c9c/tsdb/tsm1/batch_integer.go:
     annotations:
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/infusion/jQuery-webcam/f9689f93069074b39d3d5bf31bffc44263eb59ca/src/JPGEncoder.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/ingbyr/VDM/f2e8a30e6ea10e1fa56fb0ed9e97dea7e1152502/src/main/kotlin/com/ingbyr/vdm/engines/utils/EngineFactory.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/ingen-lab/Ruth/12f4f0b55f916e1766efad0a0febed17018fd276/LSLScripts/HUD/Ruth/Mike Dickson/r2_body_receiver.lsl:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
       vote: LSL
   github.com/inlife/squirrel-orm/721bfdc2a85f2b949ad9b735cf822d69c23510b6/index.nut:
     annotations:
       human-smola: Squirrel
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/innotop/innotop/935e1df8d105fc44c674395cb5dd1e5f6c6e7dc3/Makefile.PL:
     annotations:
       human-smola: Perl
       linguist: Perl
+      linguist-filename: Perl
       vote: Perl
   github.com/input-output-hk/cardano-sl/2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0/networking/src/Node/Message/Decoder.hs:
     annotations:
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/input-output-hk/iohk-ops/9bee7e217286e71e22eaba10e1d44109116cc726/nix-darwin/modules/double-builder-gc.nix:
     annotations:
       linguist: Nix
+      linguist-extension: Nix
       vote: Nix
   github.com/intel/sawr/a1b033f72a56ad467c4505677cc03886932a226f/sawr_hardware/Models/frame.scad:
     annotations:
       human-smola: OpenSCAD
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/intellij-rust/intellij-rust/a78b0fd293b52f9b1c7c6ad093f3393b20d11af9/src/test/kotlin/org/rust/ide/intentions/RemoveDbgIntentionTest.kt:
     annotations:
       human-smola: Kotlin
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/io-core/io/f430c763c0d61f6e9cf0457ba540a78642c7ecb3/core/Draw/GraphTool.Mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/io-extra/Score/8508d12ce1f3a2e0485d47fba46e67bfb2c558e4/Tabs.Mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/iolivia/fizzbuzz/41b9bcad4fbbc0be547c1e09638e6d53682c2aaa/fizzbuzz.bf:
     annotations:
@@ -8955,103 +11026,127 @@ files:
   github.com/iotauth/security_analysis/bb402ea8210a21935246593d704f485f69aab95a/model/Analysis.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/ipader/SwiftGuide/a47e4836436870bd34c1323827b3688f11f2727e/other/VirtualGS/GSwift-2/Demo/LoresView.swift:
     annotations:
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/ipfs/go-ipfs/b3aa7706b22343ff93fe34efb4a086eed521f05b/core/node/libp2p/host.go:
     annotations:
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/irr/nit-labs/a156b9a6bd1edef798b8e5bfc26017b5762319ec/wg.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   github.com/isaacphysics/inequality-grammar/43b111270d9e956769d88a0806311bdae285244c/assets/grammar.ne:
     annotations:
       linguist: Nearley
+      linguist-extension: Nearley
       vote: Nearley
   github.com/isaacspa8180/ds730/1fd61857d8bfcdf7190d47c46232f69c9b9d671f/a5/baseball.q:
     annotations:
       linguist: HiveQL
+      linguist-heuristics: HiveQL
       vote: HiveQL
   github.com/isabelangelo/mcfost/a5fa2d134db90e5c999ef91ece10b503b0817473/seds/reduced_seds/SSTTAUJ042021.4+281349_reduced.sed:
     annotations:
       human-smola: Unknown
       linguist: sed
+      linguist-extension: sed
       vote: Unknown
   github.com/ishoshani/GraceLogo/03ac60d730407f58cbdcf6ca9c1191a22843f463/logoTests.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/istoony/Power-EnJoy/735c3b3b41ff1b5b7d145ccd74d95c2b841d4272/RELEASE/RASD/alloy - final.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/isu-enterprise/icc.xmitransform/ae801e6f81d91eca553ca5ec4e2ce9a7fdea21e1/lgt/samples/trans.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/italosanntoss/exercicio-pilha/02e1ad3c3c02d7daaeb12b438ea3b9a7d9ea36a7/questao3.fy:
     annotations:
       human-ajnavarro: Python
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Python
   github.com/itsFrank/MinecraftHDL/ae4c632ab695437e387eb4830f598a348bf401df/verilog/windows/autoyosys/share/ice40/brams_init3.vh:
     annotations:
       human-smola: SystemVerilog
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/ivanboring/Drupal-Zephir/8687366577e880e2035c68bef1331aaa431174a4/scripts/drupal/drupal/bootstrap.zep:
     annotations:
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/ivanjovanovic/sicp/a3bfbae0a0bda414b042e16bbb39bf39cd3c38f8/2.2/e-2.18.scm:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
       vote: Scheme
   github.com/iznogod/OSJH/bc623d2986f7e73dddcbcaf5a9f3baa36ee25955/maps/mp/mp_the_extreme_v2.gsx:
     annotations:
       linguist: Gosu
+      linguist-extension: Gosu
       vote: Gosu
   github.com/j-a-zimmer/OSSM-Go-Playing-Program/03f6ad38916780794845f73942ef2bf25ffeb6a0/GuiBoard.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/jClarity/slow-crud-app/21300d07c15fd7446b9a68177b54f20a18aac6f7/auth-service/src/main/java/com/jclarity/auth/domain/WebUser_Roo_Jpa_ActiveRecord.aj:
     annotations:
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/jacob404/promod/b74d2ed303db2b5cc7395c5a7a3cf5086a0f06df/Fresh Install/scripts/vscripts/l4d2_darkblood02_engine_tank_helper_2_promod.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/jaggerestep/ColonialMarines/412cbc82e6b59db925770479771968afb7e026a5/code/game/machinery/computer/skills.dm:
     annotations:
       linguist: DM
+      linguist-extension: DM
       vote: DM
   github.com/jakubroztocil/httpie/fc497daf7d9a7c9eec1896fad6037c6e861d38d5/tests/test_config.py:
     annotations:
       linguist: Python
+      linguist-extension: Python
       vote: Python
   github.com/james101c/kafka-blend/a4045436cb16740a4825828a3c28d5ec8a230965/data/datatourney/development/tourney/200110/pdb/pdb.LOL:
     annotations:
       human-smola: Unknown
       linguist: LOLCODE
+      linguist-extension: LOLCODE
       vote: Unknown
   github.com/jamesbowman/j1/911439641c002a8f7a6e306ce1b1d3fd4b389fd6/toolchain/basewords.fs:
     annotations:
       linguist: Forth
+      linguist-heuristics: Forth
       vote: Forth
   github.com/jamesbowman/swapforth/b16c92c16e897cb6d38f170d6a69089a0b36aca0/common/string.fs:
     annotations:
       linguist: Forth
+      linguist-heuristics: Forth
       vote: Forth
   github.com/jameshaydon/smproc/d816ad7db67affae634a854a9550d4b90206db6d/src/Examples.idr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/jameshegarty/darkroom/ffc3bf21fa008d280bdfd00661ba88caafa7fab7/darkroom.t:
     annotations:
@@ -9061,36 +11156,44 @@ files:
     annotations:
       human-smola: Tcl
       linguist: Tcl
+      linguist-extension: Tcl
       vote: Tcl
   github.com/jamesra/OrdersAI/af2acb2ae9f5b1830200c4ef6fdc4213b10d509f/info.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/jamessan/vim-gnupg/f663d0e857bd88cb39c16ca45c37a27488648562/autoload/gnupg.vim:
     annotations:
       linguist: Vim script
+      linguist-extension: Vim script
       vote: Vim script
   github.com/jamieowen/glsl-blend/3c5fc9377ec493f6ac479ba1aa74dd27dfe0334d/source/PhotoshopMathFP.glsl:
     annotations:
       linguist: GLSL
+      linguist-extension: GLSL
       vote: GLSL
   github.com/jamshark70/hadron/93eff9a100097fd309ac7904e4a63b2141c9ee61/Hadron/HadronModTargetControl.sc:
     annotations:
       human-smola: SuperCollider
       linguist: SuperCollider
+      linguist-heuristics: SuperCollider
       vote: SuperCollider
   github.com/jan-kaspar/proton_reconstruction_validation/43dd00dec7214118cecd98a6176b9a77ae87ce94/plots/templates/th_y/th_y_RMS_vs_xi_cmp_fill.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/jan-kaspar/proton_simulation_validation/251c2741484148fadd97a8c11a2d76a6bfedea6c/plots/settings_2016_preTS2.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/janverschelde/PHCpack/2666077c7461478d61ddaf87cb713fe5d569e7ff/src/Ada/Math_Lib/Matrices/varbprec_matrix_conversions.ads:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/japhb/perl6-bench/89d9cadbcd568e05417b0b8e70cc99bb3e06bc13/microbenchmarks.pl:
     annotations:
@@ -9100,11 +11203,13 @@ files:
   github.com/jarchuleta/node_instagram/54e18d690696a9dda2162ced833af2ece250a444/views/login.hb:
     annotations:
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Harbour
   github.com/jaredpalmer/formik/5553720b5d6c9729cb3b12fd7948f28ad3be9adc/test/Field.test.tsx:
     annotations:
       linguist: TypeScript
-      vote: TypeScript
+      linguist-heuristics: TSX
+      vote: Unknown
   github.com/jaredtao/HelloCI/fda7bb12bd97e0b9816ab723689906fb7d560e8a/HelloCI.pro:
     annotations:
       linguist: QMake
@@ -9112,128 +11217,159 @@ files:
   github.com/jarnaldich/mishell/49cf8f7dfce113325ded1eca8e012a6cb29c21ca/mishell.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/jarvis57/Food-Plus/6382a99a63d7bf6a8d9a7fbba0902a253e2a329a/clips/suggestions.clp:
     annotations:
       human-smola: CLIPS
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: CLIPS
   github.com/jashkenas/backbone/75e6d0ce6394bd2b809823c7f7dc014ddb6ae287/test/sync.js:
     annotations:
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/jashkenas/coffeescript/ddb5dac49de60485b0e5def28ecd75e8a2e61e76/test/literate.litcoffee:
     annotations:
       human-smola: Literate CoffeeScript
       linguist: CoffeeScript
+      linguist-extension: Literate CoffeeScript
       vote: Literate CoffeeScript
   github.com/jasmin-lang/jasmin/0b895ab8975da6d6257c9c092a02b286fdcbc5fe/proofs/lang/low_memory.v:
     annotations:
       linguist: Coq
+      linguist-heuristics: Coq
       vote: Coq
   github.com/jasonhemann/microKanren-shen/e000fd54c8b12d7885b4543cc319782aaaaa6ead/miniKanren-macros.shen:
     annotations:
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/jaspervdj/stylish-haskell/9958a5253a9498c29508895450c4ac47542d5f2a/lib/Language/Haskell/Stylish.hs:
     annotations:
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/java-prolog-connectivity/mapquery/6883409e6e5aa4837b6687ffc9892895cf8fe8d0/src/main/resources/org/jpc/examples/osm/osm_tests.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/javascript-ninjas/monster-player-plugin/33fb5e69c17802b800375632de72ac9e128f04c1/app/scripts/controllers/MessageController.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/jaytay79/IRRXUTIL/a6c67f7695402102e4fa2fe1712d272b2df1b032/LISTUSR.rexx:
     annotations:
       linguist: REXX
+      linguist-extension: REXX
       vote: REXX
   github.com/jbabio/P3Steel/4aa256e1ae5eb822c8fed962ed96b8b103acbe0f/Proteins/X_Idler_End/Idler_End_4/inc/bearing.scad:
     annotations:
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/jboone/gr-tpms/cfed1151c548ac598537870e4c5f152fd0c893f1/cmake/Modules/GrSwig.cmake:
     annotations:
       linguist: CMake
+      linguist-extension: CMake
       vote: CMake
   github.com/jboy/nim-pymod/3e4c49afdfdab2c3325588b6b823c102f22fc588/pymodpkg/private/pyarrayenums.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/jbtayloriii/kol_libs/1a0dac41a2bee656ddf6f7affc19087cbe51d3ed/woodpuzzleCombat.ash:
     annotations:
       linguist: AGS Script
+      linguist-extension: AGS Script
       vote: AGS Script
   github.com/jcagarcia/proofs/6409903f826be9a991bf9d1907e54cb2cde1c46f/spring-controller-validation/src/main/java/org/springframework/roo/petclinic/web/PetsSearchThymeleafController_Roo_Controller.aj:
     annotations:
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/jcaillon/prolint/1c7608dcd44d90cced545a1b0b7196f36d7a6ce3/regrtest/matches.p:
     annotations:
       linguist: OpenEdge ABL
+      linguist-heuristics: OpenEdge ABL
       vote: OpenEdge ABL
   github.com/jcjohnson/fast-neural-style/813c83441953ead2adb3f65f4cc2d5599d735fa7/test/layer_utils_test.lua:
     annotations:
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/jcjohnson/neural-style/07c4b8299f8fbdafec0c514fc820ff1d7ff62e46/neural_style.lua:
     annotations:
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/jclimis/existencias/4ff9aeba251c7513c6ab849d29449e198f9eeb74/existencias_BC0.CLW:
     annotations:
       linguist: Clarion
+      linguist-extension: Clarion
       vote: Clarion
   github.com/jcouyang/TWHN/f452eb777fdb5b62fb7e4d8f4f5a62abc36cc40d/strings.arc:
     annotations:
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/jcrocholl/kossel/83b80e560b434d5352b9de0fbc87174bd02c059c/frame_motor.scad:
     annotations:
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/jdg/MBProgressHUD/d2842c91243b777615dc44cadf7c8c57519b197f/MBProgressHUD.m:
     annotations:
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/jdunmire/kicad-ESP8266/1f3d2c6e49285d4ab4976efc04913bd3974290c1/ESP8266.3dshapes/ESP-12E.scad:
     annotations:
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/jeapostrophe/exp/6458bf071f523fa4c9783cbd476b3f8ef6837f98/cbz.rkt:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/jearbear/dotfiles/9eae706575253d5c4e8b5f4be0d167b8ce9acf50/config/nvim/init.vim:
     annotations:
       linguist: Vim script
+      linguist-extension: Vim script
       vote: Vim script
   github.com/jeffThompson/PixelSorting/df13f0a19cf833168bd9438695fbf3f622cb5865/AutomaticVersions/SeedSorting_AutoIterate/SeedSorting_AutoIterate.pde:
     annotations:
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/jeffdupont/bootstrap-data-table/bb553f2097b97ba33db86607bd058b99e8c45363/example-data.cfm:
     annotations:
       linguist: ColdFusion
+      linguist-extension: ColdFusion
       vote: ColdFusion
   github.com/jefflance/asymptote-config/5915b7c21b7bb8d99a65ae24d72ef6973cc86828/edvenn_pi.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/jeffreykegler/libmarpa/6af9871d41b9f0c6fab63d2d8c7ce99b6e3be16e/work/ami/marpa_ami.w:
     annotations:
       linguist: CWeb
+      linguist-heuristics: CWeb
       vote: CWeb
   github.com/jehan-rubin/engine/e9f5b95eebd029f5d459277c21a6f29426c815b8/src/engine.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   github.com/jehan-rubin/physique_engine/30a6ec6c2f1de2764ccc1f04c56cb8b670ff38eb/nitConstraints.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   github.com/jeisma/abl_socks/713c9d95282fe188bce5db552af48e75a28b7adf/utils/SocketClient.cls:
     annotations:
@@ -9242,47 +11378,58 @@ files:
   github.com/jellyfin/jellyfin-roku/6859d7aa3f5ce8a09f2ae0a857faa6150c1bdf75/components/tvshows/group-description.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/jemc/pony-zmq/7a9f2fd20d3ffc641b653718417673b7c18879d3/zmq/zmtp/message.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/jemc/ponycc/2327fc4e10de602766fa7eb33b5e6d5d397b184b/ponycc/test/test_fixture.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/jeml-lang/jeml/8feaefdee5e5ded6d0ff8a97db0fb2e636c2bd6f/jeml.g4:
     annotations:
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: ANTLR
   github.com/jenkinsci/pipeline-examples/4af47ea76232588c01f3abac1677e22e09645d33/global-library-examples/global-function/standardBuild.groovy:
     annotations:
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/jens-maus/XML-API/915f366ffcfaabad6d0fa49db33d4178e4aa979f/xmlapi/runprogram.cgi:
     annotations:
       human-smola: Tcl
       linguist: Tcl
+      linguist-shebang: Tcl
       vote: Tcl
   github.com/jensli/FantomPatternMatching/2404229dcc0316de3829b8cd0f31cd849a4ef4d0/F4_Projects/Compiler/fan/fcode/FConst.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/jensli/Misc/1a389201779fd41b38166f07761252e6d4173534/fan/ExprSimpl.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/jepsen-io/jepsen/a354ece35f7522321bcff0c4f284dbd2b651533a/jepsen/test/jepsen/util_test.clj:
     annotations:
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/jeremytregunna/IoSpec/10bfd99c6e2eebfd8afa5e641fbac77b48adc498/core/block/equality-spec.io:
     annotations:
       linguist: Io
+      linguist-extension: Io
       vote: Io
   github.com/jespercockx/ataca/a9a7c06407a57c351143dc42d357782a541c9071/src/Ataca/Demo.agda:
     annotations:
       linguist: Agda
+      linguist-extension: Agda
       vote: Agda
   github.com/jesperfj/sfdc-oauth-playground/3629bd6c42d37f9c43f06647922348b68eb5e45c/OAuth/src/classes/TestController.cls:
     annotations:
@@ -9292,6 +11439,7 @@ files:
     annotations:
       human-ajnavarro: Go
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/jethrogb/rust-core_collections/a1a2b9a13b01755ca35357bbfbe8f7cee81439a4/mapping.rs:
     annotations:
@@ -9304,6 +11452,7 @@ files:
   github.com/jevi-me/k8s_on_openstack_kilo/f9c410ce808daf69074fa3c82f4e5968858ace53/kompose_files/patchbay-deployment.yaml:
     annotations:
       linguist: YAML
+      linguist-extension: YAML
       vote: YAML
   github.com/jgallowa07/SLiMSimulations/fda6455968359235cf4dcb443b3be4984708e3e3/MyRecipes1/MyRecipe9_0_1.E:
     annotations:
@@ -9313,34 +11462,42 @@ files:
   github.com/jgarber/redcloth/dd7ee6caaa6c899f4d5389c1b2fe4a17f1e5f326/ragel/redcloth_scan.rb.rl:
     annotations:
       linguist: Ragel
+      linguist-extension: Ragel
       vote: Ragel
   github.com/jgilfillan/Niz-Plum-84EC-S-Pro-Ble-Non-RGB-manual/37ccc61a1745b2fb295d931a29a097bb722751fe/custom keymaps/my_customer_mapping.pro:
     annotations:
       human-smola: XML
       linguist: Prolog
+      linguist-xml: XML
       vote: XML
   github.com/jgm/pandoc/803ab48a2082a4fbc835e481bd122123a7276199/src/Text/Pandoc/Filter/JSON.hs:
     annotations:
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/jgstew/bigfix-content/bc047a90d0d836507f2e000c19dc88eb0a226f95/dashboards/SessionRelevanceProperties.ojo:
     annotations:
       human-smola: XML
       linguist: XProc
+      linguist-modeline: XML
+      linguist-xml: XML
       vote: XML
   github.com/jhmaloney/GP-Mods/36044f3cca7770c0b7f983c176b56926a8b72bcd/runtime/lib/Menu.gp:
     annotations:
       human-smola: Unknown
       linguist: Gnuplot
+      linguist-extension: Gnuplot
       vote: Unknown
   github.com/jiacai2050/sicp/1b06fa3348cbf296856ed9d5cce8873af6e3c4e9/exercises/03/lib/account.scm:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
       vote: Scheme
   github.com/jiangmiao/simple-javascript-indenter/b1cbd5b147b15245b02c5a9a6789a06950de6482/indent/javascript.vim:
     annotations:
       linguist: Vim script
+      linguist-extension: Vim script
       vote: Vim script
   github.com/jiaodaxiaozi/npphighlight/84d93dda2fdbc327403c73b94d57031895135578/localsolver/test/kmeans.lsp:
     annotations:
@@ -9350,48 +11507,60 @@ files:
   github.com/jiesoul/Concepts-Techniques-and-Models-of-Computer-Programming/fa19b5f3da764d3d1b40a2607c29528cf241f949/src/ch01.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/jjlee/w3c-markup-validator-commandline/730033b1be7636b211d6163c229bbb138baa1a4a/etc/sgml-lib/REC-xhtml1-20000126/xhtml1.dcl:
     annotations:
       human-smola: Unknown
       linguist: Clean
+      linguist-extension: Clean
       vote: Unknown
   github.com/jkant76/Ableton-ChucK-01/4e8962474efd06b6697a04390f47f983fa3ac638/Ableton_External_Instrument.ck:
     annotations:
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/jkleiser/picolisp-onedoc-html/b6d6bd7fb66ed886535741f4889fdf9f1d320805/src/convConcat.l:
     annotations:
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
+      linguist-shebang: PicoLisp
       vote: PicoLisp
   github.com/jkotlinski/durexforth/b9ba211a479f123ebc618b29618df4b505daa316/forth_src/sid.fs:
     annotations:
       linguist: Forth
+      linguist-heuristics: Forth
       vote: Forth
   github.com/jkuczm/MathematicaCellsToTeX/20439c054ebf249cec1ee3b6750813adc29589c4/CellsToTeX/Tests/Integration/extractCellOptionsProcessor.mt:
     annotations:
       linguist: Wolfram Language
+      linguist-extension: Wolfram Language
       vote: Wolfram Language
   github.com/jlas/ml.q/bb0c8ca39717023de951351127342ad96dbb0f26/ml.q:
     annotations:
       linguist: q
+      linguist-heuristics: q
       vote: q
   github.com/jldbc/gunsandcrime/547aee98349ae2f9b9a2116cfe60ccfebc5c80e7/Moody Replication and Improvements.do:
     annotations:
       human-ajnavarro: Unknown
       linguist: Stata
+      linguist-extension: Stata
       vote: Unknown
   github.com/jlepak/factor-work/58ade57c41a942ff7434c1eaf07c20168b0b8a17/math/lapack/ffi/ffi.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/jlroo/SAS-Programming/b709559e0684c83d4b0d85ce79e024f5c063b9f2/HW_2/HW_2_3c_.sas:
     annotations:
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/jmarecek/timetablingPatternPenalisation/01fde49b7c5be4802addaff3930e954bd9e84d9b/udine3.ctt.e.zpl:
     annotations:
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Zimpl
   github.com/jmechner/Prince-of-Persia-Apple-II/a9e276ce886f2200985e968b6cb5bda7edf5a2bb/04 Support/MakeDisk/S/RYELLOW1.S:
     annotations:
@@ -9401,10 +11570,12 @@ files:
     annotations:
       human-smola: Raku
       linguist: Raku
+      linguist-heuristics: Raku
       vote: Raku
   github.com/joaomilho/awesome-idris/6adf450ab1dbc1449b00d5dbb83ce72467460ab5/Nat.idr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/jocelyn-old/EiffelWebReloaded/939d92f3bed039b370baedde1d499427ad7a2b0f/library/server/rest/tests/src/app/app_account_verify_credential.e:
     annotations:
@@ -9421,39 +11592,48 @@ files:
   github.com/joebo/j-fork-server/30fe475a5f342eac1dc401f985c2d227ae0134c6/spawn.ijs:
     annotations:
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/joebo/picoLisp-win-x86-64/a9a8a0bff30f432594884ca971a24f4dc9ab95cc/src64/main.l:
     annotations:
       human-smola: PicoLisp
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
       vote: PicoLisp
   github.com/joebo/todo-backend-pil/5df80c0e0973342e3c773a1977b96bb32a74f3a2/server.l:
     annotations:
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
       vote: PicoLisp
   github.com/joedf/LibCon.ahk/4d582be23abe4e11298e5035ee0ff603553a35a1/LibCon_Compiler/LibCon_Compiler.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/joedf/Webapp.ahk/b6b744fa8c6b42e04de53222aec271b5b1ea9be3/src/Example.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/joelivey/M-Editor-For-Eclipse-Original-Version/2d53709ac102bcca5c6387bb2cffe4d8c01ed8b2/XT73P101V7.KID:
     annotations:
       linguist: Genshi
+      linguist-extension: Genshi
       vote: Genshi
   github.com/joemontibello/iii-sql-queries/4cc9efaa9a0c9a1c946826afa38ca5e2d9d68e18/scratch.sql:
     annotations:
       linguist: SQLPL
-      vote: SQLPL
+      linguist-heuristics: SQL
+      vote: Unknown
   github.com/jofrfu/tinyTPU/7c9a732dfd1e305fbd86b41a6fb3146ea64693de/src/vhdl/Activation/TB_ACTIVATION.vhdl:
     annotations:
       linguist: VHDL
+      linguist-extension: VHDL
       vote: VHDL
   github.com/johnmyleswhite/ML_for_Hackers/4aa136e17eef2ca8e2b80079acf3e2075485c441/12-Model_Comparison/chapter12.R:
     annotations:
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/johnno1962/SwiftTrace/5e96cbb6d94619653f522df0da756ea8891b4e31/SwiftTrace/xt_forwarding_trampoline_x64.s:
     annotations:
@@ -9463,19 +11643,23 @@ files:
   github.com/johnrengelman/shadow/d5c662a69cfb48144a4027c344ff254f12e1e78a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformerParameterTests.groovy:
     annotations:
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/jonathonmcmurray/reQ/f29dfbf82ec461ec32721672d0da7c8de7c2e347/req/b64.q:
     annotations:
       human-smola: q
       linguist: q
+      linguist-heuristics: q
       vote: q
   github.com/jonenst/papersync-server/3d2747551eb71e58029c9e9d66e4eba99370b181/papersync-server.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/jonghough/jlearn/8361c081b618b69bfc36decde67c689d46d5c917/optimize/neldermead.ijs:
     annotations:
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/jonlaing/rationale/06a48fd39b106319a4a4477e90777db51c915353/src/Lens.re:
     annotations:
@@ -9484,74 +11668,93 @@ files:
   github.com/joom/hezarfen/da80a475cf57dee5cd3c10452878d951f1fa490f/Hezarfen/Hint.idr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/jordancolburn/recursion-looper/2708fa15031c821618d2f650379dd5c34a5904cf/looper.ck:
     annotations:
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/jordanmueller/roku_channel/676d5fca5422fd3333bbbca61c3a6db48cf6ac66/source/events.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/jordansissel/fpm/d7b466787d17581bc723e474ecf6e18f48226031/spec/spec_setup.rb:
     annotations:
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/josefprusa/Prusa3-vanilla/dafeba7de370ffe2c7b966f949a882889ea2d2e0/src/extruder-idler.scad:
     annotations:
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/josefprusa/Prusa3/7ab0186d94b4a9af7c4d832b6a4f0245dd165bc1/old_single_plate/src/x-carriage.scad:
     annotations:
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/josephmisiti/awesome-machine-learning/23e2b977571639330f7a70aabb88fa1b3e280237/scripts/pull_R_packages.py:
     annotations:
       linguist: Python
+      linguist-extension: Python
+      linguist-shebang: Python
       vote: Python
   github.com/joshaxey/3ds-Max-Batch-Import-Export-Tool/d54705d579524941a5647ef338f7c7d8133ee094/BatchExportImport - josh_axey.ms:
     annotations:
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: MAXScript
   github.com/joshthecoder/mustang/a13a2a71df6437227c16ca5b9d8a324d67aa6bed/mustang/Context.ooc:
     annotations:
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/joshthecoder/ooc-web/31a9524ac0b955429041ef0bc4b292ff33a6aec0/web/Application.ooc:
     annotations:
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/joshthecoder/proof/da37421dee377a3ccc69ae9e2a37017aa4301b6d/proof/Reporter.ooc:
     annotations:
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/joshuaballoch/talent-vs-luck-recreated/fe03d47c720ab1ca12c4f7f332999c8fed4202f4/talent-vs-luck.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/josip/eerie/20dfaec73d42874f06543e08012788be0a170ac2/io/Eerie/Exception.io:
     annotations:
       linguist: Io
+      linguist-extension: Io
       vote: Io
   github.com/josip/generys/e8bfffb8a7697d1b4eeb07e3d5a9bfcf02bee43e/io/A2_Generys.io:
     annotations:
       linguist: Io
+      linguist-extension: Io
       vote: Io
   github.com/jotego/jt12/81a732a8afc9402732fdf20be6ca7d3bb0e162ae/hdl/jt12_sumch.v:
     annotations:
       linguist: Verilog
+      linguist-heuristics: Verilog
       vote: Verilog
   github.com/joyzh06/CS3152-Labs/96d9b4bf215ef79c1abe14f6875bb5458cd96317/Lab1/com/badlogic/gdx/utils/JsonReader.rl:
     annotations:
       linguist: Ragel
+      linguist-extension: Ragel
       vote: Ragel
   github.com/jpcaissy/minilang/a53f9a1429715587087e8becc3035caf4f2755e9/semantic_analysis.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   github.com/jpcs/transform.xq/6d89a80cfc8ba64a0d14e146437ae2340e393276/lib/compile_pattern.xq:
     annotations:
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/jpfutalef/Current-Measurement-Board/94be28fd9e500bd32391bee9598597e3923c1f01/ltspice/v2_max4239_lt624X.asc:
     annotations:
@@ -9561,6 +11764,7 @@ files:
   github.com/jpginc/windows10DesktopManager/6dd6c214b4013e003a4cda38f2e52b49f84811b1/windowMover.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/jradavenport/jradavenport_idl/14ff56c6ac6d101e45fd37a02aef4804c5edbd39/pro/medbin.pro:
     annotations:
@@ -9569,101 +11773,128 @@ files:
   github.com/jrbasso/cakephp-ext/06f6362d5c4bf28afb26d73350703ad5a3868b69/cake/utility/hash.zep:
     annotations:
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/jrmarino/AdaBase/c63532644bc9c6aa041cc8db3385f7fd088a4407/src/bindings/adabase-bindings-postgresql.ads:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/jrminter/dtsa2Scripts/a0a9c6cba23ffb5399f278ff3a5e9178547c0044/plt/simulateCoatedSiO2.plt:
     annotations:
       linguist: Gnuplot
+      linguist-extension: Gnuplot
       vote: Gnuplot
   github.com/jrpavia/simserver/451214ff22bdc7d0ddf1376aaa7fb6efdd4360ee/ragel/atcmd.rl:
     annotations:
       linguist: Ragel
+      linguist-extension: Ragel
       vote: Ragel
   github.com/jrsoftware/issrc/3fa5282038c93ba6931ab987584b9faee88e3e59/Projects/ISPP/ISPP.dpr:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/jsebean/IlluminationSoftwareCreator/3d9977829e5ee070b8616960045ab54ea5155bcf/RadThumbnailView Folder/RadThumbnailPicture.rbbas:
     annotations:
       human-smola: REALbasic
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/jshoniyi/-c-Apache24/b0e7f689303e761d144c54dc718a0ca7fdff85ea/manual/mod/mod_usertrack.html.fr:
     annotations:
       linguist: Frege
+      linguist-heuristics: Frege
+      linguist-xml: XML
       vote: Frege
   github.com/jsm174/vbscript-parser/cc6b0cda5761e66e96a68a2b4860b886dc470e38/src/vbscript.ne:
     annotations:
       linguist: Nearley
+      linguist-extension: Nearley
       vote: Nearley
   github.com/jsoftware/media_imagekit/6de6b5eb1305427a99e0eb59285d421959b9c1bb/html_gallery.ijs:
     annotations:
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/jtempl/ofront/947b930bf8ecbf321c6115558d2cd64ea23468e8/V4_ofront/share/SYSTEM.Mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/jtfmumm/novitiate/2d5b847fa45eca9a75a666bbb8d7c273d8b62f14/src/agents/ekek.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/juanantoniorr/prueba/58713cc561590d0ff78cb5acbeb2e8d8f12b46a6/Roles.rl:
     annotations:
       human-smola: XML
       linguist: Ragel
+      linguist-extension: Ragel
+      linguist-xml: XML
       vote: XML
   github.com/juanplopes/euler/c3741c70877d2373ca83a2d3cb0897bdca6aa5df/158.boo:
     annotations:
       linguist: Boo
+      linguist-extension: Boo
       vote: Boo
   github.com/julien-truffaut/Monocle/67b0b03fc6cbcca23f9fdd17164fbe53f4c576a2/core/shared/src/main/scala-2.12-/monocle/std/Cofree.scala:
     annotations:
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/julienXX/terminal-notifier/3ba9ce569e234062d09c8fd01c4be11e56a9fd1b/Terminal Notifier/AppDelegate.m:
     annotations:
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/juliensf/mercury-json/82f77a2bec38119b03a8a7dcc197e899958d75c6/src/mercury_json.m:
     annotations:
       linguist: Mercury
+      linguist-heuristics: Mercury
+      linguist-modeline: Mercury
       vote: Mercury
   github.com/junyanz/CycleGAN/253a5a65cb64823748e8e8e851acabad7840b9a1/models/bigan_model.lua:
     annotations:
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/jupeter/clean-code-php/062b4e25419b63d414b0fee9ee56a5d86a6c99f4/.travis-build.php:
     annotations:
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/juque/limpia-utf8-corrupto/598da9394862498071960d1e9291b3e24c1da4bc/latin12utf8map.sed:
     annotations:
       linguist: sed
+      linguist-extension: sed
       vote: sed
   github.com/justinmeza/httpd.lol/1faf08dd2f28785160494c88aa7729f7a774d85a/httpd.lol:
     annotations:
       linguist: LOLCODE
+      linguist-extension: LOLCODE
       vote: LOLCODE
   github.com/jvail/diet/9ed6ea448e9c73bc6556e08bc1b227b75dd1344a/tmr_lp_two_groups_two_periods.zpl:
     annotations:
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Zimpl
   github.com/jvanegmond/au3_uiautomation/57c00f96877f31084eeb87805404c53c27681417/UIAWrappers.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/jvasileff/ceylon-dart/8717e9f17f758cc1d51af5940d5206018da957d0/ceylon-dart-compiler/source/com/vasileff/ceylon/dart/compiler/module.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/jvasileff/functional-ceylon/70ef059bc70873f90caa35903b875e5dd6f9e6d5/source/com/vasileff/fc/examples/trampoline/example.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/jvelilla/RosettaCode/d0ed0d5fff2957dcfb6a378cadcae769a790ec87/src/tokenize_string/tokenize_string_example.e:
     annotations:
@@ -9676,67 +11907,83 @@ files:
   github.com/jvimal/boxopa/eb4b5b03b52401b8a297bbd24d3a1a58a92b75f0/box.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/jvm-operators/haskell-example-operator/a0af1f69ed11917a2554ebf60b089d58a9a68779/src/main/frege/Brainfuck.fr:
     annotations:
       human-smola: Frege
       linguist: Frege
+      linguist-heuristics: Frege
       vote: Frege
   github.com/jwiegley/category-theory/d39ddffef514d2c541708c4779fb75b58d63af3d/Structure/Closed.v:
     annotations:
       linguist: Coq
+      linguist-heuristics: Coq
       vote: Coq
   github.com/jwiegley/nix-config/69bb0c3ae6985f09ee2f27cea4621db21fcf0474/overlays/20-git-scripts.nix:
     annotations:
       linguist: Nix
+      linguist-extension: Nix
       vote: Nix
   github.com/jwilm/alacritty/679e67d045f60d528c695a1ee8a6c0f3d6feeda1/alacritty_terminal/src/grid/row.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/jwinder/emacs-config/6cfbb3914713d26447a0d76eb2992f91acbb089b/snippets/sh-mode/shell-script-template:
     annotations:
       linguist: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/jzbontar/mc-cnn/b944e2fb58b130a01ec70dd7314ed540e970f58a/SpatialLogSoftMax.cu:
     annotations:
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/k33g/files/47df1abcb511c8e6de95af6725ef6f1d207f5236/snippets/golo/json/jsonToDynamicObject.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/k33g/goloctokit/cbeb1c9f57b936a432b8b72310f5c5e0313ae793/repository.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/k33g/jarvis-ci/41bf13a1fb42c6cd3ddb6fc095d338ae1d673d8b/main.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/k33g/kiss/e3edbc71ce81596d849b2b62455127a586971b17/src/main/golo/imports/promise.augmentations.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/k33g/lambdas-sky/7da875a2401a04a1bbbc4e510d3048b5899a6c86/imports/dvcsClient.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/k33g/malossol/10f717bf6a98950783094167b6b831e973db24c6/demo.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/k33g/web.2.day.golo/938d920c93886f206e31eea42bf61ea304923784/08-func-golo.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/ka3a4ok/NProjectReferenceCorrector/960d578214859cffd560dfedd0fe3423f54715e3/NProjectReferenceCorrector/Properties/AssemblyInfo.n:
     annotations:
       linguist: Nemerle
+      linguist-heuristics: Nemerle
       vote: Nemerle
   github.com/kaelzhang/lua-gaia/14b34bd757b43f4574ac5d6539811b6fe4fa0a34/nginx/config/redis.hb:
     annotations:
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Harbour
   github.com/kagof/BefungeRepo/d18f20c8a0fa864e8ba83fd0afa5416434079266/NumberGuesser.bf:
     annotations:
@@ -9745,10 +11992,12 @@ files:
   github.com/kaina404/FlutterDouBan/2dfe56ba628bfb5c00f516647d5eaa64c3aecb89/lib/demo/slide_container.dart:
     annotations:
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/kaiyuanw/MuAlloy/1083004d6968e92ada75e52f21dcf8bf61a80b26/experiments/models/other.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/kanaka/mal/609fc44f44a61638f5d1ec1bcf60d4701a3a212a/nasm/step1_read_print.asm:
     annotations:
@@ -9757,18 +12006,22 @@ files:
   github.com/kanytu/Android-studio-material-template/361ba3efc5de5b193bf9955b2ee577c5045529b4/MaterialNavigationDrawerActivity/root/src/app_package/ScrimInsetsFrameLayout.java.ftl:
     annotations:
       linguist: FreeMarker
+      linguist-extension: FreeMarker
       vote: FreeMarker
   github.com/karlrupp/microprocessor-trend-data/7bbd582ba1376015f6cf24498f46db62811a2919/40yrs/plot.gnuplot:
     annotations:
       linguist: Gnuplot
+      linguist-extension: Gnuplot
       vote: Gnuplot
   github.com/karpathy/char-rnn/6f9487a6fe5b420b7ca9afb0d7c078e37c1d1b4e/util/model_utils.lua:
     annotations:
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/karrots/ROS-DDNS/e83304ab3b821dc68ba1a54f31f287ddbd611557/DDNS-DHCP.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/karthikgade77/performance-test-apache-drill/4c40292cf7031e8c770c4df0cbb541f7c62d0637/TPCDS/Queries/74.q:
     annotations:
@@ -9778,51 +12031,63 @@ files:
   github.com/kasun04/microservices-integration-ballerina/ef15f303df9e26e79acf8a14ffedd3fe1552cf5d/catalog/InventoryService_pb.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/katalon-studio-samples/DataDrivenTest/e2bb06b1bfdc95cf3259742e3d7e07ec68021039/Object Repository/Login Page of Demo Application/input_password.rs:
     annotations:
       linguist: RenderScript
-      vote: RenderScript
+      linguist-xml: XML
+      vote: Unknown
   github.com/katalon-studio-samples/DragAndDropExample/84baad1522dc27333322eaaaca1d1fe97a15ece9/Object Repository/Page_Droppable  jQuery UI/iframe_demo-frame.rs:
     annotations:
       linguist: RenderScript
-      vote: RenderScript
+      linguist-xml: XML
+      vote: Unknown
   github.com/katalon-studio-samples/Material-Login-App-Test/0e784674a595902ab55272c44079711d6feeb120/Object Repository/Material Login App/android.widget.EditText0.rs:
     annotations:
       linguist: RenderScript
-      vote: RenderScript
+      linguist-xml: XML
+      vote: Unknown
   github.com/katalon-studio-samples/ShadowDOMSampleProject/bdc9e33a7afa0b0674e6d224a08385d0aaf18cd0/Object Repository/aStoreLink.rs:
     annotations:
       linguist: RenderScript
-      vote: RenderScript
+      linguist-xml: XML
+      vote: Unknown
   github.com/katalon-studio-samples/android-mobile-tests/433d1f72a668cae30a1fd427f20bec190bb9786a/Object Repository/Application/App/android.widget.TextView-Activity.rs:
     annotations:
       linguist: RenderScript
-      vote: RenderScript
+      linguist-xml: XML
+      vote: Unknown
   github.com/katalon-studio-samples/katalon-mobile-automation/8beaae95fb354d1431e256b5078f8eb6e4ba137d/Object Repository/Mobile Spy Object Locators/button_Send.rs:
     annotations:
       linguist: RenderScript
-      vote: RenderScript
+      linguist-xml: XML
+      vote: Unknown
   github.com/kaviththiranga/ballerina-day-tooling-tutorial/d668b4155c173f1e32699a513ebf3012a7b06f01/resources/hello-service/demo/tests/hello_service_test.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/kazurayam/KatalonDiscussion4977/2d39aff1ed7aad79c52bb70f4f565b12692cbc92/Object Repository/Page_Basic line/svg_namespace-ignorant.rs:
     annotations:
       linguist: RenderScript
-      vote: RenderScript
+      linguist-xml: XML
+      vote: Unknown
   github.com/kburtch/SparForte/6df424e05a0fd8d0e5963f4ada2acea2baa77206/src/areadline/readline-completion.ads:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/kchmck/vim-coffee-script/9e3b4de2a476caeb6ff21b5da20966d7c67a98bb/syntax/coffee.vim:
     annotations:
       linguist: Vim script
+      linguist-extension: Vim script
       vote: Vim script
   github.com/kcloze/medoo-zephir/e2cc0cb811009eec095835ca7eacc9e579f5cd81/medoo/medoo.zep:
     annotations:
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/kdsingh11/Basics_Verilog_Codes/bee21d0fe3ecf05ca171add3d315e35790d486e0/ptr.v:
     annotations:
@@ -9832,145 +12097,181 @@ files:
   github.com/keale/POLARIS-Vision/f08afdbbbdf8c20f2e789a6beeec3765bd21b6f0/POLARIS Vision.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/kealist/RS-fossil-mirror/81e8dfc901d5273e78383b9a3dd959b6fd47edd3/ZeroMQ-binding/examples/0MQ-reply-server.red:
     annotations:
       linguist: Red
+      linguist-extension: Red
       vote: Red
   github.com/keefmarshall/rainwater-dg/049f0d1eae695bd08698a759f6207efff385ecc2/rw.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/keijiro/ShaderSketches/fbe4ee6fbaa536b202b0e5c172456ce3227f9603/Fragment/Eyes2.glsl:
     annotations:
       linguist: GLSL
+      linguist-extension: GLSL
       vote: GLSL
   github.com/keijiro/sketches2016/15226baec2674820e5728c9b89ff21008444dd56/Simplex7/Simplex7.pde:
     annotations:
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/keirwhitaker/shopify-birthday-suit/69246e0f0bd3f83817342c042b012ceaae34e960/layout/theme.liquid:
     annotations:
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/kekcleader/Karax/1ecc14a058d251a4b13aca4a61b618ec91e9f249/Karax.Mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/kemalcr/kemal/a4bdecdc7d17a3fa705db4e1c3360590f836cb5d/spec/handler_spec.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/kenburke/event_detection/e0d996155705dfdd7c4a943c063f42fbebc9c28b/EventDetection.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/kennyledet/Algorithm-Implementations/4a3ad1e01ea8c1d629445f6f2e0f8d6724a5d61b/Self_Descriptive_Number/Lua/Yonaba/selfdescriptivenumber_test.lua:
     annotations:
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/keon/algorithms/66d7f97f2ab37a2c23dfcc1946c62c136a5086fe/algorithms/tree/segment_tree/segment_tree.py:
     annotations:
       linguist: Python
+      linguist-extension: Python
       vote: Python
   github.com/kevinzluo/pollard-rho/285aa34c79b95e11deefd1af13b3928ccd1c0847/asy/drawGraph.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/kezong/fat-aar-android/bbf6190ac4ccc2ce4c4d4cfa92164853883a386f/source/src/main/groovy/com/kezong/fataar/FlavorArtifact.groovy:
     annotations:
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/kfprimm/mapletce/1df4654a4c7c1483fecf26223198831c5b5a357a/src/engine.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/kfprimm/prime.mod/d30f81a63c5ffc4b6373ed1801a9938d21a9dbc9/kbsplines.mod/kbsplines.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/kfrye/cs161/3b544c811350b48261b0d7a6d6ff3b5ed1a8fdca/treasureHunt.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/khagag/tiva_c_dynamic_drivers/97fccef2e18580c690883f1257c75eee2add9ea1/Release/tm4c123gh6pm_startup_ccs.rl:
     annotations:
       linguist: Ragel
+      linguist-extension: Ragel
       vote: Ragel
   "github.com/khanhvu207/competitiveprogramming/5cc7b020c0fd64b6d84e4c0cba1256225803814b/CST 2019/Th\u1EA7y Vinh/T13/CHAMTUAN13/debai/room/room.i3":
     annotations:
       human-smola: Unknown
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Unknown
   github.com/kiberpipa/nix-rehash/d14e37eb26baf4f31749c28de3565de98a024500/container.nix:
     annotations:
       linguist: Nix
+      linguist-extension: Nix
       vote: Nix
   github.com/kidswong999/dobotArm/3430280746122fd73eabf8b7139ff801aa2be1bb/dobotProcessingPC/application.windows64/source/dobotProcessingPC.pde:
     annotations:
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/kielthecoder/amx/a573fbb18778a56f3c34d518e93f20d651f9dd25/Marantz/Marantz v1.axs:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/kimasendorf/ASDFPixelSort/ac4fdf0f3aae2d21c42d599e5323a52e4e2b4262/ASDFPixelSort.pde:
     annotations:
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/kimjaemin0407/ex_project/7b86593a47cc69b2804c5b6a50b9341b6957c126/4.Self:
     annotations:
       human-smola: Java
       linguist: Self
+      linguist-extension: Self
       vote: Java
   github.com/kingj5/iOSKit/98bf5776ca706d38df4e8eacdbe1f23078167d8a/ExampleViews/MainView.xojo_code:
     annotations:
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/kingsunc/Nsis_Duilib/fbc8099d40859152d00d80386df26bce5af5838b/NSIS_Install/NSIS/Contrib/Modern UI 2/Deprecated.nsh:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/kinverarity1/lasio/c0abaffc1656e7acdfdb12efff37d0f2cf845c66/standards/examples/1.2/sample_curve_api.las:
     annotations:
       linguist: Lasso
+      linguist-extension: Lasso
       vote: Lasso
   github.com/kiwanami/emacs-epc/e1bfa5ca163273859336e3cc89b4b6460f7f8cda/epcs.el:
     annotations:
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/kjx/combinators/cec7cbd8c20195c4e2196745a934b64f5d785d9d/combinators.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/kjx/inheritator2/41c2ab87ce69c9e70ba4255cb9f96333df4a636d/subtyping.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/kkkgo/KMS_VL_ALL/1019757f9e115b744f5c65855e40b2406ed964ff/AutoRenewal-Setup.cmd:
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/kkrings/ansible-roles/71f89dd6bd15d78c617086b48798230bd16380d1/dev/tasks/pyenv.yml:
     annotations:
       linguist: YAML
+      linguist-extension: YAML
       vote: YAML
   github.com/klange/ponyos/aec744f0a2740d8bb6b8e59c53b135a49e297603/hdd/usr/ponysay/ponies/snowflake.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/klayoutmatthias/si4all/51bff19ee59377e46fc373b6c3b74fd153c6e53a/process.xs:
     annotations:
       human-smola: Unknown
       linguist: XS
+      linguist-extension: XS
       vote: Unknown
   github.com/klemensj/Pollinators/e06b2e51070c914c6684015f23209d755cc8ed1f/Greenroofs.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/klyone/HDLObf/c8c4133b33213b2c5f16558ea45784cad7f06cfc/src/vhdl.g4:
     annotations:
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: ANTLR
   github.com/knan02/hive_sample/3f36f5aaebe1a0f2752bd9919b48226c82d896e1/scripts/model-build-c.q:
     annotations:
@@ -9979,63 +12280,78 @@ files:
   github.com/knaw-huc/backlogs/ca946919c687a8fcea28db904a55328f7b9bf4d0/src/grammar.ne:
     annotations:
       linguist: Nearley
+      linguist-extension: Nearley
       vote: Nearley
   github.com/knop-project/knop/ab47641eb6c6152772caea0d9a1a0028cd9f967c/knop9/knoplibs/knop_base.lasso:
     annotations:
       linguist: Lasso
+      linguist-extension: Lasso
       vote: Lasso
   github.com/knxroot/bdcut-cl/d1a2dadeb14a56e8fe7b7bc19baf0927ab1012d4/BD/Oracle_utf8/BDCUT_CL__Oracle_utf8__generado.sql:
     annotations:
       human-smola: PL/SQL
       linguist: PL/SQL
+      linguist-heuristics: SQL
       vote: PL/SQL
   github.com/koalaman/shellcheck/93eca1cb8e7e8c1428a1375e985a669b43c41e95/src/ShellCheck/Analyzer.hs:
     annotations:
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/koksyn/RedUnit/0bf3bb07a510643ca90f1742de0e1d6cec12c8da/src/modules/general.red:
     annotations:
       linguist: Red
+      linguist-extension: Red
       vote: Red
   github.com/komish/terraria_server/8dfc172f6e44aa610341a5f078b6d16fa14c1d65/tasks/prepare_host.yml:
     annotations:
       linguist: YAML
+      linguist-extension: YAML
       vote: YAML
   github.com/koolproxy/merlin-koolproxy/75c68a9b63eb5b97b3c897cbf2c3e53509ded7ec/koolproxy/webs/Module_koolproxy.asp:
     annotations:
       linguist: Classic ASP
+      linguist-extension: Classic ASP
       vote: Classic ASP
   github.com/koolshare/armsoft/ff8d316b8f84a3232a544b6a5ed84994dd071a83/kms/kms/webs/Module_kms.asp:
     annotations:
       linguist: Classic ASP
+      linguist-extension: Classic ASP
       vote: Classic ASP
   github.com/koolshare/koolshare.github.io/9f9d29acbbad5c60d22013f8a017151b84a78bbf/ssid/ssid/webs/Module_ssid.asp:
     annotations:
       linguist: Classic ASP
+      linguist-extension: Classic ASP
       vote: Classic ASP
   github.com/koolshare/ledesoft/cc72f38ce95181a666b4c974b4ede947b85c3523/fwupdate/fwupdate/webs/Module_fwupdate.asp:
     annotations:
       linguist: Classic ASP
+      linguist-extension: Classic ASP
       vote: Classic ASP
   github.com/koolshare/rogsoft/d9d4919c4473b534e93e3d1a7acea599d25b167a/fastd1ck/fastd1ck/ROG/webs/Module_fastd1ck.asp:
     annotations:
       linguist: Classic ASP
+      linguist-extension: Classic ASP
       vote: Classic ASP
   github.com/koreader/koreader/f1f75c5cb0fa063c35f49a84b2e025f1d292ea01/frontend/ui/trapper.lua:
     annotations:
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/kory75/R-360-3D-Printer/b2fa530f17a980e93e837631baa3cbe232a2ef93/extruder/src/functions.scad:
     annotations:
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/koryonik/logtalk-experiments/7840902c9110e76dc9d4ad6f5848d216cbcf9412/test-runner/test_runner.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/kos59125/sleep-sort-in-nemerle/56063b87c289ac92dc56c11225060c5aa0d4c67d/Concurrency/Properties/AssemblyInfo.n:
     annotations:
       linguist: Nemerle
+      linguist-heuristics: Nemerle
       vote: Nemerle
   github.com/kprevas/ronin/12b981c1581eb6cafc50283f8092f66803ad3eec/roblog/src/view/SinglePost.gst:
     annotations:
@@ -10048,35 +12364,44 @@ files:
   github.com/krimple/spring-roo-in-action-examples/1d4e83f4ad43916f246ab027621cc32b12019a34/chapter-10-email-jms/coursemanager-email-jms/src/main/java/org/rooinaction/coursemanager/web/CourseRegistrationController_Roo_Controller.aj:
     annotations:
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/krips/uvoting/08e22bec2a89bfb1e819a33e48b4b2ec92c42970/preliminaries.ec:
     annotations:
       linguist: eC
+      linguist-extension: eC
       vote: eC
   github.com/krish240574/dbn/665a8115fd0f17550dc11b219331f77b16ffdc34/glw.dyalog:
     annotations:
       linguist: APL
+      linguist-extension: APL
       vote: APL
   github.com/krish240574/dbn_bn/5279c92e1f8f9581f19fcb4f829f6ad4df77cf9d/finetunedbn.dyalog:
     annotations:
       linguist: APL
+      linguist-extension: APL
       vote: APL
   github.com/krschultz/android-proguard-snippets/c636c6c8448565e91e25a66f11fab3fca035c29c/libraries/proguard-facebook-fresco.pro:
     annotations:
       human-smola: Unknown
       linguist: IDL
+      linguist-heuristics: Proguard
       vote: Unknown
   github.com/kskkwn/.emacs.d/2d37f1b99e7d6842c919deb0177f350458684e23/snippets/latex-mode/article.yasnippet:
     annotations:
       linguist: YASnippet
+      linguist-extension: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/ksonnet/ksonnet-lib/0d2f82676817bbf9e4acf6495b2090205f323b9f/ksonnet.beta.4/k.libsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/ksromanov/RagelExample/6b62651df2c3b67ebadf36b4ad88333df89f20e3/lexer.rl:
     annotations:
       linguist: Ragel
+      linguist-extension: Ragel
       vote: Ragel
   github.com/kstrauser/pgdbf/4e847759b5eee96da9dc3d2604e0b555ddd57ccb/m4/lib-prefix.m4:
     annotations:
@@ -10085,63 +12410,78 @@ files:
   github.com/ktekinay/Kaju/0f3b33fcb802bf6e1650f22b6ab005509b1e3976/Kaju Classes/Kaju/BinaryInformation.xojo_code:
     annotations:
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/ktekinay/M_Crypto/7202121d56a787602550f4f6295208ed667e14a0/Shared Classes/Bcrypt_MTC.xojo_code:
     annotations:
       human-smola: Xojo
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/kubeflow/examples/7a2977ef119239d6e2a131c1ca5ee1727d0db5ce/code_search/demo/cs-demo-1103/ks_app/components/params.libsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/kubeflow/fairing/9b0d4ed4796ba349ac6067bbd802ff1d6454d015/tests/workflows/components/params.libsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/kubeflow/katib/6410b036d3e51d0828e077184f93aaf6847916d1/test/workflows/environments/releasing/params.libsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/kubeflow/kfserving/cc8f507374b690c0c83cc7311ed698fcb69bd1a4/test/workflows/components/workflows.libsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/kubeflow/kubeflow/16aada51473702f815463b9520241e4b9b062be0/kubeflow/tf-batch-predict/prototypes/tf-batch-predict.jsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/kubeflow/pytorch-operator/5522f9144268e2495a924d24647b4a2d9b63eaae/test/workflows/components/workflows.jsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/kubeflow/tf-operator/4926a28666e6ee3897d0a4f8d094aba200442449/test/workflows/components/workflows.jsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/kubernetes-monitoring/kubernetes-mixin/325f8a46fac9605f1de8bc20ca811cb92d1ef7e5/dashboards/network-usage/namespace-by-pod.libsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/kubernetes/kubernetes/f23dd405f18f23dda4d00820ab20ec49852e5727/cmd/kubeadm/app/discovery/https/https.go:
     annotations:
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/kurisuwhyte/emacs-multi/0987ab71692717ed457cb3984de184db9185806d/multi.el:
     annotations:
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/kutu/GrindPlayer/080d1a953bdef1fd83d4cae1ce69295b811f2776/src/ru/kutu/grindplayer/views/mediators/StatInfoMediator.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/kxcontrib/cburke/bf516a050386b4e4b05913eb4c83d43bc6f62acb/jk/source/util.ijs:
     annotations:
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/kylemacfarlane/zplgrf/403ed11d2c798607602d80cb9d03601ed0b7e805/src/zplgrf/tests/input/pdf-optimised-zb64.zpl:
     annotations:
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Zimpl
   github.com/kzu/GitInfo/77eb5f5e218db8eb94aa57dcfedacbbbff42f58b/src/GitInfo/build/GitInfo.cs.pp:
     annotations:
@@ -10151,135 +12491,166 @@ files:
   github.com/l-flat/lflat/8eb5f43bacb9dc519e4794523a1c89d9d54bfdf1/loader.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/lacanoid/pgddl/ba91f0773804fab00ce40484308bd6ebc7e4f0f5/ddlx.sql:
     annotations:
       human-smola: PL/pgSQL
       linguist: SQLPL
+      linguist-heuristics: SQL
       vote: PL/pgSQL
   github.com/laddp/ansible-stuff/d6348a84d88f6dfc65ed5d84b6a9f7496a32def8/google.yml:
     annotations:
       linguist: YAML
+      linguist-extension: YAML
       vote: YAML
   github.com/laeb-io/aeio/6212f7f6486f3747c02fb26d338ea0b2e57479b0/src/aeio_sup.lfe:
     annotations:
       linguist: LFE
+      linguist-extension: LFE
       vote: LFE
   github.com/laeb-io/aelisp/a5bcd45d7986fd5c8a95c00026cfb42f2f6f1081/src/aect.lfe:
     annotations:
       linguist: LFE
+      linguist-extension: LFE
       vote: LFE
   github.com/lakwarus/ballerina-workshop/4203d62b3be3b3a54c2aaf9d4c0c3c94c3d5688c/tutorial-08/demo/demo.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/lambourg/Ada_Bare_Metal_Demos/2a76970f857e2970c4d569a5a808df84cd7274a1/fractals/src/fractals.ads:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/lang-flags/de/10a6d633dd70807d9355cb59e619c5408e0c5c42/a.shen:
     annotations:
       human-smola: Unknown
       linguist: Shen
+      linguist-extension: Shen
       vote: Unknown
   github.com/lang-flags/fr/352067103548b749c7823914ced25865ce38b9b5/a.hb:
     annotations:
       human-smola: Unknown
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Unknown
   github.com/lapism/search/13da3e832240dfc1779354e7f0081b9798304e03/src/main/java/com/lapism/search/behavior/SearchBehavior.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/laravel/framework/0a5fb9048f72f44c8d8a197f8d42c177eccb5f60/tests/Broadcasting/PusherBroadcasterTest.php:
     annotations:
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/laravel/laravel/bfd4b1e92f7c6b4e6b74cfdde995a5afad648d96/app/Http/Controllers/Auth/VerificationController.php:
     annotations:
       human-smola: PHP
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/larrypoo/vista-utilities/8531106095245645accbda99a753d169298ee618/KBAPHL7VIEWER1.KID:
     annotations:
       linguist: Genshi
+      linguist-extension: Genshi
       vote: Genshi
   github.com/larsbrinkhoff/lbForth/00aa97948c6e12c46ee903da96948998c8c33853/targets/pic/asm.fth:
     annotations:
       human-smola: Forth
       linguist: Forth
+      linguist-extension: Forth
       vote: Forth
   github.com/larshp/abapGit-Plugins/cc3862b9a2feaefa8ae300997e7c8bddf3967189/src/zcl_abapgitp_object.clas.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/larshp/abapGitServer/741903adb1fce9225a2c48159f4be41fe0e6a18f/src/frontend/zags_migration_03.prog.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/larshp/abapOpenReview/18ad4209c143b86aa4c40f7408b073e1b01e8525/src/zcl_aor_transport.clas.locals_imp.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/larshp/upDOWNci/fee1d90c822e63569e25256319c43d7ef4e081c2/src/zcl_updownci_file.clas.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/larsiusprime/firetongue/fc311394616279d99f7ff164bb52e3a17319ac04/firetongue/CSV.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/larsyencken/marelle/02fb567b10493d1469b533013486994c34a92547/sudo.pl:
     annotations:
       linguist: Prolog
+      linguist-heuristics: Prolog
       vote: Prolog
   github.com/larzm42/dom4inspector/1f39fbc7fe94c2c81a7c82ce75a59b776b8a0c9b/mods/ExpandedMods/Globals/GuardiansOfTheDeep.dm:
     annotations:
       human-smola: Unknown
       linguist: DM
+      linguist-extension: DM
       vote: Unknown
   github.com/lasp-lang/partisan/98aa8b80160db621173be692f0e729079a3336fc/src/partisan_peer_service_server.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
       vote: Erlang
   github.com/lauryndbrown/Cisp/9364c7392ff903bbb3f2f7d72e188e0126afd89b/cisp-error.cbl:
     annotations:
       linguist: COBOL
+      linguist-extension: COBOL
       vote: COBOL
   github.com/lazerwalker/hubot-imessage/ec1163b4779b75174f46d16c04bb768378295075/src/Hubot Event Handler.applescript:
     annotations:
       human-ajnavarro: AppleScript
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/lboasso/oberonc/688da3d12b2b04c25f6f3d7f132543aa488fe0e5/tests/base/TestByteType.Mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/ldc-developers/ldc/94743b90fc2205bf406d0665503ddf361a2c0eb7/dmd/opover.d:
     annotations:
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/ldci/RedEdit/5a4b41c88dac6bae7fe883621ef9a448a75fe039/editor.2.0.1.r:
     annotations:
       human-smola: Rebol
       linguist: Rebol
+      linguist-heuristics: Rebol
       vote: Rebol
   github.com/ldci/redCV/1ad8b70390b6eeb376cb686c7982e562e0f58417/libs/tiff/rcvTiffRoutines.red:
     annotations:
       linguist: Red
+      linguist-extension: Red
       vote: Red
   github.com/ldclakmal/ballerina-samples/468c6e3a0973bfdf8b55e802bd17b7cd41eb4a58/src/connectors/committer.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/ldfallas/graphicswithmercury/e7eb1071e9d7c7ce26c43cb666cda97eb08b4b33/test.m:
     annotations:
       linguist: Mercury
+      linguist-heuristics: Mercury
       vote: Mercury
   github.com/le-moulin-studio/java-semantic-diff/badbd873e0d5df585bd63c316f2a72c75d013796/src/main/antlr4/Java.g4:
     annotations:
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: ANTLR
   github.com/leachim6/hello-world/4f62f18aab3d7dd8b0095ce45b0925736700ae1d/a/assembler_6809vectrex.asm:
     annotations:
@@ -10288,115 +12659,145 @@ files:
   github.com/leanmix2018/Central-sfv-SFDC/e140c043d2d66ce98e8c5370a60c079543bfb65e/src/main/resources/customer-request.dwl:
     annotations:
       linguist: DataWeave
+      linguist-extension: DataWeave
       vote: DataWeave
   github.com/leanmix2018/test32/5ff5fbcbf3a0bea172250f895e4f88990f90f9c8/src/main/resources/orders-request.dwl:
     annotations:
       linguist: DataWeave
+      linguist-extension: DataWeave
       vote: DataWeave
   github.com/learnbyexample/scripting_course/37b501884a4677495baaa0ced1892c2f04198820/.vimrc:
     annotations:
       linguist: Vim script
+      linguist-filename: Vim script
       vote: Vim script
   github.com/learnroku/crash-course/fdce9023c75198b95657389c22e032bf54e4628b/lesson_6/components/screens/content_screen.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/ledgersmb/LedgerSMB/24a8d7a2c99f4d6390cdf0356f4f3e05124c2c1b/sql/modules/Date.sql:
     annotations:
       linguist: PL/pgSQL
+      linguist-heuristics: PL/pgSQL
       vote: PL/pgSQL
   github.com/lehitoskin/blight/807b0437c92ee41c68ca5a767d973817ae416b65/audio.rkt:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/lemire/simdjson/c4f1baad31bc47b183fa5a602ce1ccdccdfcc883/tools/json2json.cpp:
     annotations:
       linguist: C++
+      linguist-extension: C++
       vote: C++
   github.com/leoc/.emacs.d/5ee2d1a183e1bee5e706a7129ebb600cec6a7482/snippets/haml-mode/lorem.4:
     annotations:
       linguist: YASnippet
+      linguist-heuristics: Roff
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/leocwolter/caelux/7c3df5f037ff8f3cc2e6f6c5d0ff81d057f17914/src/layouts/default.html.hb:
     annotations:
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Harbour
   github.com/leon-vv/Todo/2563287306b7cdc901b7d3a8fbefc8229e4e1a62/Main.idr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/leonardocarvalho/sicp/5dd4833e5f1c1261bd1d5aa80a4de9eaf25a0115/chapter1/7-8.lisp:
     annotations:
       human-ajnavarro: NewLisp
       linguist: NewLisp
+      linguist-heuristics: NewLisp
       vote: NewLisp
   github.com/leoxiaobin/deep-high-resolution-net.pytorch/163eb4797e5242d753ccbc69a4354b487657fdcb/lib/nms/nms_kernel.cu:
     annotations:
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/lepinekong/redlang.red/371040193337d1ca50d42d49be099a410d822ec3/lib-ext.red:
     annotations:
       linguist: Red
+      linguist-extension: Red
       vote: Red
   github.com/level44/design-patterns-in-tcl/1da3cbee2220b535b227d99a3aec499b2c84f7b1/Builder/Builder.tcl:
     annotations:
       linguist: Tcl
+      linguist-extension: Tcl
       vote: Tcl
   github.com/lexi-lambda/hackett/8e4e0e904ac37df58b8c8ef29c0f94ad4151246f/hackett-test/tests/hackett/integration/pattern-alias.rkt:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/lexrus/LTMorphingLabel/dfa416622d3fa8d3f4361e094224617aa1522f35/LTMorphingLabel/LTMorphingLabel+Burn.swift:
     annotations:
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/lfe-rebar3/clean/4a0be20e4ebba78921d5ae2adfa77c0d01b51943/src/lfe-clean.lfe:
     annotations:
       linguist: LFE
+      linguist-extension: LFE
       vote: LFE
   github.com/lfe-rebar3/test/f435d7aae128d56b91614da2ae7cf103add32eea/src/lfe-test.lfe:
     annotations:
       linguist: LFE
+      linguist-extension: LFE
       vote: LFE
   github.com/lfe-rebar3/version/c251d852b699798657cfc836847626498e92991b/src/lfe-version.lfe:
     annotations:
       linguist: LFE
+      linguist-extension: LFE
       vote: LFE
   github.com/lfex/lcfg/b631f707f4c51b6f9b1221a76616d9587530bbc2/src/lcfg-deps.lfe:
     annotations:
       linguist: LFE
+      linguist-extension: LFE
       vote: LFE
   github.com/lfex/lfeyawsdemo/7ae331cf8abb36741dd76b8eb0f7b88237f4d973/src/sample-app-routes.lfe:
     annotations:
       linguist: LFE
+      linguist-extension: LFE
       vote: LFE
   github.com/lfex/ljson/65078dcc07f9322dc40203b4d55fda980d899ddf/src/ljson.lfe:
     annotations:
       linguist: LFE
+      linguist-extension: LFE
       vote: LFE
   github.com/lfex/logjam/f8dd75722ea6a97d154218d1c137dbb786e62d64/src/logjam-util.lfe:
     annotations:
       linguist: LFE
+      linguist-extension: LFE
       vote: LFE
   github.com/lfex/ltest/8194e2912d03c3ec00768e208b5789d6ac0c1fad/src/ltest-listener.lfe:
     annotations:
       linguist: LFE
+      linguist-extension: LFE
       vote: LFE
   github.com/lfex/lutil/3db9ebe11e4605d9fe4cf9b0c36ceb903289631b/src/lutil.lfe:
     annotations:
       linguist: LFE
+      linguist-extension: LFE
       vote: LFE
   github.com/lfkrebs/stata-cookbook/77f3a73d1f6eb0429b7bce0fd80d72133a27ec7a/labeling.do:
     annotations:
       linguist: Stata
+      linguist-extension: Stata
       vote: Stata
   github.com/lhb5883/LabVIEW/129c22c55a35e62310bb0143502e3ed50b1e6162/Actor Framework/Simple Actor Example/Simple Actor Example.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/liamoc/learn-you-an-agda/118c5d99819c6b3c3a5e1dedfc0078c4fa8c2ece/Printf.agda:
     annotations:
       linguist: Agda
+      linguist-extension: Agda
       vote: Agda
   github.com/liancheng/brainsuck/afbdcd050c145458ee7fc528c03748381ccb4311/scripts/hanoi.b:
     annotations:
@@ -10405,18 +12806,22 @@ files:
   github.com/liasomething/shapeConverter/48485e50c38ded43319a0abe16ac46648b60d35d/ShapeConverter/Button.pde:
     annotations:
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/libra/libra/3d577356a92a364b2cf2549b9f6f488a44a27b2d/language/vm/vm-runtime/src/counters.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/libstatgrab/Unix-Statgrab/6f19575750d4479216afdb661a19451e2d9c527f/Statgrab.xs:
     annotations:
       linguist: XS
+      linguist-extension: XS
       vote: XS
   github.com/libuv/libuv/780c08a63efb65aed65da57c36f1c5b10f25cc1d/test/test-loop-time.c:
     annotations:
       linguist: C
+      linguist-extension: C
       vote: C
   github.com/linboqiao/EEA/5b6ffa08d1972946d6941ac6b7ae57f9fe805dcc/limo-re/parser/bllip-parser/first-stage/DATA/EN/ru.g:
     annotations:
@@ -10426,40 +12831,49 @@ files:
   github.com/lincolnlau/block/a56b023ddfaaafcbcb6bfb901e859a461fa6c890/src/parser/Component.g4:
     annotations:
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: ANTLR
   github.com/linuxdeepin/deepin-wm/ce6b375d86b98bebc3d9bfd598eb48987118710d/src/Widgets/SafeWindowClone.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/linxinhong/ViATc/755cead6477dfc8968009f41dc7d41252fc1ac4b/actions/General.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/lirios/fluid/a99dc04a067abeb9110664f5427e9a701e6744d4/src/imports/controls/SubheadingLabel.qml:
     annotations:
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/lirios/lirios/b247bae2d11bbbcb51345fc50e3b08c62c0ea655/config/liri.qbs:
     annotations:
       human-smola: QML
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/lisael/pied/f4d9d6bbb7858633fd01101d91b550bd9c5d1704/pied/term_mode_vi_normal.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/lisawray/fiftyshades/a316281545f88b212b6afdfa51e05e0cf3de74fe/50shades.pb:
     annotations:
       human-smola: Unknown
       linguist: PureBasic
+      linguist-extension: PureBasic
       vote: Unknown
   github.com/liuaijiao/gitbranch/4f710d6b42f6078208325e31a64436365bf25def/ws_objects/mybreanch1.pbl.src/w_breanch1.srw:
     annotations:
       linguist: PowerBuilder
+      linguist-extension: PowerBuilder
       vote: PowerBuilder
   github.com/liuziwei7/fashion-landmarks/5cd79b79b22ea9973879cfe579be7585867febeb/scripts/pipeline_init.m:
     annotations:
       linguist: MATLAB
+      linguist-heuristics: MATLAB
       vote: MATLAB
   github.com/ljepson74/svsc/84df9d4ce0f956a70fd0150c47ec04c09dcf2b9d/my_sysverilog_examples/svs_lessons/lesson000X_mluvm_svsc/uvm_examples/xcore/e/xcore_port_config.e:
     annotations:
@@ -10468,79 +12882,98 @@ files:
   github.com/ljun20160606/blog/e2994de802f814031f87ab0fb85b5b1db3a6bde8/directory/tcp.md:
     annotations:
       linguist: Markdown
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/ljunkie/rarflix/ae24f3e956887a494c80f3132d37032ab07fbc07/Plex/source/rottenTomatoes.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/llinaresvicent/dotfiles/535d7cb7512ed6c14a39bc0c78c44074a6476285/.i3:
     annotations:
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Modula-3
   github.com/llvm-hs/llvm-hs/5eac40827f256f40fe5a13b70635ef1aff3f0f6f/llvm-hs/test/debug_metadata_2.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/llvm-mirror/llvm/2c4ca6832fa6b306ee6a7010bfb80a3f2596f824/test/Analysis/ConstantFolding/gep-constanfolding-error.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/lo-th/Shader.lab/18dcb7ac274be4a008eff022392e9e0234da9e82/glsl_test/organic.glsl:
     annotations:
       linguist: GLSL
+      linguist-extension: GLSL
       vote: GLSL
   github.com/loadingio/loading-bar/af5271ef7c675783fe870b5a60d6057f32f73e47/src/loading-bar.ls:
     annotations:
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/loadingio/transition.css/2f6b91c4b5b5ee28705de638ae3a7cd4a5df4574/tool/build-css.ls:
     annotations:
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/locklin/j-zeromq/ed643d255b400dfa8953a1df5108045fafdeb7a3/zmq-tsub.ijs:
     annotations:
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/logtalk-actions/portability/6915012efb8d269dc9267218f445911df8b6fc12/tests.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/loic0712/OpaBlog/6d90239599181c847bc4d0c81890476857b44f45/opablog.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/lolcodepp/sketches/a1fdc680cd46d84dfd3b3cf3b4bf0a393fc27754/deadfish.lol:
     annotations:
       linguist: LOLCODE
+      linguist-extension: LOLCODE
       vote: LOLCODE
   github.com/lorenzogentile404/foodhack-cph-2018/8a3cecf4fe9345689dc6fb7edb5870c139f6440e/diet.zpl:
     annotations:
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Zimpl
   github.com/lorin/alloy-consistency/6e6f1741f4e44dbb66f33e253732786c1416e0bc/concrete-executions.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/lorin/tla-linearizability/6a919f81f41ce43c884b87dde0976143b80d35db/TestRespectsPrecedenceOrdering.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/lostbearlabs/tiny-tlaplus-examples/7c25faa7495da0e29dd5796a0330b4e303a3e2ae/implements/ImplementsB.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/lowRISC/lowrisc-chip/7090b7b70f33aa3763e360d1c5b79fa3dd8a611c/src/main/verilog/sd_top.sv:
     annotations:
       human-smola: SystemVerilog
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/lowRISC/opentitan/85ca4e361f3152b835863ab86b54ce5c60d4e45f/hw/dv/sv/jtag_agent/jtag_agent_pkg.sv:
     annotations:
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/lowleveldesign/debug-recipes/6321575b4f6c7722b4bf2baa74ff2f97b7412eea/asp.net/diag-pages/WhoAmI.aspx:
     annotations:
       linguist: ASP.NET
+      linguist-extension: ASP.NET
       vote: ASP.NET
   github.com/lshhhhh/questplusplus/9bc06a0ed07e84dc0489290dad5ed1e942c8e354/input/target.word-level.ch:
     annotations:
@@ -10554,63 +12987,78 @@ files:
   github.com/lso400/kdb-grafana/7a3fe69fbc2c9c937725a3d9e4aac5658a0299a7/grafana_functions.q:
     annotations:
       linguist: q
+      linguist-heuristics: q
       vote: q
   github.com/luanfujun/deep-painterly-harmonization/a33a9a70366b6baff1cc0291f857b5895b271fc1/cuda_utils.cu:
     annotations:
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/lucattelli/ab4-themes/b050c17585631ca2175c34cee94510bab137ffca/test/abap_test.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/lucidnz/bootstrapify-1/b36ab7ff045eddb5558fe56fc85d5793c92f3b5f/theme/snippets/tags.liquid:
     annotations:
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/luckyframework/lucky/71dc544cca00675bdcd9451a13af35b4069482ad/spec/lucky/with_defaults_spec.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/lucydotc/Worthless-item-harvesting-kolmafia-plugin/5c48a6d4069a5a299a26a5d61c970005cef89cee/worthwhile_chewing_gum.ash:
     annotations:
       linguist: AGS Script
+      linguist-extension: AGS Script
       vote: AGS Script
   github.com/lueyoung/gmt-kafka/d3a978d960a86567e42380a3698dc92cd517240f/manifest/services.yaml.sed:
     annotations:
       human-smola: YAML
       linguist: sed
+      linguist-extension: YAML
       vote: YAML
   github.com/lukebussey/foundationify/4d4009dbd429cbf2c4d5f4f3d6b932f2e4739a55/templates/blog.liquid:
     annotations:
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/lukesampson/concfg/a38c23651458ea48e463f7402bf166c65855759f/libexec/search.ps1:
     annotations:
       linguist: PowerShell
+      linguist-extension: PowerShell
       vote: PowerShell
   github.com/lukesampson/scoop/6eb90c9c112c8c6c1790f1bd4e1c9cd67a6e70df/bin/describe.ps1:
     annotations:
       linguist: PowerShell
+      linguist-extension: PowerShell
       vote: PowerShell
   github.com/lukevear/qmakeAndroidSourcesHelper/e5974bb62b862fe5d106e13c11414929c2bd295e/functions.pri:
     annotations:
       linguist: QMake
+      linguist-extension: QMake
       vote: QMake
   github.com/lumihq/purescript-react-basic/feee3a51a531f65ff0c0802bffa77e9cd0bd0164/src/React/Basic.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/luna/luna/61e444cd94ff740caf3449d44edea5a3c165880e/core/src/Data/Graph/Data/Component/List.hs:
     annotations:
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/lutsen/weemail/b926ca9d0927b1dd278451cdbf1c19a83160ee0b/_partials/head.kit:
     annotations:
       linguist: Kit
+      linguist-extension: Kit
       vote: Kit
   github.com/luxas/kubeadm-workshop/592921a9754939b6db435c99e4f9377ddd5a98df/images/nginx/Makefile:
     annotations:
       linguist: Makefile
+      linguist-filename: Makefile
       vote: Makefile
   github.com/luxe/unilang/749e8285ff61aed471f3b37ba2e4a05aa75cd7f7/source/code/utilities/graphics/imgui/ui/draw/text/str_to_bdf_segments.hcp:
     annotations:
@@ -10621,40 +13069,49 @@ files:
     annotations:
       human-smola: NewLisp
       linguist: NewLisp
+      linguist-heuristics: NewLisp
       vote: NewLisp
   github.com/luyanfei/myexam/6e34782a94250042e7d28caf7f0e5b3cd79329d8/src/main/java/cn/jhc/myexam/server/repository/CategoryRepository_Roo_Jpa_Repository.aj:
     annotations:
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/lvcabral/Prince-of-Persia-Roku/aefc4d3932742e83464c511b661660ff784417e6/source/gameMods.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/lvzon/dsmr-p1-parser/9d82c0ba9fa45671f89a198832da525403f4f35e/parser-tools.rl:
     annotations:
       linguist: Ragel
+      linguist-extension: Ragel
       vote: Ragel
   github.com/lymslive/vimllearn/de5056511465305e1ef94a934a7f4d166194f2a7/example/funcref.vim:
     annotations:
       linguist: Vim script
+      linguist-extension: Vim script
       vote: Vim script
   github.com/m-yac/tt-in-cagda/d2c1c36cb3e09d8c3c73b8a043dbe36865765bce/src/DTLC/Base.agda:
     annotations:
       linguist: Agda
+      linguist-extension: Agda
       vote: Agda
   github.com/ma-ath/Amplificador-de-Potencia/eb5828dd4ff27abb62e4369cfa17e55c920f02dd/eletronica-iv-trabalho-PSpiceFiles/Trabalho/Trabalho.ALS:
     annotations:
       human-smola: Unknown
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Unknown
   github.com/macgregor/kol-telegram/33bc04925bebbaa29da77b376dab99fe3544c4e1/Release/scripts/telegram/__telegram_data.ash:
     annotations:
       human-smola: AGS Script
       linguist: AGS Script
+      linguist-extension: AGS Script
       vote: AGS Script
   github.com/machakann/vim-Verdin/11e2deeb01b3aa0de93685a02eabf9f1ccc90976/test/Dictionary.vim:
     annotations:
       linguist: Vim script
+      linguist-extension: Vim script
       vote: Vim script
   github.com/machineagency/jubilee/61c863b8147d2bf7c510df376cbd499c32062899/software/duet_config_files/sys/tpost1.g:
     annotations:
@@ -10665,20 +13122,24 @@ files:
     annotations:
       human-smola: REALbasic
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/macports/macports-base/aeb6d4386cd92afd0924a69bc8ee6154e651e8b3/src/port1.0/tests/portclean.test:
     annotations:
       linguist: Tcl
+      linguist-modeline: Tcl
       vote: Tcl
   github.com/macports/macports-ports/64f94ba5263135f2f0b1c5b5f1e2a88e340d5d26/lang/scheme48/Portfile:
     annotations:
       human-ajnavarro: Tcl
       human-smola: Tcl
       linguist: Tcl
+      linguist-modeline: Tcl
       vote: Tcl
   github.com/macropeople/macrocore/b1efcfc0d465e98f0ff5148d9bee0c05d74c9796/meta/mm_gettree.sas:
     annotations:
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/macshine/state_space/18fc800c183818f5e51011ad5a11ebf444e256af/make_manifold.m:
     annotations:
@@ -10689,40 +13150,49 @@ files:
     annotations:
       human-ajnavarro: Verilog
       linguist: Verilog
+      linguist-heuristics: Verilog
       vote: Verilog
   github.com/madeindjs/Crystagiri/f43ce36c8cb3ac2eb066d0f3478162c686946fc3/src/crystagiri/tag.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/madison-traynham/OrcadParts/538540ffc5a82af6ddb72910f4ea016fe017e2a0/pcb_lib/x7r_0603.caps.dcl:
     annotations:
       human-smola: Unknown
       linguist: Clean
+      linguist-extension: Clean
       vote: Unknown
   github.com/maduce/fosscad-repo/5b946f7d623b29914461182fa815e6a1c9f4146e/Rifles/AR-15_Magazine_Catch/Mag_catch_finger.scad:
     annotations:
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/magecoach/run.mage.coach/baf02f8cd929d212fc2629da58b1da9263246011/server/views/home.hb:
     annotations:
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Harbour
   github.com/magnesium-lang/scratch/126aac1e82f033f387cc4b0ed74ffc1e23a7797e/scratch.mg:
     annotations:
       human-smola: Unknown
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Unknown
   github.com/mahengyang/seqchart/43c7dc2e2706b4447a2d30816730c7eee5cd1dd8/main.red:
     annotations:
       linguist: Red
+      linguist-extension: Red
       vote: Red
   github.com/maheshraju/salesforceconnectorapi/388eb6dbc14a100d7f37d92fa8e3d0a24806dd74/src/test/resources/sample_data/Account.dwl:
     annotations:
       linguist: DataWeave
+      linguist-extension: DataWeave
       vote: DataWeave
   github.com/mainframed/MiniLabs/00431025c7a519e0589a2af25a24a3960ab09738/Extra/APF.rexx:
     annotations:
       linguist: REXX
+      linguist-extension: REXX
       vote: REXX
   github.com/majaxadobe/acme-sac/a37310031957f93b176f483b33c10095d341af86/appl/cmd/dict/roget.b:
     annotations:
@@ -10731,75 +13201,93 @@ files:
   github.com/major/MySQLTuner-perl/345bf1ae246e0a2740ffc75064532991fa605faf/build/updateCVElist.pl:
     annotations:
       linguist: Perl
+      linguist-heuristics: Perl
       vote: Perl
   github.com/makuto/galavant-unreal/08b761953f686695c730efca28f85acfb40693fd/GalavantUnreal/GalavantUnrealConfig.pri:
     annotations:
       linguist: QMake
+      linguist-extension: QMake
       vote: QMake
   github.com/malmaud/TensorFlow.jl/a74b560c2b4989579cd2f4a573c875ab54bf0951/src/protobufs/checkpointable_object_graph_pb.jl:
     annotations:
       linguist: Julia
+      linguist-extension: Julia
       vote: Julia
   github.com/manashmandal/OpenCV-With-QT-Quick-Demo/c9e9f07c81572fa564662ff8485e09d3c59f6f8a/OpenCV.pro:
     annotations:
       linguist: QMake
+      linguist-heuristics: QMake
       vote: QMake
   github.com/manastech/webmock.cr/78bb0e3b5850c700da0e7fbdd2d6c180cc4a061b/spec/webmock_spec.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/mandosrex/AoE3ImpMod_Base/69b6d477f39f45f54689d0b6104d544756248924/RMM/sonoraLarge.xs:
     annotations:
       human-smola: Unknown
       linguist: XS
+      linguist-extension: XS
       vote: Unknown
   github.com/mangadventure/font/ad3f03a512b27ff346457a2d417fbdd3400a383c/icons/numlist.svg:
     annotations:
       linguist: SVG
+      linguist-extension: SVG
       vote: SVG
   github.com/manoloide/AllSketchs/b5ad40b0f5bd0b43ab77777e3246d28b5347ecb8/2013/animator/animator01/animator01.pde:
     annotations:
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/maphew/svg-explorer-extension/9cb3c236a360cf2473cad9eab55da4c7a92d3809/build-SVGThumbnailExtension-Desktop_Qt_5_12_3_MinGW_64_bit-Release/Makefile:
     annotations:
       linguist: Makefile
+      linguist-filename: Makefile
       vote: Makefile
   github.com/mapmeld/fortran-machine/63e8a13894d0c37dfa22091833dc57a2e50ea538/flibs-0.9/flibs/experiments/chk_integer.f90:
     annotations:
       linguist: Fortran
+      linguist-extension: Fortran
       vote: Fortran
   github.com/marcan/xmos-speaker-dsp/216125b6b6ef4199b0cabe38f6913ea29f278e4e/firmware/dsp.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/marcelbirkner/docker-ci-tool-stack/2489e0c29df998bc4d23c7725cf56a3569f02a03/jenkins/groovy/upgradeAllPlugins.groovy:
     annotations:
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/marcellourbani/abap_debugger_object_graph_extension/f4713f494301519ee64297df77f020ace9a6bc18/zcl_debug_obj_graph_factory.clas.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/marcolapo98/test-EcommerceSite/b77557648bfc0359c1f5e503402901ad184e642d/templates/_nav.kit:
     annotations:
       linguist: Kit
+      linguist-extension: Kit
       vote: Kit
   github.com/marcoscleison/cdo/3823daf62822d811a6e057101009391fc6319a73/example/update_mysql_ex.chpl:
     annotations:
       linguist: Chapel
+      linguist-extension: Chapel
       vote: Chapel
   github.com/marcoscleison/chapel-http/34b9f8c4f16dab5d11f8449c8ac94a8a868caf19/http.chpl:
     annotations:
       linguist: Chapel
+      linguist-extension: Chapel
       vote: Chapel
   github.com/marcqualie/hoard-utils/1069f1b8d943afeb9d4d66008fc8901fdc81275c/hoardutils/servermetrics.zep:
     annotations:
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/marcvanzee/music-generator/3499f7177daf7df4dd1b234d345f8f48f2ec4ea5/notes.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/marekyggdrasil/optilogistics/4a8f367694a3470a7783bed3558418d3ac857a2d/example_1.mod:
     annotations:
@@ -10808,64 +13296,80 @@ files:
   github.com/markcwm/openb3dmax.mod/c43e78e2e117dba8e880fe7fafdb3bc17e845360/openb3dlib.mod/openb3dlib.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/marklogic-community/Corona/a5178fccc91a5e68e98e9dfb56587329a6f7dd10/corona/lib/store.xqy:
     annotations:
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/marklogic-community/atompub-server/f458905c8cb75c308798f805951d9af6387928f6/AtomPub/post.xqy:
     annotations:
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/marklogic-community/commons/875714edb546c79702b5424e0ffa63502e3b2401/http/rapid-app-demo/src/modules/test-lib-parser.xqy:
     annotations:
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/marklogic-community/data-explorer/fb3f78fe2897cb2a9ee4b2c4fb08d9627fdab60b/src/main/ml-modules/root/server/endpoints/api-auth.xqy:
     annotations:
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/marklogic-community/ml-rest-lib/325ff01d199c0d5647174d820d1a8979e8560060/MLS/tests/default.xqy:
     annotations:
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/marklogic-community/roxy/457fe50add5f24107bb890af88ac724bdf443bd2/src/test/test-config.xqy:
     annotations:
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/marklogic-community/smart-mastering-core/c77acfe3c72f1703a569afa86c14a6a6ae938228/src/test/ml-modules/root/test/suites/merging-json/rollback-merge.xqy:
     annotations:
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/martin-leuner/alcove/4abaded6c04b3b6005a1ed46bfb5c138f4f3fab9/gap/Matroid.gi:
     annotations:
       linguist: GAP
+      linguist-extension: GAP
       vote: GAP
   github.com/maryrosecook/gameoflife/24b6dc0ecae3431412b583e353d1d06d84d3b3af/main.ik:
     annotations:
       linguist: Ioke
+      linguist-extension: Ioke
       vote: Ioke
   github.com/masak/temporal-flux-perl6syn/dae2d68c1d2cf98b21d3031bfdc6fb7a22dcc3ba/S26-documentation.pod:
     annotations:
       human-smola: Raku
       linguist: Raku
+      linguist-heuristics: Pod 6
+      linguist-modeline: Raku
       vote: Raku
   github.com/masak/web/783673f94cdd745399366c7bee805818ebf922e6/lib/Ratel.pm:
     annotations:
       human-smola: Raku
       linguist: Raku
+      linguist-heuristics: Raku
       vote: Raku
   github.com/masonwheeler/RMXP-Scanner/8e8d21ff89a6094bfae05ac574992f6d8ba0bb18/RMTable.boo:
     annotations:
       linguist: Boo
+      linguist-extension: Boo
       vote: Boo
   github.com/massimo-filippi/mikrotik/0d2e5f4a3acbdeacc3ac337cd543df92109a7556/backup-config.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/massiveinteractive/MassiveUnit/2fef211fded516f97afc49f31698b1a59cf22c53/test/massive/munit/client/URLRequestTest.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/matej-macak/Neuron_Vagrant/1d40cea1b931629bac4fd53d064d753b21e7ceea/Python3.4/Mods/h.mod:
     annotations:
@@ -10879,6 +13383,7 @@ files:
     annotations:
       human-smola: Logtalk
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/materialsvirtuallab/snap/d2b9c3c618cc3a808ca2f8cc3267211b98105226/Mo/usage/elastic_example/displace.mod:
     annotations:
@@ -10887,19 +13392,23 @@ files:
   github.com/math-comp/math-comp/71e397e46b65c1c27a65471170d71f388c8a45f1/mathcomp/ssreflect/div.v:
     annotations:
       linguist: Coq
+      linguist-heuristics: Coq
       vote: Coq
   github.com/matheusamazonas/yapcol/1596773c95d2670b7467de250555edf32a6f6f8f/yapcol.icl:
     annotations:
       human-smola: Clean
       linguist: Clean
+      linguist-extension: Clean
       vote: Clean
   github.com/matheusjustino/Projeto-Alloy/47cba78a78a69e079306581972facbc4b14bd7a0/AppStore.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/mathiasbynens/dotfiles/8cf8c1c8315a6349224eeb3ecc033d469456025f/.aliases:
     annotations:
       linguist: Shell
+      linguist-shebang: Shell
       vote: Shell
   github.com/matslina/awib/eaf1d79c6b896ee156637f14cb19382611b892a6/lang_generic/backend.b:
     annotations:
@@ -10908,34 +13417,42 @@ files:
   github.com/mattermost/mattermost-server/a7c1514d8e5aab7efbe174cce1d770f2e0160fd4/utils/markdown/fenced_code.go:
     annotations:
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/matthieugomez/sumup.ado/6a82fb066130c0b6022a561dd43004df7d12a675/sumup.sthlp:
     annotations:
       linguist: Stata
+      linguist-extension: Stata
       vote: Stata
   github.com/matthieugomez/tidy.ado/f6c946d98b0b0db6fa9c22c88417ef0e91b6c813/gather.sthlp:
     annotations:
       linguist: Stata
+      linguist-extension: Stata
       vote: Stata
   github.com/matthmsl/docker-nit/c850ac7c9785fac0964705050abc81a14c10793c/docker.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   github.com/mattoraptor/7langs/f09e101310c6295bfc442217fce3f8cda6b16b69/io/day1/rpc.io:
     annotations:
       linguist: Io
+      linguist-extension: Io
       vote: Io
   github.com/mattrepl/reputator/2a62d960d34f7b23ec2011a79aabeaec9eecff14/reputator.arc:
     annotations:
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/mattsmi/CLIPS_Date_Functions/770ac9fb12314f1cc1400738bfdace8c652ca66a/VariousDateFuncs.clp:
     annotations:
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: CLIPS
   github.com/mauriciolauffer/ABAP/e0116d1a1e195f37d04024c1b219f4c6e8f235f5/Utilities/class_bdcdata.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/maxmanus96/Pattern-Recognition/c56f84af25b343e6e00aa0b993e4b8f0d87dd0ea/Untitled1.m:
     annotations:
@@ -10946,47 +13463,59 @@ files:
     annotations:
       human-smola: Shell
       linguist: Shell
+      linguist-extension: Shell
+      linguist-shebang: Shell
       vote: Shell
   github.com/mbcrawfo/GenericMakefile/d1ea11252105597156fb5aaecf687391475c2ca1/c/Makefile:
     annotations:
       linguist: Makefile
+      linguist-filename: Makefile
       vote: Makefile
   github.com/mbgh/aes128-hdl/420273ed18f42b3af70acfeb060b3ec5a80a6bc4/src/sv/mixColumn.sv:
     annotations:
       human-smola: SystemVerilog
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/mblakele/task-rebalancer/9d8596a8c30ec3838dd420eb434903f14ef620b1/rebalance.xqy:
     annotations:
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/mbourgey/Concordia_Workshop_Biopython/963869b8f5f4b0268b1326b3b185709e3b21da2a/data/muscle-patato_pep.clw:
     annotations:
       linguist: Clarion
+      linguist-extension: Clarion
       vote: Clarion
   github.com/mbutterick/pollen/618c4100628b3a3c38c82d8a8362a1991337a0c0/pollen/scribblings/utils.rkt:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/mcaceresb/stata-gtools/e38a399422f1bd263fea6f061fb57bc331f2c612/src/github-issues/30b/reply01.do:
     annotations:
       linguist: Stata
+      linguist-extension: Stata
       vote: Stata
   github.com/mcandre/factcheck/d433ad1628b264429e3137ae35517844559eba6c/factcheck/factcheck.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/mcanet/knitic/46c96a99258f1c9941bf987fbe4c57e1e55e369a/protoAppKnitic_p5/protoAppKnitic_p5.pde:
     annotations:
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/mchav/GeoQuiz-Frege/ac08e0059f32b5807576ed349f85ac876908bcfa/app/src/main/frege/io/github/mchav/freoquiz/MainActivity.fr:
     annotations:
       linguist: Frege
+      linguist-heuristics: Frege
       vote: Frege
   github.com/mchav/froid/0fe48c35adbe3b65abbfdbaa747a8578d2c743cf/src/frege/froid/view/MotionEvent.fr:
     annotations:
       linguist: Frege
+      linguist-heuristics: Frege
       vote: Frege
   github.com/mcimini/GradualizerDynamicSemantics/c013ae31547a81e5214e0fa39c1999b86c9a0ca4/GradualFpl_mechanized_proofs/fpl.mod:
     annotations:
@@ -11002,23 +13531,28 @@ files:
     annotations:
       human-smola: Mirah
       linguist: Mirah
+      linguist-extension: Mirah
       vote: Mirah
   github.com/mcsoto/cosmos/578c831e3ac5cceba906bdd77ca5111e1ea4ffb2/src/hello.pl:
     annotations:
       human-smola: Prolog
       linguist: Prolog
+      linguist-heuristics: Prolog
       vote: Prolog
   github.com/mdn/webassembly-examples/c82d7669903fee8e935c23c0ff9686509bb49da3/js-api-examples/memory.wat:
     annotations:
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/mecon/factor/28a1573d8e2f67a47a2bc4358c00a2766d3e33d2/core/alien/syntax/syntax.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/meddle0x53/echo/e77e218d6898dd69cc7c8e8f5d385b58a843bc32/src/echo-sup.lfe:
     annotations:
       linguist: LFE
+      linguist-extension: LFE
       vote: LFE
   github.com/mehlon/limbo-playground/b10d5b3276f0e3de788e5ea8b05a25148026e3f0/appl/imagemap.b:
     annotations:
@@ -11028,19 +13562,23 @@ files:
     annotations:
       human-smola: Unknown
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Unknown
   github.com/menski/dotfiles-old/2bf5eea12ad781f78a063e1f0941e0673c9c7a93/xorg/.Xresources.color.self:
     annotations:
       human-smola: Unknown
       linguist: Self
+      linguist-extension: Self
       vote: Unknown
   github.com/mephistopheles-8/ats2-spsc/9527d26351d558e60139e22745402233609a7e07/DATS/ringbuf.dats:
     annotations:
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/metabase/metabase/d9835d0bf30f92a3074bd36467b2aa4abe987a39/test/metabase/query_processor/middleware/parameters/native/substitution_test.clj:
     annotations:
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/metabrainz/musicbrainz-server/fbab8249f94cdba154410e19ceb8d304b7c178d9/admin/replication/BundleReplicationPackets:
     annotations:
@@ -11049,139 +13587,173 @@ files:
   github.com/metacore/A2Community/ccb8d7d5054d69effd465076beb4f4a42bbf5985/Work/Components/WMChart.Mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/metagol/metagol/c68ba54e55cab3126b7c87166bbac679dc59c863/metagol.pl:
     annotations:
       linguist: Prolog
+      linguist-heuristics: Prolog
       vote: Prolog
   github.com/metalfist213/Tiffany/f8ef8aaaa85de5aecc83b4e6b704b00043fd3bdd/GameCore/libs/com/badlogic/gdx/utils/JsonReader.rl:
     annotations:
       linguist: Ragel
+      linguist-extension: Ragel
       vote: Ragel
   github.com/meteor/meteor/d84f4c2083cb669d09beb6d3ee50f93995113db7/packages/autoupdate/autoupdate_server.js:
     annotations:
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/mfelsche/pony-maybe/110847b0fb63f59182423072a5624db10bce83c2/maybe/maybe.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/mfelsche/ponycheck/76523d528992145bea6b39375f357ffc9c108348/ponycheck/property.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/mgonto/restangular/a81d594f12fc88ba4b16e35ff328f6c7fddfb741/test/restangularSpec.js:
     annotations:
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/mguida22/doge-latin/4c083c9a8beeb5d9f4e27cb8932360cb990fcbd2/doge-latin.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/mhliu0419/M160_Project2/bbbee1b0e53efad5497ca45d8b98bb4c2751821c/sudoku_2.zpl:
     annotations:
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Zimpl
   github.com/mhmerrill/arkouda/ae96c375d40642d032c37301676ef3392d4ee61e/toys/brad_countingsort.chpl:
     annotations:
       linguist: Chapel
+      linguist-extension: Chapel
       vote: Chapel
   github.com/mhmxs/ballerina-gold-exchanger/2ee3a47bef09633b0d18d32bc86a2426af94121a/exchange-enterprise.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/michaelstepner/healthinequality-code/b4c87435752c0b15334b0e7fca86ca860a3a47a6/code/covariates/clean_brfss.do:
     annotations:
       linguist: Stata
+      linguist-extension: Stata
       vote: Stata
   github.com/michaelvillar/dynamics.js/c82261d09309157f9567c4119cd3474e2af6148c/src/dynamics.coffee:
     annotations:
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/michalstocki/FlashWavRecorder/50fbef845c4f6e861562ecedd7c210d69017d78e/src/test/flashwavrecorder/MicrophoneSamplesEventTest.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/michauds/pqnit/d1403590bfd645a43b30b7284cb49cff8eb40f12/libpq.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   github.com/micropython/micropython/4be316fb072ab7c2f28da815ead970ebf705c328/drivers/cc3100/src/flowcont.c:
     annotations:
       human-smola: C
       linguist: C
+      linguist-extension: C
       vote: C
   github.com/microsoft/TypeScript/1c42c1aaa82de92d40030ae9e3ecb95831ad18f5/tests/cases/fourslash/formattingofSingleLineBlockConstructs.ts:
     annotations:
       human-smola: TypeScript
       linguist: TypeScript
+      linguist-heuristics: TypeScript
       vote: TypeScript
   github.com/microsoft/fsharplu/0ffaa2503076597f5993e7b4b2df7dd8781974f4/FSharpLu/Platform.fs:
     annotations:
       linguist: F#
+      linguist-heuristics: F#
       vote: F#
   github.com/microsoft/llvm/eddbfad05ce3a85732d8bff9f85ef63afc97ad7e/test/CodeGen/Mips/stack-alignment.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/microsoft/php-sdk-binary-tools/050caa59e5f3ba952a8f3dc22b62f78a06352502/msys2/usr/share/bison/skeletons/lalr1.java:
     annotations:
       human-smola: M4
       linguist: M4
+      linguist-extension: Java
+      linguist-modeline: M4Sugar
       vote: M4
   github.com/microsoft/sql-server-samples/535fa5ab277ef0d8426f38f5ec9f6e16566be8c3/media/demos/sql-sampledb/sampledb1/sampleDB1.sql:
     annotations:
       linguist: SQLPL
-      vote: SQLPL
+      linguist-heuristics: SQL
+      vote: Unknown
   github.com/microsoft/terminal/9dc922fc37a479dd560675ac4ea1ce3713ae0ada/src/host/inputBuffer.hpp:
     annotations:
       linguist: C++
+      linguist-extension: C++
       vote: C++
   github.com/microsoft/tigertoolbox/b4a78b7b890e572a6657b13f529833ad70f7a141/Evaluate-Compression-Gains/view_CompressionGains.sql:
     annotations:
       human-smola: TSQL
       linguist: PL/pgSQL
+      linguist-heuristics: TSQL
       vote: TSQL
   github.com/microsoft/vcpkg/df4773c05614eb19084ae4db1fbc1bb3295d3ec6/ports/wren/portfile.cmake:
     annotations:
       linguist: CMake
+      linguist-extension: CMake
       vote: CMake
   github.com/microsoft/vscode/6d398260cbede43588b10e7b610d06500f127fb3/src/vs/workbench/services/extensions/electron-browser/extensionService.ts:
     annotations:
       linguist: TypeScript
+      linguist-heuristics: TypeScript
       vote: TypeScript
   github.com/midori-browser/core/d8546ca689af185a456ec1f394bb89926d7c142a/extensions/statusbar-features.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/mihaifm/screenkey.ahk/76b544456826fbb41ce18d7402887036f5361c2f/screenkey.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/mikebharris/COBOL-katas/b8cd2b1027f80a11ed171dec64c173df0ceb5482/COBOL-Number-Names/IntegerInWords.cbl:
     annotations:
       human-smola: COBOL
       linguist: COBOL
+      linguist-extension: COBOL
       vote: COBOL
   github.com/mikechambers/as3corelib/24c6c16aecbf0d8fcc043ae671e689b0d4b4c559/src/com/adobe/crypto/SHA224.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/mikeduglas/cJSON/c5a1f08307bb031c53dde2e6f5c9b92579f57cc5/libsrc/dynstrclass.CLW:
     annotations:
       linguist: Clarion
+      linguist-extension: Clarion
       vote: Clarion
   github.com/mikeduglas/libcurl/cd233916d226481b683eca47bf7366a1a916abf8/libsrc/libcurlmail.clw:
     annotations:
       linguist: Clarion
+      linguist-extension: Clarion
       vote: Clarion
   github.com/mileszs/ack.vim/36e40f9ec91bdbf6f1adf408522a73a6925c3042/autoload/ack.vim:
     annotations:
       linguist: Vim script
+      linguist-extension: Vim script
       vote: Vim script
   github.com/millerc3/Marching-Cubes/eb9f29658dacb79e91a9e3264404fc5a40696e8e/build_0_1_Data/Mono/etc/mono/2.0/DefaultWsdlHelpGenerator.aspx:
     annotations:
       linguist: ASP.NET
+      linguist-extension: ASP.NET
       vote: ASP.NET
   github.com/mingodad/ZeroBraneStudioLJS/db3e63bc53ffce8ebfa9c5b28c90dfccd1a6a0f4/lualibs/luadist.ljs:
     annotations:
@@ -11190,27 +13762,33 @@ files:
   github.com/minimalcomps/minimalcomps/90477b4ac7f2e0d59cb94cb7f2badcadb1799f2d/src/com/bit101/components/HSlider.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/mint-lang/mint/87082bedcf07c2c8012db1550f429287cd9c5cef/src/type_checkers/connect.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/mintern-java/functions/abf2f22ba6a1353e686f16313cf54917c2eddbb8/src/main/fmpp/Base.ftl:
     annotations:
       human-smola: FreeMarker
       linguist: FreeMarker
+      linguist-extension: FreeMarker
       vote: FreeMarker
   github.com/mirah/dubious/5985b669e604ccb9247a7a8ad1b41bbafe5f1d53/src/dubious/text_helper.mirah:
     annotations:
       linguist: Mirah
+      linguist-extension: Mirah
       vote: Mirah
   github.com/misdanwijaya/KatalonDemo/761c0c164e7e2a8f41b2a14618fc8624b5df226d/Object Repository/Page_Sample Store/iframe.rs:
     annotations:
       linguist: RenderScript
-      vote: RenderScript
+      linguist-xml: XML
+      vote: Unknown
   github.com/mist-devel/mist-board/a4e82ddd83d138e23fa1a52b8bc4755b5bd89205/cores/bbc/rtl/T65/T65_Pack.vhd:
     annotations:
       linguist: VHDL
+      linguist-extension: VHDL
       vote: VHDL
   github.com/mitxela/bf-tic-tac-toe/a1551c2c7b5dca4830545358216c299f8c41e53d/tictactoe-comments.bf:
     annotations:
@@ -11219,22 +13797,27 @@ files:
   github.com/mjavascript/practical-modern-javascript/7f9241cf248c286f5589e82a58765ed1dbb21a9b/theme/pdf/pdf.xsl:
     annotations:
       linguist: XSLT
+      linguist-extension: XSLT
       vote: XSLT
   github.com/mjb392/test-vista/baf0998bb155fa2fce7ecafc626d15b2ae8a04c4/Packages/Enrollment Application System/Patches/EAS_1.0_103/EAS-1_SEQ-84_PAT-103.KID:
     annotations:
       linguist: Genshi
+      linguist-extension: Genshi
       vote: Genshi
   github.com/mjcamerer/PhysicsEditor-XML-to-Function-Converter/82e1b45c2ab351378aa0c881752a4d06026ee6d9/Physics_Editor_XML_to_Function_Converter.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/mjcamerer/SimpleBox2D/230f925485d338457f8e736c8c9a7895ce9c3c56/box2dWorld.monkey:
     annotations:
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/mjhorvath/ColorMine/5f157b15e9e1969eb58e122acc2714ff1f3a4b39/ColorMine.inc:
     annotations:
       linguist: POV-Ray SDL
+      linguist-heuristics: POV-Ray SDL
       vote: POV-Ray SDL
   github.com/mjl-/dhcpd/15871ae11410d82c2fa0fc6501a5bc72f5077b39/appl/lib/ipval.b:
     annotations:
@@ -11243,10 +13826,12 @@ files:
   github.com/mjl-/lsynergy/cfb616ee1f60e1273d292fe1e95ec0ff5ca9050c/module/synergy.m:
     annotations:
       linguist: Limbo
+      linguist-heuristics: Limbo
       vote: Limbo
   github.com/mjl-/lyricd/d4ae0473b75574590decee49dd4f3557453d90f5/module/lyricutils.m:
     annotations:
       linguist: Limbo
+      linguist-heuristics: Limbo
       vote: Limbo
   github.com/mjl-/nfssrv/1c89da78fb6abf5d96ae8d76ac167a57fbe5796d/appl/cmd/portmapper.b:
     annotations:
@@ -11283,26 +13868,32 @@ files:
   github.com/mjohnsullivan/flutter-by-example/1b8599679b45ccdae45edc3167fa3fd8af5de24d/counter_architectures/change_notifier_example/lib/main.dart:
     annotations:
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/mjrb/mongo-lol-driver-example/08d1816f797f926afaf62d1c98bbfc840fd52b73/cgi-bin/index.lol:
     annotations:
       linguist: LOLCODE
+      linguist-extension: LOLCODE
       vote: LOLCODE
   github.com/mkromberg/apldemo/a54cb67f9551b458ea32d39aa1261517d382886a/Weather.dyalog:
     annotations:
       linguist: APL
+      linguist-extension: APL
       vote: APL
   github.com/mkromberg/qconnect/66fa9bd0853fa858f7909ec41c1310eca5490130/UT.dyalog:
     annotations:
       linguist: APL
+      linguist-extension: APL
       vote: APL
   github.com/mkromberg/vending/4747b05826c9b4cd7716140728201be8ee3848bd/Dispense.dyalog:
     annotations:
       linguist: APL
+      linguist-extension: APL
       vote: APL
   github.com/mlochbaum/JtoLaTeX/f84788b01af70613a2fd63431e8c68c658f33db7/jdoc.ijs:
     annotations:
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/mlubin/JuMPSupplement/07c282e0513dd204e9600975e05f08c40f368da0/acpower/opf_6620bus.mod:
     annotations:
@@ -11313,74 +13904,93 @@ files:
     annotations:
       human-smola: Unknown
       linguist: Boo
+      linguist-extension: Boo
       vote: Unknown
   github.com/mmastrac/snippets/4fe8455d9e39901b1ef41afde671dbb02aa7c816/mikrotik/dhcp-dns.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/mmatyas/GridWars/229dcf7c53a2e28afbafb5c8dada9c6c9f8f885f/sound.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/mmhelloworld/hello-play-frege/edcbca6df7702c1b5043ff007bf93dca44ade86e/src/main/frege/helloplay/FregeApplication.fr:
     annotations:
       linguist: Frege
+      linguist-heuristics: Frege
       vote: Frege
   github.com/mmhelloworld/idris-jvm/dee79c35c262db854a0ae3f9e0de07b526b20f7f/idris-jvm-ffi/src/main/idris/IdrisJvm/IO.idr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/mndrix/brass-plates/e8f0a7ab06f7f0bf2713b310675c95065086e4ee/people.m:
     annotations:
       linguist: Mercury
+      linguist-heuristics: Mercury
       vote: Mercury
   github.com/mndrix/microkanren-prolog/fef99b8cefa55b46977f581fe0e568887490261a/edcg.pl:
     annotations:
       linguist: Prolog
+      linguist-heuristics: Prolog
       vote: Prolog
   github.com/mne-tools/mne-testing-data/cc40c2964c81c83b9af317fc3cf9a9634a05f095/CTF/testdata_ctf_mc.ds/testdata_ctf_mc.hc:
     annotations:
       linguist: HolyC
+      linguist-extension: HolyC
       vote: HolyC
   github.com/mntmn/amiga2000-gfxcard/a8d21e93363febaabfb9dca5496db47b8b55a222/va2000-spartan6/xilinx_modules/tmds_out_fifo.v:
     annotations:
       linguist: Verilog
+      linguist-heuristics: Verilog
       vote: Verilog
   github.com/moappi/statbox/0f176a218c9c2cc73eab8639cd25087d9791efb2/src/stdlib/api_libs.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/moby/moby/c36460c437c8c515c543dd31afcbb5c2a9f5dd48/daemon/daemon_linux_test.go:
     annotations:
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/mockk/mockk/74f0951f69633db7a53a130ce66b2dda21f91231/mockk/jvm/src/main/kotlin/io/mockk/impl/instantiation/JvmMockFactory.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/mohan-phanindra/flights-odata-api/ffb337c4d8a2d2c6510118fa9541c0eed15f1bd1/src/main/resources/dwlScripts/getFlightsIdBuildQuery.dwl:
     annotations:
       linguist: DataWeave
+      linguist-extension: DataWeave
       vote: DataWeave
   github.com/mohanson/pywasm/9e101e91de8aea42c4c9dbc637f7b1ec57be3bf9/tests/spec/globals.wast:
     annotations:
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/mohemiv/TCLtools/545b2ad2a06a75eae36e1a8cc5eb77c77770be8d/tclproxy.tcl:
     annotations:
       linguist: Tcl
+      linguist-extension: Tcl
+      linguist-shebang: Tcl
       vote: Tcl
   github.com/moliad/liquid-libs/5f2454b055b434f659860df13721ecd0bfa242e8/glob.r:
     annotations:
       linguist: Rebol
+      linguist-heuristics: Rebol
       vote: Rebol
   github.com/moliad/misc-libs/99fde4a8cc7d7ddec8d33a9027ba62eee2203589/crypto.r:
     annotations:
       linguist: Rebol
+      linguist-heuristics: Rebol
       vote: Rebol
   github.com/moliad/slim/7b1ef657a9f29651b4f66372d58776d0ef81e24a/slim.reb:
     annotations:
       linguist: Rebol
+      linguist-extension: Rebol
       vote: Rebol
   github.com/molin1987/DNS/7a1c79ceea92c5b1fe23050358b6a4d2aa44a3a0/named/soundcloud.com.b:
     annotations:
@@ -11390,31 +14000,38 @@ files:
   github.com/monero-project/monero-gui/d5f4d5d93fa52876dc1fef591ea0210eab561d48/pages/AddressBook.qml:
     annotations:
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/mongrol/mongiloti/0d8afdf6089733ee1e5ae96658c9709d7ecc8eca/axoloti/drumsy2.axs:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/monkeylord/XposedTemplateForAS/d5cdd502ba09161c9d233c15331ba067be51cb61/Xposed Code/root/src/app_package/ClassesEnum.java.ftl:
     annotations:
       linguist: FreeMarker
+      linguist-extension: FreeMarker
       vote: FreeMarker
   github.com/morbos/STM32/2f87e26aacdf90ba9d8d1ca64ae12d2c8528a964/WB/WB55/client_wb55/src/comm/comm-shci.adb:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/moritz/perl6-Sudoku/187a83401ae9b6eca6f5c9b3d656bd317851b429/test.pl:
     annotations:
       linguist: Raku
+      linguist-heuristics: Raku
       vote: Raku
   github.com/morrisallison/event-station/4d749dabc67f2599c759e7a26de95da4f9d28dbd/tests/EventStation/Listeners/all-spec.ls:
     annotations:
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/morrisjs/morris.js/14530d0733801d5bef1264cf3d062ecace7e326b/lib/morris.grid.coffee:
     annotations:
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/mortcanty/CRCENVI/6938c3597139ed815affec0889baba1c8ada6f93/AUXIL/gausskernel_matrix.pro:
     annotations:
@@ -11423,48 +14040,60 @@ files:
   github.com/mortenbra/alexandria-plsql-utils/ada48755255df1be0bde6708adf243747c0000bd/ora/image_util_pkg.pks:
     annotations:
       linguist: PL/SQL
+      linguist-extension: PL/SQL
       vote: PL/SQL
   github.com/mortensol/EasyCrypt/c38842cebb09cf5ae5ca374b8d68fdbbd2239af8/CPA-masters-finished.ec:
     annotations:
       linguist: eC
+      linguist-extension: eC
       vote: eC
   github.com/moshowgame/SpringBootCodeGenerator/b7861ca9fc2ea542d4fc446953c8964b691d61f5/generator-web/src/main/resources/templates/code-generator/mybatis/mybatis.ftl:
     annotations:
       linguist: FreeMarker
+      linguist-extension: FreeMarker
+      linguist-xml: XML
       vote: FreeMarker
   github.com/mothdragon/CardCreator/31053b5d09aa4df666cfd5107a6b2a39f5b3529a/attribDialog.ec:
     annotations:
       linguist: eC
+      linguist-extension: eC
       vote: eC
   github.com/moyuanhui/kubernetes-study/29bd8d14042fb3af4ad0eaae14de9bef608af62c/yaml/coredns/coredns.yaml.sed:
     annotations:
       linguist: sed
-      vote: sed
+      linguist-extension: YAML
+      vote: Unknown
   github.com/moz-code/prez/280c19321ee037739c108dd6cdeffde9cd81767c/src/commands.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   github.com/mozart/mozart2/4806504b103e11be723e7813be8f69e4d85875cf/lib/main/dp/Site.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/mozilla-services/screenshots/33eeff19d361e2a12f5474cf9a0d5ef409082c99/locales/zh-TW/server.ftl:
     annotations:
       human-smola: Unknown
       linguist: FreeMarker
+      linguist-extension: FreeMarker
       vote: Unknown
   github.com/mozilla/blurts-server/39de9a07442a3c0e4240c22066fcc3cf817f2104/locales/zh-TW/bento.ftl:
     annotations:
       human-smola: Unknown
       linguist: FreeMarker
+      linguist-extension: FreeMarker
       vote: Unknown
   github.com/mperham/sidekiq.cr/25b1abcb4791d2b33d76286cd5ee049fcf45bbfd/src/sidekiq/middleware.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/mpeterv/luacheck/7360cfb4cf2c7dd8c73adf45e31a04811a745250/spec/serializer_spec.lua:
     annotations:
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/mpf/Optimization-Test-Problems/9ccb0ef85fb1a43b51f7149c76d5448ac9bbf9ae/cute/bt7.mod:
     annotations:
@@ -11474,39 +14103,49 @@ files:
     annotations:
       human-smola: CMake
       linguist: CMake
+      linguist-filename: CMake
+      linguist-heuristics: Text
       vote: CMake
   github.com/mratsim/Arraymancer/94efff361327c2748f8f073a27a96265f2d9f784/tests/manual_checks/allocator_regression_178_1st_part.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/mravella/maya_model/dcd2e3ad283c2b3f8fd82c18c4f09da1d0200d14/maya_model.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/mrhdias/perl6-Imlib2/07c0af9e7bb7dd95dcc1cc2183fa9f210bcd2ff6/t/14-color_ranges.t:
     annotations:
       linguist: Raku
+      linguist-heuristics: Raku
       vote: Raku
   github.com/mriffey/ClarionUD/211fbe0784ff0cb480a3d4409f5bba9a2451446c/libsrc/win/UltimateDebug.clw:
     annotations:
       linguist: Clarion
+      linguist-extension: Clarion
       vote: Clarion
   github.com/mriffey/RADFusionObjectsInClarion/9059cbd81c42c5e2b074b3d2d93c38ca78ec6190/ExampleCode/Code/Projects/PlayWav2.clw:
     annotations:
       linguist: Clarion
+      linguist-extension: Clarion
       vote: Clarion
   github.com/mrjbq7/re-factor/726fb3271774921d89bb33b2d4c62c3f34b22e91/yahoo/finance/finance.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/mrkkrp/common-lisp-snippets/c82ebf18f4ad49f390dd96ffcc59f8683c1a868b/snippets/lisp-mode/gnugpl:
     annotations:
       linguist: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/mrlesmithjr/ansible-rpi-k8s-cluster/cb06e785e8ab14df0b9089392d6539c1c19b0131/deployments/archive/coredns.yaml.sed:
     annotations:
       linguist: sed
-      vote: sed
+      linguist-extension: YAML
+      vote: Unknown
   github.com/msabbott/log4oe/21f19e3059744efeb611746834f3cb6cc651b4e4/log4oe/Tests/Stubs/StubLogger.cls:
     annotations:
       linguist: OpenEdge ABL
@@ -11515,15 +14154,18 @@ files:
     annotations:
       human-smola: C
       linguist: eC
+      linguist-extension: eC
       vote: C
   github.com/mschuldt/rtx2000_simulator/407c0be3cc1d774fdbbd90162121de045cabc3cf/RTX2000/TESTS/example.4th:
     annotations:
       linguist: Forth
+      linguist-extension: Forth
       vote: Forth
   github.com/msdx/android-proguard-cn/03c350d27bf84fa6aeafbd9968fef3fd51aa15ca/android.pro:
     annotations:
       human-smola: Unknown
       linguist: IDL
+      linguist-heuristics: Proguard
       vote: Unknown
   github.com/mshanemc/einstein-ai/2ab7bc8b64a336690e0341fc987880e7ac4a1fb4/src/classes/InvocableLanguageFeedback.cls:
     annotations:
@@ -11537,14 +14179,17 @@ files:
     annotations:
       human-smola: ColdFusion CFC
       linguist: ColdFusion
+      linguist-extension: ColdFusion CFC
       vote: ColdFusion CFC
   github.com/msracver/FCIS/309f6c9a1669bf05a955b66519a807951e70197f/lib/mask/mv_kernel.cu:
     annotations:
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/mstraughan86/Esoteric-Language-Studies/9d499081fa17ac5708882de1f0b35e201942a471/LOLCODE/app1.lol:
     annotations:
       linguist: LOLCODE
+      linguist-extension: LOLCODE
       vote: LOLCODE
   github.com/mthmulders/brainfuck-jvm/0f0c608ef0c3fed14751ee4615c3a1ae1226a919/language/src/test/resources/oobrain.bf:
     annotations:
@@ -11553,26 +14198,33 @@ files:
   github.com/mthom/shen-minikanren/6f90f1d7390fe45e2a40e048993a6737b9a1418d/types.shen:
     annotations:
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/mtiid/groove/07691b94cf4dc9543a3a630002957a8bbcd6a0be/rRobot.ck:
     annotations:
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/mtmd/FPGA_Based_CNN/95678ce28163a3a684ee6fb5ea26c7b0643324fe/DE5Net_Conv_Accelerator/pll_reconfig_xcvr_clk_src.v:
     annotations:
       linguist: Verilog
+      linguist-heuristics: Verilog
       vote: Verilog
   github.com/mulesoft-catalyst/analytics-event-aggregator/473c5a02c3bad794fe32dab39a67607353b909ac/src/main/resources/mappings/transform-to-analytics-event-array.dwl:
     annotations:
       linguist: DataWeave
+      linguist-extension: DataWeave
       vote: DataWeave
   github.com/mulesoft-consulting/oidc-mediator-sfdc/f525ea0ef11ed26b9ad2a03a173c5066c0c6b4c5/src/test/resources/sample_data/unknown_1.dwl:
     annotations:
       linguist: DataWeave
+      linguist-extension: DataWeave
+      linguist-xml: XML
       vote: DataWeave
   github.com/mulesoft-labs/data-weave-custom-data-format/d70c11fb3dbb6019b7c9bc87fb0cfb47bfa02d84/src/test/dwtest/org/mule/weave/simplefixedwidth/FixedWidthTest.dwl:
     annotations:
       linguist: DataWeave
+      linguist-extension: DataWeave
       vote: DataWeave
   github.com/multigrid101/terra/58d179b3aea47072d955d3b46dce3974e8d77f31/lang.t:
     annotations:
@@ -11581,23 +14233,28 @@ files:
   github.com/muratdem/PlusCal-examples/aa351b771a6cd933d74d9ef601632fb6ff6be952/DiningPhil/diningRound1.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/muriloventuroso/easyssh/5e411c2a695a8d613069e55c9599f4e4bbc2c43c/src/Widgets/Connection.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/musikinformatik/SuperDirt/45015c9029e9c21a0b594b3ae07f848389b43d22/hacks/pitch-model-from-tidal.scd:
     annotations:
       linguist: SuperCollider
+      linguist-extension: SuperCollider
       vote: SuperCollider
   github.com/mvasilchuk/yasem/3e3c76de1dba9d45c3f4cf89604d77f2e3f93505/dir_config.pri:
     annotations:
       linguist: QMake
+      linguist-extension: QMake
       vote: QMake
   github.com/mwand/eopl3/2648675ca8e8ee804701a31f6198838d2c7a04f5/chapter4/call-by-need/drscheme-init.scm:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
       vote: Scheme
   github.com/mxgmn/WaveFunctionCollapse/c50df86be3ae819fcced8dcba8b00ca614c62b09/Model.cs:
     annotations:
@@ -11606,32 +14263,39 @@ files:
   github.com/myclabs/DeepCopy/9012edbd1604a93cee7e7422d07a2c5776c56e0c/tests/DeepCopyTest/Filter/ReplaceFilterTest.php:
     annotations:
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/mysql/mysql-sys/a1374ea7cf341b71fd1060136533ce01fe0bd57b/views/p_s/io_global_by_wait_by_latency.sql:
     annotations:
       human-smola: SQL
       linguist: PL/pgSQL
+      linguist-heuristics: SQL
       vote: SQL
   github.com/nPoseTeam/nPose-LM-LG-chains-plugin/1fa16a6b674677b48e58a99618beafc356829121/LSLScripts/nPose LMLG chains plugin.lslp:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
       vote: LSL
   github.com/nPoseTeam/nPose-V2/2d5dfc50b15de6662aa23335fe851c647585f95f/nPose Scripts/Adjuster/nPose Adjuster.lsl:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
       vote: LSL
   github.com/nPoseTeam/nPose-V3/0f04bf1eb8bd6fbe6837994c71eea4d16257d87c/nPose Scripts/nPose Slave.lslp:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
       vote: LSL
   github.com/nagadomi/waifu2x/03dc6511a726b064d26209b220bbf90384f10880/lib/reconstruct.lua:
     annotations:
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/nagaraju-inturi/loopback-replication/adb7a2624e2a5af647b3420c0414850e30c0f80f/server_ctx/parallel_iud.ec:
     annotations:
       human-smola: C
       linguist: eC
+      linguist-extension: eC
       vote: C
   github.com/nanc-in-a-can/canon-generator/3e00abce4d2ddeef8c69f483ea6fb70f87c35316/Can/register-synthdefs.sc:
     annotations:
@@ -11644,30 +14308,37 @@ files:
   github.com/natcoanand/test-project-cicd/7c19e257b5a57dbbfc3e6bdb69f17ec335a00a99/target/munitworkingdir-64779977805367/container/.mule/services/mule-service-weave-2.1.6-mule-service/Mule.dwl:
     annotations:
       linguist: DataWeave
+      linguist-extension: DataWeave
       vote: DataWeave
   github.com/nathangeology/geoviz/5643e8880b4ecc241d4f8806743bf0441dd435c1/geoviz/sample_data/7_7-4.las:
     annotations:
       linguist: Lasso
+      linguist-extension: Lasso
       vote: Lasso
   github.com/nature-of-code/The-Nature-of-Code-Cosmos-Edition/78567193ea2822f196520f21b7b736c4ad5318de/dome/dome-library-cubemap/GravitationalAttractionDome/GravitationalAttractionDome.pde:
     annotations:
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/nature-of-code/noc-examples-processing/88e5094be3a83de4b1a1a5a0f7eeb962b1e09f08/introduction/Figure_I_2_BellCurve/Figure_I_2_BellCurve.pde:
     annotations:
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/nb312/flutter-ui-nice/59e23637da10349af1ad1831439ba203291e8b81/lib/page/statistics/StatisticPageOne.dart:
     annotations:
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/nchenche/herbifun/36c46923de4b7438a9d7ca6294c50a18c2e65bca/datas/A_hmmbuild_2018-08-14_18-10-50/runs_output/A-9_nr.clw:
     annotations:
       linguist: Clarion
+      linguist-extension: Clarion
       vote: Clarion
   github.com/ndmitchell/hlint/89ba76d3dd4cff046b4e691e2bf526c4718f3d3f/src/HSE/Scope.hs:
     annotations:
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/ndparker/rcssmin/f9ed9a82f23f235e884e39645ccd5de7deb88d4c/tests/yui/out/dataurl-base64-singlequotes.out.b:
     annotations:
@@ -11677,34 +14348,42 @@ files:
   github.com/ndw/xprocbook/798d433e1b114aa4867f850d6dee816185354133/src/core/xpl/insert-3.xpl:
     annotations:
       linguist: XProc
+      linguist-extension: XProc
       vote: XProc
   github.com/nealcrook/hForth/cdccc69e3f5ab40d6bbc337392e5a7dfaa87504d/8086/MULTI.F:
     annotations:
       linguist: Forth
+      linguist-heuristics: Forth
       vote: Forth
   github.com/neauoire/pilOS/b8f147aedfa673ec454686d5fe8d4166f2bcdfbe/init/lib/btree.l:
     annotations:
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
       vote: PicoLisp
   github.com/nebulasio/research/62165b13020aec4431d8dd3d1c218c7bc3708787/pod/PODCommit.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/nedpals/vargs/fc193513733c2ed99467f5d903a824ea9087ed52/vargs.v:
     annotations:
       linguist: V
+      linguist-heuristics: V
       vote: V
   github.com/neerogi/neerogi/197d15e077cec1cf7b9b2e9fe7552b8919fde09b/src/main/java/org/neerogi/domain/Title_Roo_DbManaged.aj:
     annotations:
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/neilcosgrove/LNX_Studio/a6b4c05b7eed6e710487c417b3b9115ddcdcc4e5/SCClassLibrary/LNX_Studio Library/10. by others/wslib_reduced/Various/SegWarp.sc:
     annotations:
       linguist: SuperCollider
+      linguist-heuristics: SuperCollider
       vote: SuperCollider
   github.com/nekulin/celastica/7f11b94c1f7ddf3a95a17f1a14953b24e178e50d/elastica/Filter/HasParent.zep:
     annotations:
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/nemasu/asmttpd/167cfda160305bdedab8d10076350f7ff8a23851/string.asm:
     annotations:
@@ -11714,22 +14393,27 @@ files:
     annotations:
       human-smola: REXX
       linguist: REXX
+      linguist-extension: REXX
       vote: REXX
   github.com/nestjs/nest/67c6a7f9c8b6e0f8b9787af45f8aec9cad2fd1ad/packages/microservices/helpers/kafka-parser.ts:
     annotations:
       linguist: TypeScript
+      linguist-heuristics: TypeScript
       vote: TypeScript
   github.com/netdata/netdata/928c52f73f7f21e6d434bff82b01effedb6010bd/database/engine/pagecache.c:
     annotations:
       linguist: C
+      linguist-extension: C
       vote: C
   github.com/newcontext-bbh/UUnit/60800d6029aa60127e0192240e34ed16434534ad/UUnitAssert.boo:
     annotations:
       linguist: Boo
+      linguist-extension: Boo
       vote: Boo
   github.com/newrelic/futurestack14_badge/84d128943b562ebc6c01cb75be2089fbd2b39eaa/agent.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/nferraz/st/915674e31bea860345c4980bef1dc6a955757cb4/script/st:
     annotations:
@@ -11738,51 +14422,64 @@ files:
   github.com/nfisher/gir/55e52b7647141e0f9ad64e906bd0b144672063ea/graphql_values.rl:
     annotations:
       linguist: Ragel
+      linguist-extension: Ragel
       vote: Ragel
   github.com/nginformatica/advpl-testsuite/32e03811fe9facb0c6c72fec1d75555b3526c03f/src/fluentexpr.prw:
     annotations:
       linguist: xBase
+      linguist-extension: xBase
       vote: xBase
   github.com/ngudbhav/TriCo-electron-app/957676efbbbd1f770078f979a2fc48fd03b1fc37/new.nsi:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/ngudbhav/Webkiosk-Wrapper/f61e48d093387af6e078a9305159b04cc2fd9ffb/setupx32.nsi:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/ngzhang/Icarus/3be28e9d8cd9426d0b21729bb70eaacd78a7a72d/FPGA_project/Src/serial.v:
     annotations:
       linguist: Verilog
+      linguist-heuristics: Verilog
       vote: Verilog
   github.com/nicferrier/elmarmalade/ad50d9c62fcec947834da2b307b87ba2ef72f694/marmalade-repo-test/packages/less-css-mode/0.10/less-css-mode-0.10.el:
     annotations:
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/nickg/nvc/2dfb3aab2928dded9a8e39cdab27d8c87cd56bf8/test/sem/file.vhd:
     annotations:
       human-smola: VHDL
       linguist: VHDL
+      linguist-extension: VHDL
       vote: VHDL
   github.com/nickik/Persistent-Vector-in-Dylan/f58f0a5dc476853f65babbf1be140e7793235d94/PersistentVector.dylan:
     annotations:
       linguist: Dylan
+      linguist-extension: Dylan
       vote: Dylan
   github.com/nickmil/BoxeeBox/d5b70df496c6d1e4a6b16943028c0000f1225503/BoxeeBox_UI_v01.axs:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/nicolaishestakov/8i5a-pizza/bffe64f681d233d7121a1b6dba466a91d5714415/db/Pizza Conceptual Schema.txl:
     annotations:
       linguist: TXL
+      linguist-extension: TXL
+      linguist-xml: XML
       vote: TXL
   github.com/nicolas-p/skov/21b92b970433d1b962906bd27664486be05b850d/basis/ui/tools/environment/theme/theme.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/niel/php-yenc/c488fd43774dc29c121c04390c4b9a1d459b85b9/yenc/yenc.zep:
     annotations:
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/niessner/Opt/ba5e6612a3d608e1539bdf0a700541a6d99bdec6/API/src/ad.t:
     annotations:
@@ -11791,156 +14488,196 @@ files:
   github.com/nightscape/papa-carlos-aunt/834e70850b8ddeecf4207d2e1d18402538d13d97/src/main/antlr4/ANTLRv4Parser.g4:
     annotations:
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: ANTLR
   github.com/niklascarlsson/presentations/4f1a3cd9f89939871f814dbff088e2ab8476fda9/literate_programming/snippets/Ex24:
     annotations:
       linguist: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/nikzsaz/progress-4GL-code/7d571aa0967a902fc534f0e027a82a4bc33b8ede/My Observations/caselogic.p:
     annotations:
       human-smola: OpenEdge ABL
       linguist: OpenEdge ABL
+      linguist-heuristics: OpenEdge ABL
       vote: OpenEdge ABL
   github.com/nilp0inter/dotfiles/2af9e96e19cd23e5d22d316704ba1bd8adfd9254/.i3:
     annotations:
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Modula-3
   github.com/nim-lang/Aporia/3273cb144172deb2dae615191b30a62093c365ee/suggest.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/nim-lang/Nim/61889c604a5f3185339b8e6fd84fca7b0a8df1f9/tests/iter/titer12.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/nim-lang/nimble/a8a5bdd863ab311f39c242c705207b937695e270/src/nimblepkg/publish.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/nim-lang/nimforum/35baa815fdb3762f779474ff6e81ae20dec2070c/src/frontend/postlist.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/nimaai/shen-lfe/0c82d1b61356ad6ade9e75b10632aa1109198e7a/compile.shen:
     annotations:
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/nimgl/nimgl/82525e1015d965665bca01f3d333d8d88c08a39d/src/nimgl/imgui/impl_opengl.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/ninenines/cowboy/63b17e4edf666d995ec86cdcda17a62ba5ebc423/src/cowboy_children.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
       vote: Erlang
   github.com/ninenines/gun/bd6425ab87428cf4c95f4d23e0a48fd065fbd714/src/gun_data_h.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
       vote: Erlang
   github.com/nishantraut/SpringRoo/d49c1eadbece14ad3487e0d2a2d32994bc5355b2/HelloSpringRoo/src/main/java/com/springsource/roo/pizzashop/domain/Topping_Roo_ToString.aj:
     annotations:
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/nisrulz/flutter-examples/6be058b2c5bdcda2b06cb702f228bb57a8e2f972/expense_planner/lib/main.dart:
     annotations:
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/nitlang/nitutorial/9848e67dd20ad716202e51c6ea797110ca79135c/srv/web.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   github.com/nitrologic/mod/f4f1e3c5e6af0890dc9b81eea17513e9a2f29916/axe3d.mod/model.mod/model.bmx:
     annotations:
       linguist: BlitzMax
+      linguist-extension: BlitzMax
       vote: BlitzMax
   github.com/nix-community/setup.nix/47e69c8f4c870dcf288b47d4b0035b6d72225b4c/default.nix:
     annotations:
       linguist: Nix
+      linguist-extension: Nix
       vote: Nix
   github.com/njoy/NJOY2016/fb2e9129e973f9bf66180c1d0f1ed058554ffc17/src/thermr.f90:
     annotations:
       linguist: Fortran
+      linguist-extension: Fortran
       vote: Fortran
   github.com/nkly/purescript-express/b0d3d31703a02a7dddc48fa23669bebe6de85e90/test/Test/App.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/nknorg/nkn-simulation/dbc6520446a99f8313b6ba16b87ae836ce5136de/cellular_automata_gossip_ising_sim/Sim_Cellular_Automata_Gossip_Ising_Consensus.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/nlppln/nlppln/1155191921289a65ba2becd2bf8dfabb48eaf1f1/nlppln/cwl/liwc-tokenized.cwl:
     annotations:
       linguist: Common Workflow Language
+      linguist-extension: Common Workflow Language
+      linguist-shebang: Common Workflow Language
       vote: Common Workflow Language
   github.com/nmikheecheva/stepik/e445cea747a9ccac3035fe21e6ddce964cebd7a2/phylogenetics/3aligned.clw:
     annotations:
       linguist: Clarion
+      linguist-extension: Clarion
       vote: Clarion
   github.com/nobuyukinyuu/SimpleUI/f72a5d4b1671b803b64a4515960b439ed970496b/SimpleUI/circularProgressbar.monkey:
     annotations:
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/node-cache/node-cache/21a8dc0422b47aa1c3fd05c5abc07d60fcf64668/Gruntfile.coffee:
     annotations:
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/nodemcu/nodemcu-flasher/d929c5171545d10c4849d6493d2504ea0983fd19/ESP8266Flasher.dpr:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/nodename/as3delaunay/71563ed1d573d087603103f9c66f52f4452dc868/src/com/nodename/Delaunay/selectNonIntersectingEdges.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/nogates/vigia/2d46649ad5cd6cd804ec3385925f48f29dc817d2/features/support/examples/my_blog/my_blog.apib:
     annotations:
       linguist: API Blueprint
+      linguist-extension: API Blueprint
       vote: API Blueprint
   github.com/noio/kingdom/cee25a0ad127321a64a80a002e33a88f84075bce/org/flixel/FlxSound.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/nophead/Mendel90/a82d99a868fab4d475926c1019104be3e13e90b2/scad/vitamins/tubing.scad:
     annotations:
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/norman/friendly_id/ae73e4449daca24ce007a4de467901a2ff0dabf2/test/reserved_test.rb:
     annotations:
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/norvig/paip-lisp/858a6927503656c800e3599c846a86aebd30ae44/lisp/waltz.lisp:
     annotations:
       human-smola: Common Lisp
       linguist: Common Lisp
+      linguist-heuristics: Common Lisp
+      linguist-modeline: Common Lisp
       vote: Common Lisp
   github.com/nosnhojn/svunit-code/f438886faebaeed7375f645d6ad0adf4b370523e/svunit_base/svunit_pkg.sv:
     annotations:
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/notepad-plus-plus/notepad-plus-plus/cf7e373dca890d65ecc86489fe9cce1bcc7597f7/scintilla/src/ScintillaBase.h:
     annotations:
       linguist: C++
+      linguist-heuristics: C++
       vote: C++
   github.com/novoda/bintray-release/4dd13fb4d0a3c8b6548701698080bc4cd59af499/plugin/core/src/main/groovy/com/novoda/gradle/release/PublishExtension.groovy:
     annotations:
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/nowelium/Log4Io/0b1fb982877ff812e3088bfb69aaa8ad03dbb568/io/PatternLayout.io:
     annotations:
       linguist: Io
+      linguist-extension: Io
       vote: Io
   github.com/npocmaka/batch.scripts/8a1b6e185058ed9b8eb3cc7dbc2b7cfe4dbfd85a/hybrids/.net/colorInput.bat:
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/nprapps/roku-tinydesk/be73de17ae51ec8c4f6a452f8163af21b7288f25/source/feedUtils.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/nsauzede/sdl2test/6dcef532631f53ad5fd79026722eac488abbbfeb/tetrisnomix_v.v:
     annotations:
       linguist: V
+      linguist-heuristics: V
       vote: V
   github.com/nsauzede/vsdl2/5f4d142ab38c0a0126fd6f2e239d0507f209ca91/vsdl2.v:
     annotations:
@@ -11949,31 +14686,38 @@ files:
   github.com/nsqio/nsq/5b67f580f3cbb63c02c4678e76896f5807147145/apps/nsq_to_http/nsq_to_http_test.go:
     annotations:
       linguist: Go
+      linguist-extension: Go
       vote: Go
   github.com/nst/iOS-Runtime-Headers/fbb634c78269b0169efdead80955ba64eaaa2f21/protocols/TSWPHeaderFooterProvider.h:
     annotations:
       human-smola: Objective-C
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/nsumner/callgraph-profiler-template/6511cf9ec6ac2f89ed49713c725e2f32e2d4bbc2/test/ll/05-internal-multiple-files.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/nuclearsandwich/fanciful_meanderings/efbf7e14ee9df8a35bad11d2d741f6b608ca7739/guessing-game.fy:
     annotations:
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Fancy
   github.com/nuclearsandwich/fancy-vim/f6e76619b6ebd8cd0bf3a2aa36bff7f33f32f378/sample.fy:
     annotations:
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Fancy
   github.com/nucular/powder-djs/f01dc2eefd8ab10d6c8bf3da87f50a17d7da9572/powder.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/nuex/zodiac/7515f68a8d8f2f0345c80874b34eeedddd3407da/lib/config.awk:
     annotations:
       linguist: Awk
+      linguist-extension: Awk
       vote: Awk
   github.com/numpy/numpy/480dc6bc01aa465389fcad0c85502d25d954f579/numpy/random/src/philox/philox.h:
     annotations:
@@ -11982,68 +14726,87 @@ files:
   github.com/nvbn/thefuck/fdea32b47d4b941fce7a9d538d00c1484e31feb5/thefuck/specific/git.py:
     annotations:
       linguist: Python
+      linguist-extension: Python
       vote: Python
   github.com/nvie/gitflow/15aab26490facf285acef56cb5d61025eacb3a69/contrib/gitflow-installer.sh:
     annotations:
       linguist: Shell
+      linguist-extension: Shell
+      linguist-shebang: Shell
       vote: Shell
   github.com/nvm-sh/nvm/04ad1b528cfa746866dca415cc9a0463463e79db/test/fast/Unit tests/nvm_die_on_prefix:
     annotations:
       linguist: Shell
+      linguist-shebang: Shell
       vote: Shell
   github.com/nwchemgit/nwchem/14c0e445f2101ccc50e6ff10e383863e43840e78/src/tce/ccsdt_beta/ccsdt_lr_beta_4_4_21_4.F:
     annotations:
       human-smola: Fortran
       linguist: Fortran
+      linguist-heuristics: Fortran
       vote: Fortran
   github.com/oarevalo/BugLogHQ/980766d65fadffec56860cadcd751a0cb63a751d/install/named-instance-template/config/buglog-config.xml.cfm:
     annotations:
       human-smola: ColdFusion
       linguist: ColdFusion
+      linguist-extension: ColdFusion
+      linguist-xml: XML
       vote: ColdFusion
   github.com/oasis-tcs/odata-openapi/e06fa1fa9e4762611f6227821369a007cf9c9cfa/tools/V2-to-V4-CSDL.xsl:
     annotations:
       linguist: XSLT
+      linguist-extension: XSLT
+      linguist-xml: XML
       vote: XSLT
   github.com/oazabir/SQLServerPerformanceDashboard/3847e8003f266d5ebb0926d585d5cb7f8adce0a6/Source/SQLServerDashboard/CurrentSessions.aspx:
     annotations:
       linguist: ASP.NET
+      linguist-extension: ASP.NET
       vote: ASP.NET
   github.com/ob/cache/a2fb5d7a70dc95e3d84ab409e38ae2b620a46a89/results/knoppix_seq_2d_all.plot:
     annotations:
       linguist: Gnuplot
+      linguist-extension: Gnuplot
       vote: Gnuplot
   github.com/obecebo/bdt-virtio-blk/d1cf01c98f6787cd4a555043363b4feef225d172/DskBlk2.HC:
     annotations:
       linguist: HolyC
+      linguist-extension: HolyC
       vote: HolyC
   github.com/obecebo/erythros/a84dade6d460343cae4e3c5148774b8d0b8e69a9/System/Programs/Games/Cherub.exec/LCD.HC:
     annotations:
       linguist: HolyC
+      linguist-extension: HolyC
       vote: HolyC
   github.com/obecebo/gihon/b680416a1c644af89d9448918032c27ae2e536b8/Command.HC:
     annotations:
       linguist: HolyC
+      linguist-extension: HolyC
       vote: HolyC
   github.com/obj1-unahur-2019s1/semillas-al-viento-FlorenciaMssy/0ac76ea7a662d1b89463391d11fe8d1b98e6fdfa/src/plantas.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/obj1-unahur-2019s2/granjavilla-feder701/3a5f3119cc52d833ef39a346fa176f747b957546/src/hector.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/obj1unq/2019s1-granjavilla-BarbaraSilv/2f6c1472b738aed3edadc218e4f9ad97f8ef7270/src/farmville.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/obj1unq/2019s1-juego-integrador-moreyra-g-gonzalez-r-baez-g/aa501aab4424e45ba536da22dd8d84c69b98bcba/src/cosas.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/obj1unq/2019s1-juego-integrador-silva_romero/bd096db9afff0b540b98f452e26c367b3f267bb3/src/enemigo.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/ocaml-community/utop/83ee76fc39b6cb394f5fb19063a3a7da09224339/src/lib/uTop_token.ml:
     annotations:
@@ -12052,42 +14815,55 @@ files:
   github.com/ocamllabs/ocaml-effects-tutorial/506e891c9cf41448b22d29d7e4f704df6fe180de/sources/solved/state2.ml:
     annotations:
       linguist: OCaml
+      linguist-heuristics: OCaml
       vote: OCaml
   github.com/odi-so/FaceTimeCallerInfo/1de295f50c84d0c387640f85e7003c39f7fc8662/FaceTimeCallerInfo.applescript:
     annotations:
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/odinuge/tt-to-subrip/3670c09763d2ba534bbb572fe3790c0b4c5bc6f3/tt-to-subrip.awk:
     annotations:
       linguist: Awk
+      linguist-extension: Awk
+      linguist-shebang: Awk
       vote: Awk
   github.com/odlarcos/Ingenieria-del-Conocimiento_UGR/aa8de2f84b08d5f89fb5a4cae021f2651ba160f8/OficinaInteligente.clp:
     annotations:
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: CLIPS
   github.com/odonnell-anthony/katalon-automation-practice/4b86734d5fd17d5be9629648f596b7a3dea15741/Object Repository/Page_Order - My Store/Total_shipping.rs:
     annotations:
       linguist: RenderScript
-      vote: RenderScript
+      linguist-xml: XML
+      vote: Unknown
   github.com/ohanhi/elm-native-ui/d1fd123bed4f1c1f72a922784d1b4b8136f6b7d7/src/NativeUi/Style.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/ojdkbuild/ojdkbuild/a021aad4af757969928e481bb13c3d42466c9cf3/src/java-1.8.0-openjdk/CMakeLists.txt:
     annotations:
       linguist: CMake
+      linguist-filename: CMake
+      linguist-heuristics: Text
       vote: CMake
   github.com/ok1mpd/Netlinx-UPnP-control-point/e566c0b83f77b47d3d5795626656b63aae660f1e/Radio.axi:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/olear/natron-linux/2e5bc40260dbe8d169b1e7eac687bd4bcfeb6662/EL7/config.pri:
     annotations:
       linguist: QMake
+      linguist-extension: QMake
       vote: QMake
   github.com/oleganza/iopackage/528c627faf0866b59d423d0e060b9bb814137751/verify.io:
     annotations:
       linguist: Io
+      linguist-extension: Io
+      linguist-shebang: Io
       vote: Io
   github.com/oligot/epm/a28b7311d55e2a77de70f9eaba368f082973cca0/lib/epm_package.e:
     annotations:
@@ -12096,61 +14872,75 @@ files:
   github.com/oliverit/express.abap/ff37cde6eb2b54ba2f68c015eec81298173887d1/yea_unit_test_response.clas.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/omarroth/invidious/e56129111a5d182ddfcc75935c1222cc11e46234/src/invidious/channels.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/omcljs/om/775f3adebde911988674f1bf179fd8b920031c8e/src/test/om/next/next_test.clj:
     annotations:
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/omniti-labs/pg_jobmon/c7a17d29a9064a0ed78390923eb04c845339b2f6/updates/pg_jobmon--0.4.5--1.0.0.sql:
     annotations:
       linguist: PL/pgSQL
+      linguist-heuristics: PL/pgSQL
       vote: PL/pgSQL
   github.com/ongardie/raft.tla/34cdd49d22615426ea00a6605b95be57b3cab49a/raft.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/onivim/oni2/89675e266c408952cd56e52e2bcb6e36634b1d76/src/Model/Indentation.re:
     annotations:
       linguist: OCaml
-      vote: OCaml
+      linguist-heuristics: Reason
+      vote: Unknown
   github.com/onnx/onnx/e108da9a9a9916880ca7d1a0cfff96637921212c/onnx/backend/test/data/node/test_slice/test_data_set_0/output_0.pb:
     annotations:
       human-smola: Unknown
       linguist: PureBasic
+      linguist-extension: PureBasic
       vote: Unknown
   github.com/onox/orka/328954163d9b0502f35c3d1ec8d868a545e8e205/src/tools/orka_info.adb:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/onryldz/x-superobject/4e60eb88fe977feb1d9bff6e5fb10d4e7d180fcb/XSuperJSON.pas:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/ooc-lang/nagaqueen/3431f99e73cd98083644d880e5bcf5573399ec64/test/printexceptions.ooc:
     annotations:
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/ooc-lang/rock/079f9b970e2bf33bfa613c670c3d88cea99ac26e/sdk/net/DNS.ooc:
     annotations:
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/ooc-lang/sam/5b71b4e32a3fdae3e0a4b2fe35f3d20fbb6da534/source/sam/Arguments.ooc:
     annotations:
       linguist: ooc
+      linguist-extension: ooc
       vote: ooc
   github.com/opal/c_lexer/2ea21587e143e2e22a892c61203183ff4d6c91ca/ext/lexer/lexer.rl:
     annotations:
       linguist: Ragel
+      linguist-extension: Ragel
       vote: Ragel
   github.com/opaluchlukasz/xiaomi.yi-scripts/0c3f48072ecc66fbffcd93de320ef6e769650cbc/autoexec.ash:
     annotations:
       human-smola: Shell
       linguist: AGS Script
+      linguist-extension: AGS Script
       vote: Shell
   github.com/open-force/jsonparse/547b0cf62f9b5ed9f6d6ef8fc037fe3bd10cf98a/JSONParseTests.cls:
     annotations:
@@ -12159,6 +14949,7 @@ files:
   github.com/open-mmlab/mmskeleton/5476eff5d67adf7780685a62905550dbd184b3e8/src/nms/nms_kernel.cu:
     annotations:
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/openEHR/adl-tools/1b55f2d44868874025482f51023af7b453183405/apps/resources/icons/compiled/icon_rm_cimi_item_group.e:
     annotations:
@@ -12168,59 +14959,74 @@ files:
   github.com/openai/baselines/665b888eeb688396894455a0d94febc4f712e0c0/baselines/common/wrappers.py:
     annotations:
       linguist: Python
+      linguist-extension: Python
       vote: Python
   github.com/openai/blocksparse/76a81b7123483bac3db639322d7035ee0c7b227b/src/batch_norm_op_gpu.cu:
     annotations:
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/openai/gym/21bd4f304be8f5cf7d0354e50ae4a977b7cfe5eb/gym/envs/classic_control/rendering.py:
     annotations:
       linguist: Python
+      linguist-extension: Python
       vote: Python
   github.com/opencog/opencog/0a775af256162c84910aa578e0e12f9319fb78d2/opencog/nlp/anaphora/rules/pre-process/pre-process-#3.scm:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
       vote: Scheme
   github.com/opencollab/scilab/0068b70ee75ebbfd7f0201abec7a5e56df5469b0/scilab/modules/m2sci/macros/sci_files/sci_cot.sci:
     annotations:
       linguist: Scilab
+      linguist-extension: Scilab
       vote: Scilab
   github.com/opencrypto-io/data/78956f7f756f414a91e28cd16fb1337e2c456165/db/projects/binance/project.yaml:
     annotations:
       linguist: YAML
+      linguist-extension: YAML
       vote: YAML
   github.com/opencrypto-io/schema/29363ef2c7f446b66f9267fd62261a40fec4cee2/models/exchange.yaml:
     annotations:
       linguist: YAML
+      linguist-extension: YAML
       vote: YAML
   github.com/opencv/opencv/417034518c0884743e79ea7828eee0b6724287bc/modules/imgcodecs/src/grfmt_base.hpp:
     annotations:
       linguist: C++
+      linguist-extension: C++
       vote: C++
   github.com/openfl/openfl/48307426774e43cdaa2e69cd772b3def0c991ddc/src/openfl/display/JPEGEncoderOptions.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/opengds/OpenGDS/9b990ecbcdeb78ebcd952fdf03efaf937daeae33/Open_GDS_Tools/Open_GDS.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/openj/core/10a2a193f65b8ae0eb1d1e49ba86c847ec1daf42/test/g430fin.ijs:
     annotations:
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/openlawteam/docs/a4db7949647060557d83352840a57e2c90edbf98/docs/beginners-guide/README.md:
     annotations:
       linguist: Markdown
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/openmole/openmole-market/efd649088e6e4acb741a6fdfa0688563c8441a69/metamimetic-networks/model/OM_Metamimetic_Networks_GIT.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/openresty/nginx-tutorials/5e044d0dc61fe17a80cda7ee384235a777f6154f/utils/wiki2html-cn.pl:
     annotations:
       linguist: Perl
+      linguist-heuristics: Perl
       vote: Perl
   github.com/openscenegraph/OpenSceneGraph-Data/cad848e5c41e9cbf406ac87fc0d55b9e1821c367/shaders/depthpeel_final.frag:
     annotations:
@@ -12229,41 +15035,51 @@ files:
   github.com/opensimworld/active-npcs/f45cdf12711d70a5a6042efaada48ad47103ad93/Greeter.lsl:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
       vote: LSL
   github.com/openstack-attic/akanda/49976b089a75e315233ab251bb9c591cfa5ed86d/specs/template.tst:
     annotations:
       human-smola: reStructuredText
       linguist: Scilab
+      linguist-heuristics: Scilab
       vote: reStructuredText
   github.com/openthings/kubernetes-tools/46d04f6809e55c4ae43c374a658cd1375d484557/ksonnet/guestbook/components/guestbook-ui.jsonnet:
     annotations:
       linguist: Jsonnet
+      linguist-extension: Jsonnet
       vote: Jsonnet
   github.com/oprypin/nim-random/775f878ed1f89677e17b0ab28e3498a36f8b7679/src/random/private/murmurhash3.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/oracle/graphpipe/224c32130006d652a9c3bf205abd700ad67940b3/Makefile:
     annotations:
       linguist: Makefile
+      linguist-filename: Makefile
       vote: Makefile
   github.com/oracle/xml-sample-demo/1f24722b306f8807bca73869f981c2a8afe37a7a/XFILES/src/sql/PUBLISH_XFILES_ICONS.sql:
     annotations:
       human-smola: PL/SQL
       linguist: SQLPL
+      linguist-heuristics: SQL
       vote: PL/SQL
   github.com/ordogfioka/Clean/48780cb5f4cdf539534e9405d903e6c94d19574f/zh2/bintree.icl:
     annotations:
       human-smola: Clean
       linguist: Clean
+      linguist-extension: Clean
       vote: Clean
   github.com/oreillymedia/HTMLBook/22f23a1288779680566ee88ff4cedcf2d7528a18/htmlbook-xsl/xspec/tutorial/escape-for-regex.xslt:
     annotations:
       linguist: XSLT
+      linguist-extension: XSLT
+      linguist-xml: XML
       vote: XSLT
   github.com/organization/RapidPM/062f592e3b8a655d79be3ccd8913c891e04401e4/pocketmine/utils/binarystream.zep:
     annotations:
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/organization/boundstone/aedb0f6073285641e374dad62b1e88c5cf10d237/bstone/open_connection_reply2.v:
     annotations:
@@ -12272,60 +15088,75 @@ files:
   github.com/orgcandman/pcap-mode/52780669af0ade136f84d73f21b4dbb7ab655416/pcap-mode.el:
     annotations:
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/orlandohill/waxeye/467f56169ef1b72953816c12cc02b4f91b083fa7/src/waxeye/dfa.rkt:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/ornicar/lila/cded1ff0e26ff54c3a25359d1471696ca2a8e633/app/controllers/Page.scala:
     annotations:
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/orthopteroid/hydrolp-a/02e0a87d4c868d26be7737339168a579d2bef4e0/MBHModel.zpl:
     annotations:
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Zimpl
   github.com/osalvador/tapiGen2/0a46ff9976fce4f53d21555ba2420db92c244aee/source/packages/TAPI_GEN2.pkb:
     annotations:
       linguist: PL/SQL
+      linguist-extension: PL/SQL
       vote: PL/SQL
   github.com/osalvador/tePLSQL/081b3bfeb14b61c3a671188fa72ecb8e07b243bb/TE_TEMPLATES.sql:
     annotations:
       human-smola: PL/SQL
       linguist: PL/SQL
+      linguist-heuristics: SQL
       vote: PL/SQL
   github.com/oscfdezdz/Dotfiles-WIP/fbcb800a377c3c7ae85bec90f038e54cc500a44b/config.i3:
     annotations:
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Modula-3
   github.com/osener/wring/8d18eee931a347e96e11a806c2838b76c6474a73/src/Uri.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/otabat/shen-jvm/623c8db71a97d3c09f68b7b1d494fc930e041900/shen/test/interpreter.shen:
     annotations:
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/otto-krause/recuperacion-y-practica-Caaaamorlivo/1f8e659381aa19dc2ba3cb19055e795dc98f1a73/jaloguin.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/otto-krause/recuperacion-y-practica-MateoPereyra88/a07dc7616c432f7b105c0d7db1cc6445219a0bbc/jaloguin/src/example.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/overtone/overtone/2005bd7c40b8f348d615e61c0687c79143696a2c/src/overtone/sc/examples/osc.clj:
     annotations:
       human-smola: Clojure
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/owncloud/core/f54a3ed1e798d9de252baeea93906fd62029cce5/lib/private/Preview/Office.php:
     annotations:
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/oyvindkinsey/easyXDM/2769b632c1dd8c0b1f36bdab9596b331bf499b95/tools/apache-ant-1.7.1/etc/coverage-frames.xsl:
     annotations:
       linguist: XSLT
+      linguist-extension: XSLT
+      linguist-xml: XML
       vote: XSLT
   github.com/pablojorge/brainfuck/ef60abec5cd6de90f05e410741001124bc8eb275/programs/bizzfuzz.bf:
     annotations:
@@ -12334,18 +15165,22 @@ files:
   github.com/pablwoAraujo/Logica_Para_Computacao/3cb393b72947d80e9900e392e7dad56b467fd351/projetoFinal.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/paf31/purescript-thermite/d73d903083b78d18f673b4a02eddba9c84e4588e/src/Thermite.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/palgorhythm/BATTERY/432853b822393c204a6a968e1eec3a85164521a6/alloy.ck:
     annotations:
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/pallets/flask/a250997f75cd540bcf268c2d451ab035611aaee2/src/flask/views.py:
     annotations:
       linguist: Python
+      linguist-extension: Python
       vote: Python
   github.com/pannous/english-script-samples/2a03a41634c15007a4c78183f89c755a8fb97bdf/fibonaccis2.e:
     annotations:
@@ -12354,48 +15189,59 @@ files:
   github.com/papyros/qml-material/80e0294cec30fd9ca794ed0c545d3e4be511291c/src/extras/CircleImage.qml:
     annotations:
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/parallella/parallella-examples/364595c1a5547b6c1d2007481747147430fcdadb/rpi-camera/parallella_7020_headless_gpiose_elink2/parallella_7020_headless_gpiose_elink2.srcs/sources_1/bd/elink2_top/ip/elink2_top_axi_vdma_0_0/synth/elink2_top_axi_vdma_0_0.vhd:
     annotations:
       linguist: VHDL
+      linguist-extension: VHDL
       vote: VHDL
   github.com/parallella/parallella-hw/a6bcdf844c56366525bef73d3355c75bba19e3f5/archive/fpga/ip/xilinx/fifo_async_103x32/fifo_generator_v12_0/hdl/builtin/builtin_top_v6.vhd:
     annotations:
       human-ajnavarro: Unknown
       linguist: VHDL
+      linguist-extension: VHDL
       vote: Unknown
   github.com/paras16jul1991/aws-Emr/5559f31d69ea171da20571e334faf1c79e5cea01/hive_emr_script.q:
     annotations:
       linguist: HiveQL
+      linguist-heuristics: HiveQL
       vote: HiveQL
   github.com/parcel-bundler/parcel/a836a17c5a85fdc328f48755e1384d6bb4705b65/packages/core/parcel-bundler/src/visitors/globals.js:
     annotations:
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/parlarjb/tla_workshop/7dffede194c85bd9c43037134d9ec855598cf4ab/specs/TCommit.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/part-cw/lambdanative/9fe5b9dd0f4c30a027adfe1156f13eb1eaa6adf1/modules/pathfinding/pathfinding.scm:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
       vote: Scheme
   github.com/pasadinhas/es-project/e62738a396b40b78127d638db9bff455718127c4/project-2.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/passy/build-time-tracker-plugin/42b7d53594bfc168589851001065643fa55718af/src/main/groovy/net/rdrei/android/buildtimetracker/reporters/JSONReporter.groovy:
     annotations:
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/pastorsj/RDTProtocol/af80f197abb9217917eb0d4fad0de1a9cd3fb3cb/Milestone2/RDT20.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/path/FastImageCache/2615d275abe6195f4a90a7b46593768b74b3b273/FastImageCache/FastImageCacheDemo/Classes/FICDPhotosTableViewCell.m:
     annotations:
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/patriciogonzalezvivo/thebookofshaders/35e9aa2c29a4ddcd3c22b3eee0143e3a9fe52e0d/18/grain.frag:
     annotations:
@@ -12404,14 +15250,17 @@ files:
   github.com/patrickTingen/DataDigger/304f0b40b76c3c2668c8396a09956c0fc4253ba2/dQuestion.w:
     annotations:
       linguist: OpenEdge ABL
+      linguist-heuristics: OpenEdge ABL
       vote: OpenEdge ABL
   github.com/patrickTingen/ResizABLe/a1c7d0c6b607b015bf6c2745fcd08a3333964bdf/TestWindow.w:
     annotations:
       linguist: OpenEdge ABL
+      linguist-heuristics: OpenEdge ABL
       vote: OpenEdge ABL
   github.com/paullefebvre/winapilib/bef5249b0fe3dfe5ebfc74799b9775274cee95c2/UI/SystemInfoWindow.xojo_window:
     annotations:
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/pauloamgomes/CockpitCMS-Moderation/4f1ea9543e04053f1145dff2dc35027dd01dbec7/views/settings/index.php:
     annotations:
@@ -12421,112 +15270,138 @@ files:
   github.com/paultag/PJD5132/06d3ff7b93a6f18839d4bf2b9ff1043997af527f/PJD5132/serial.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
       vote: Hy
   github.com/paultag/acid/5c3518019b98fff1a311679dbe6bc763ae032db4/acid/language.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
       vote: Hy
   github.com/paultag/crank/fb210f089966b9a20a8dc6ccb3128d8a144e9e57/eg/docker.io/go-md2man.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
       vote: Hy
   github.com/paultag/lysergide/d7f77311c01644fbf0b931e3b320d15e6464e478/eg/hack.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
       vote: Hy
   github.com/paultag/marx/96fbba5b37ff3108a58f569e53cefb990e70db46/marx/language.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
       vote: Hy
   github.com/paultag/snitch/f583f3ef087e7b1cd13ed3c7edb57d80b9c8cf25/snitch/rules.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
       vote: Hy
   github.com/paultag/wheatley/84d46c9f2a3e2885a415d1da766cac7714b5a5e1/wheatley/dsl.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
       vote: Hy
   github.com/pavels/spektrum/04f5577e1fd8b6e53f4c0f0d85e82fe5412b279a/scale.pde:
     annotations:
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/paycoguy/pet-clinic/09b0c1653716bdfac8b32eba3f622dc29cafb59e/src/test/java/com/springsource/petclinic/domain/OwnerDataOnDemand_Roo_DataOnDemand.aj:
     annotations:
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/pbatard/rufus/7ec7331200c047e920590cf65a2b1dee3162213a/src/dos.c:
     annotations:
       linguist: C
+      linguist-extension: C
       vote: C
   github.com/pchapin/thumper/fea32a8c628f835b5d7435238ce0fbb5fcff5bd5/src/tests/network-addresses-test.adb:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/pdep-utn-frd/2019-tpwgame-grupo-de-paradigma/dbe936f5be9559b2b581e229db0baf45e29e4b5e/src/visuales.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/pdep-utn/sabados-tarde/b7b2f9e1bcd7c0dbd25ab08782ec6e6e12b7acde/seguimiento/2019/objetos/ejemplos/clase-4/dominio.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/pebosch/Ingenieria-del-Conocimiento-P1-Introduccion-a-Clips/264bc9ae44fb851f6193de32211801163fbf37bb/Practica1.clp:
     annotations:
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: CLIPS
   github.com/peers/peerjs/0645dc3ddd51cbc1649ed13af56d9b66958fd62b/lib/dataconnection.ts:
     annotations:
       linguist: TypeScript
+      linguist-heuristics: TypeScript
       vote: TypeScript
   github.com/peewpw/Invoke-WCMDump/ca23612be2275fbb1982d5fbd578cbabd072fdc8/Invoke-WCMDump.ps1:
     annotations:
       human-smola: PowerShell
       linguist: PowerShell
+      linguist-extension: PowerShell
       vote: PowerShell
   github.com/pekabon/LogGrok/4d6528754c8ad49acec5d267e89ac16cb65badce/LogGrok.LogParserBase/ReadSubStream.n:
     annotations:
       human-smola: Nemerle
       linguist: Nemerle
+      linguist-heuristics: Nemerle
       vote: Nemerle
   github.com/pengdev/home-networking/9dd139aed3ee3bd5caa0c3dec1218d88e104bf88/data/build/tmp/oneMoreTime_dlna_android_bw_700k/traffic_long.xpl:
     annotations:
       human-smola: Unknown
       linguist: XProc
+      linguist-extension: XProc
       vote: Unknown
   github.com/penk/terrarium-app/564aec92ad5bf41e846e4e78faad64dd1349d492/qml/main.qml:
     annotations:
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/pepdiz/newlisp/57d5e88a3243a7f2a5a4225170708363800081ee/composition.lsp:
     annotations:
       human-smola: NewLisp
       linguist: NewLisp
+      linguist-heuristics: NewLisp
       vote: NewLisp
   github.com/perabrahamsen/daisy-model/90238a85932be2f9279c77ca60a912176928b3ca/txt/rootdens/row.plt:
     annotations:
       linguist: Gnuplot
+      linguist-extension: Gnuplot
       vote: Gnuplot
   github.com/perl6/ecosystem/c0513b95f7b6794bb3efef2da15a445b821628fc/.travis/testpackagemeta.p6:
     annotations:
       human-smola: Raku
       linguist: Raku
+      linguist-extension: Raku
       vote: Raku
   github.com/permissions-dispatcher/PermissionsDispatcher/fa5133fda48fcedc10018f31ad7055f4df9f80fc/processor/src/test/java/permissions/dispatcher/processor/base/BaseTest.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/peterjc123/pytorch-scripts/74db863d67ce48a5b2770d8197a9a6a4c317dfe9/cuda92.bat:
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/peterkir/example.aspectj/0a354c099f5d722c621fce0c592bb84d1ea0d553/example.aspectj.pde.wildcard/src/example/aspectj/wildcard/AfterAspectJ.aj:
     annotations:
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/peterldowns/iterm2-finder-tools/49b1fe78bb50329b864902850104504ccfb53b45/application/application.applescript:
     annotations:
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/petriw/Commodore64Programming/58dedb2310d37d6d80205d225084078d8b677eec/10-MultipleInterrupts/MultipleInterrupts.asm:
     annotations:
@@ -12535,27 +15410,34 @@ files:
   github.com/pfargo/xojo-shortsdesigner/e30421301d00b8a4de69eb54612307fa79fbea93/PAF/PrintKit/PAF_PrintKit/PrintStyle.xojo_code:
     annotations:
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/pgRouting/pgrouting/d242c2e8c2e36943308fe53fbf7844c008aa5be9/pgtap/max_flow/edgedisjointpaths-types-check.sql:
     annotations:
       linguist: PL/pgSQL
+      linguist-heuristics: PL/pgSQL
       vote: PL/pgSQL
   github.com/pglatza/debug-single-xsltmode/e66decc89a65d6545f264c027cd4d1710773a071/debug-single-xsltmode.xpl:
     annotations:
       linguist: XProc
+      linguist-extension: XProc
+      linguist-xml: XML
       vote: XProc
   github.com/pgpartman/pg_partman/1795eb2cd54f30d2f5c0717bb53c48c436c17c13/updates/pg_partman--0.3.1--0.3.2.sql:
     annotations:
       linguist: PL/pgSQL
+      linguist-heuristics: PL/pgSQL
       vote: PL/pgSQL
   github.com/pgrest/pgrest/85ecaf10fee7091a236a3fe91fa8f993aabe33a8/test/select.ls:
     annotations:
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/phalcongelist/beanspeak/bcfb859cd09295a095956a80a9eadda0ce4e63b7/beanspeak/exception.zep:
     annotations:
       human-smola: Zephir
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/pharo-project/pharo-launcher/a3894e183044b2f91d159dc77cf7927111cfd2e0/src/PharoLauncher-Core/PhLJenkins2Entity.class.st:
     annotations:
@@ -12568,107 +15450,136 @@ files:
   github.com/philc/vimium/8c9404f84fd4310b89818e132c0ef0822cbcd059/content_scripts/vomnibar.coffee:
     annotations:
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/philiparvidsson/LSTM-Text-Generation/87aab381b5fecc597c3799facc57841eeb33b3e0/lstm.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
+      linguist-shebang: Hy
       vote: Hy
   github.com/philipfennell/grasp/09aaf1222d4df071b944336b0c57bbffaa811d43/src/test/xproc/gsp/merge-submission.xpl:
     annotations:
       linguist: XProc
+      linguist-extension: XProc
+      linguist-xml: XML
       vote: XProc
   github.com/philipfennell/xproc-plus-time/f779519c7f6c0c5e0c67303cb9976fc484dc36c7/tests/resources/xproc-test-suite/lib/exclude-inline-prefixes.xpl:
     annotations:
       linguist: XProc
+      linguist-extension: XProc
       vote: XProc
   github.com/philiplaureano/Tao/5fa94a4c7d3950b3e958446a32046aa7d5bb2d39/src/Tests/Tables/Reads/FieldLayoutTableReadTests.n:
     annotations:
       linguist: Nemerle
+      linguist-heuristics: Nemerle
       vote: Nemerle
   github.com/phillipi/pix2pix/942ab18f2c30a26f5dce43e576bf2b8fe6c1136f/util/cudnn_convert_custom.lua:
     annotations:
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/philss/floki/6cdca965dec3e9a72289008e08e6b9dfe45dcd68/test/floki/selector/tokenizer_test.exs:
     annotations:
       linguist: Elixir
+      linguist-extension: Elixir
       vote: Elixir
   github.com/phoenixframework/phoenix/1021c4d84679666136cef4ec73ba4d0544446a3b/lib/mix/phoenix/context.ex:
     annotations:
       linguist: Elixir
+      linguist-extension: Elixir
       vote: Elixir
   github.com/php/php-src/abc382e885fff83d059e5c3fe3762c8e8497510c/sapi/fpm/fpm/fpm_events.c:
     annotations:
       linguist: C
+      linguist-extension: C
       vote: C
   github.com/phpDocumentor/ReflectionCommon/63a995caa1ca9e5590304cd845c15ad6d482a62a/src/ProjectFactory.php:
     annotations:
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/phpbrew/phpbrew/755aaf61000788a5948fc26aa1a1b0b8c48d1cdd/tests/expected/php/5.3.29/Makefile.in:
     annotations:
       linguist: Makefile
+      linguist-filename: Makefile
       vote: Makefile
   github.com/phred/factor-zeromq/c0b2f47d12e187a4b53573dc7f2c501ed7808e5d/zeromq.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/phuse-org/phuse-scripts/89c7c625c9fca46499447f395f4d2478a03efb2b/whitepapers/WPCT/WPCT-F.07.06.sas:
     annotations:
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/phw/peek/7cf050b5fa255b4b4033aef977ba17d037b46441/src/post-processing/gifski-post-processor.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/pi-hole/pi-hole/e41c4b5bb691cea1f5b950d39518d8c404b5846e/advanced/Scripts/list.sh:
     annotations:
       linguist: Shell
+      linguist-extension: Shell
+      linguist-shebang: Shell
       vote: Shell
   github.com/piXelicidio/pxMaxScript/597b31021f2466e9f594eaf4dc1ae2f8fe523e35/SymmetryFix/pxSymmetryFix - Copy.ms:
     annotations:
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: MAXScript
   github.com/picolisp/picolisp/a35f6907709ab1f956f1894e46ad09a5ba0591c2/src64/sys/x86-64.sunOs.code.l:
     annotations:
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
       vote: PicoLisp
   github.com/picrin-scheme/picrin/2af16bc88fbfca2efafd27ca9e5006d73c06f6fb/contrib/20.r7rs/t/r7rs.scm:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
       vote: Scheme
   github.com/pigworker/CS410-15/043477e6143af6a78b677bb528c46621da11df00/McK-B.agda:
     annotations:
       linguist: Agda
+      linguist-extension: Agda
       vote: Agda
   github.com/pigworker/CS410-17/ecf7c3bbe9b468eb72578d05c7dd4dfa913dce44/lectures/Lec6Done.agda:
     annotations:
       linguist: Agda
+      linguist-extension: Agda
       vote: Agda
   github.com/pigworker/TypesWhoSayNi/7015fcde9a76984134691e9176bfb144ebeca7d5/codeb/Relevant/Abstraction.agda:
     annotations:
       linguist: Agda
+      linguist-extension: Agda
       vote: Agda
   github.com/pikamau5/maxscripts_public/217ebdea51714d3e8d9494efb83ced44ac049857/ObjectNameCleanup.ms:
     annotations:
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: MAXScript
   github.com/pikelang/Roxen/17502b5bea5e2a2d6e6c8c47f0065ebbfa306181/server/etc/test/modules/TEST.pmod/http.pmod/WebDAV.pmod/TestUtils.pmod:
     annotations:
       linguist: Pike
+      linguist-extension: Pike
       vote: Pike
   github.com/pikelang/xenofarm/5c173e0f9c381b5eb0cd34f1e577a993ce15a10a/projects/pike/result_parser.pike:
     annotations:
       linguist: Pike
+      linguist-extension: Pike
       vote: Pike
   github.com/pikey8706/LogCatch/2345503297e3a6b8e1a5960fc6f08036e3aed075/src/text_color_loader.tcl:
     annotations:
       linguist: Tcl
+      linguist-extension: Tcl
       vote: Tcl
   github.com/pikitfense/Coffee/539c39fdbc5975289645e9150531aa05b92e3f99/Compile/Coffee003.clw:
     annotations:
       linguist: Clarion
+      linguist-extension: Clarion
       vote: Clarion
   github.com/pillar-markup/pillar/3a801e439fe7426d00caa9d79851733891313e63/src/Pillar-Tests-Model/PRVisitorTest.class.st:
     annotations:
@@ -12677,204 +15588,254 @@ files:
   github.com/pingcap/tla-plus/e3714440dba348bf2e2a19c41c201374ab6c36ee/CollapseRollbacks/CollapseRollbacks.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/pirapira/bamboo/1cca98e0b6d2579fe32885e66aafd0f5e25d9eb5/src/ast/syntax.ml:
     annotations:
       linguist: OCaml
+      linguist-heuristics: OCaml
       vote: OCaml
   github.com/piriys/piriys_info_498/ef0b3e20266eb51c19102cc298eb5f392353ada8/scavenger_npc.lsl:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
       vote: LSL
   github.com/pitagora-galaxy/cwl/554d9ff564d7e64d245fb92095765cf176355387/workflows/tophat2/Tophat2Workflow-se.cwl:
     annotations:
       linguist: Common Workflow Language
+      linguist-extension: Common Workflow Language
       vote: Common Workflow Language
   github.com/pki-io/pki-io/55e3be010c87bdd189e2522ea2d26357f2e5704f/manpage/pki.io:
     annotations:
       human-smola: Roff
       linguist: Io
+      linguist-extension: Io
       vote: Roff
   github.com/plataformatec/devise/14863ba4c92cd9781a961be0486f0ea7dfe84144/lib/devise/secret_key_finder.rb:
     annotations:
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/plataformatec/mox/3eb6e02f8a72d1c5fbdad1ac31d8e3e0891db1e8/mix.exs:
     annotations:
       linguist: Elixir
+      linguist-extension: Elixir
       vote: Elixir
   github.com/playframework/playframework/0b2581127381b37da990d9bb02ea87658935a187/transport/server/play-server/src/main/scala/play/core/server/common/PathAndQueryParser.scala:
     annotations:
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/pljson/pljson/bd4184c0ab6f3bf9e5d25380705189c0158b5981/testsuite/pljson_ext.test.sql:
     annotations:
       linguist: PL/SQL
-      vote: PL/SQL
+      linguist-heuristics: SQL
+      vote: Unknown
   github.com/ploeh/ZeroToNine/3497cf64e6f78921939b3096c363317775917906/Src/Zero29.UnitTests/Properties/AssemblyInfo.fs:
     annotations:
       huma-smola: F#
       linguist: F#
+      linguist-heuristics: F#
       vote: F#
   github.com/plotly/Igor-Pro-Graph-Converter/76ae64d1a64a6eccca0eaeecb8e1b0a977f7fb7e/src/PlotlyPrefs.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/plotnick/clweb/4c736b4c8b4c0afbdd939eefbcb986c16c24c1e3/test.clw:
     annotations:
       human-smola: Unknown
       linguist: Clarion
+      linguist-extension: Clarion
       vote: Unknown
   github.com/plum-umd/cgc/511fa41d8b635bbfe5779fa7fb24d5777dbcaaa5/Prelude/Data/Natural.agda:
     annotations:
       linguist: Agda
+      linguist-extension: Agda
       vote: Agda
   github.com/plumatic/plumbing/6d713472f7324344545aa93597cb2a137b3404b3/test/plumbing/fnk/fnk_examples_test.cljx:
     annotations:
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/pluskid/Mocha.jl/5e15b882d7dd615b0c5159bb6fde2cc040b2d8ee/src/cuda/layers/power.jl:
     annotations:
       linguist: Julia
+      linguist-extension: Julia
       vote: Julia
   github.com/pmahent/cs2project/9d7b7ce4968eddf2a53429786c0b605646df464c/CS2.Tests/BaseTest.n:
     annotations:
       human-smola: Nemerle
       linguist: Nemerle
+      linguist-heuristics: Nemerle
       vote: Nemerle
   github.com/pmb6tz/windows-desktop-switcher/62dca84f97d7be0360306bcaa0b5b38af974b93b/user_config.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/pmoura/lgtstep/6044a6fe77aaef48f2cf379a3107c81444e74ce3/xml.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/pnnl/chgl/e3e3985fbf943eff5f09967f7065fb44b2ac1005/example/demo.chpl:
     annotations:
       linguist: Chapel
+      linguist-extension: Chapel
       vote: Chapel
   github.com/podlomar/krython/1c66266f68ae849936c7afe0e9cf06ef9e7cb035/src/grammar.ne:
     annotations:
       linguist: Nearley
+      linguist-extension: Nearley
       vote: Nearley
   github.com/poetiq/poetiq/57900f400de450a266fd6ff56e1fca238efe9a10/src/dt.q:
     annotations:
       linguist: q
+      linguist-heuristics: q
       vote: q
   github.com/pointwise/AircraftMesher/744b4e2c0c7d052639803322a8cec6862a0d1369/AircraftMesher.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/pointwise/AirfoilGenerator/e8ffbce9b4e8d7f4e4ffecb91d6d8daf06d3be84/AirfoilGenerator.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/pointwise/AirfoilMesh/75241f6e5764118f60c6eec253a3537768cebd6b/AirfoilMesh.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/pointwise/ButterflyMaker/69640569d9a6c1fe89f21373e5dc9c943685b041/ButterflyMaker.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/pointwise/ConGeometricAutoDimension/f6b29c20e347a9db99370545f4870e2f2467b303/ConGeometricAutoDimension.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/pointwise/CreateFFD/43e5920362ca64a8a3368e2f60aac840af36bbdf/CreateFFD.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/pointwise/CreateFromAnalyticFunction/e8dc6830cd04079e9ed062f2586249a37e8cab29/CreateFromAnalyticFunction.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/pointwise/CreateOH/948cfe307ef593e36d43fca93a1b7e84ec8bb5e4/CreateOH.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/pointwise/GeomToMesh/4a95681a0fd5bd7b7b46f4fc9b9f40855613760b/GeomToMesh.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/pointwise/GridCoordEnum/3807bade6eff04871e489562ae8587f59eb7de97/pwio.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/pointwise/GridRefine/29175d48795e7086ba51205b7bc26ab9c23633d6/gridRefine.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/pointwise/ScaledOffset/0cdf4785e0b6a1235782bd7376f28300f0bd5255/ScaledOffset.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/pointwise/Semicircle/a0e1662231fc57083a0b74ab98f1013e546bc549/Semicircle.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/pointwise/TriQuad/49a41fcdd04f91b1ccc9a3cd7dc7a14a17deefe9/TriQuad.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/pointwise/VSP2CFD/986d6b8ea10ecc7cc2bc9e79c2859f6f40638ca2/VSP2CFD.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/pokepetter/Speculaer_Unity/37b15964868e58cec95e952c52ef2ec21ab548ee/Assets/InputFolderChanger.boo:
     annotations:
       linguist: Boo
+      linguist-extension: Boo
       vote: Boo
   github.com/polygonal/ds/cf911f3d91aba1a6f02a9775798a552b03fabf86/src/polygonal/ds/NativeArray.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/ponylang/changelog-tool/6eb9dc01c78112484f2dd3010305513e0ebf540c/changelog.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/ponylang/pony-stable/6a8f3f39a4fca5464d085acfcc506d012ce17e72/stable/bundle.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/poppa/Pike-Modules/f011833cd2d4a0c0cd5a180ca3f6b46e0030c10f/Social.pmod/Twitter.pike:
     annotations:
       linguist: Pike
+      linguist-extension: Pike
       vote: Pike
   github.com/poppa/pike-for-sublime/bb16fc58781e65370175c46c9ceeb6bb4964cf22/from-tmlanguage:
     annotations:
       linguist: Pike
+      linguist-shebang: Pike
       vote: Pike
   github.com/poppa/pike-redux/51a191b38fe8d33243078cf766ea2f99f0dbbee9/Redux.pmod/Middleware.pmod/module.pmod:
     annotations:
       linguist: Pike
+      linguist-extension: Pike
       vote: Pike
   github.com/postcss/postcss/0ff95e2f12dd7d09e732dc9c837ed16ab484fcf1/lib/parser.es6:
     annotations:
       human-smola: JavaScript
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/potassco/asprilo-encodings/0bd438fe8b25df11bd33926490729b817f1550d2/abc/quantities.clp:
     annotations:
       human-smola: Unknown
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: Unknown
   github.com/potatoHVAC/dotfiles/4c0b80418453bbcd9679762d088b371ee1c4723b/.i3:
     annotations:
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Modula-3
   github.com/potigol/potigol-grammar/383b2bcae94a0a741705eedb42b97cfda3670340/potigol.g4:
     annotations:
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: ANTLR
   github.com/powerline/fonts/e80e3eba9091dac0655a0a77472e10f53e754bb0/install.sh:
     annotations:
       linguist: Shell
+      linguist-extension: Shell
+      linguist-shebang: Shell
       vote: Shell
   github.com/powerline/powerline/15c611ca468c607d914ae47d24191c6ac2500f3e/powerline/lib/unicode.py:
     annotations:
       linguist: Python
+      linguist-extension: Python
       vote: Python
   github.com/powerman/inferno-re2/86eabf151b1b55e4692f1b243f6e294d6f8cffde/t/re2/match_unicode.b:
     annotations:
@@ -12883,34 +15844,42 @@ files:
   github.com/ppepos/pep8-dbg/42b397fde3bde87dcd76f6a94a9ea1399bf7d61d/src/debugger.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   github.com/pqnelson/economics-notes/149192d5f8ded995514ae9c0a77c0306bfdfcac7/sraffa/reswitching.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/prabath/ballerina-security/2e80fa3419901b84e8e898e0da8d893d5f2b0c32/service-service-auth-with-mtls/order-processing/order_processing_service.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/prabhakarg-dm/AWS-Training-Session9/a230a0c249a293d0309408280e3cfb0ce49c496c/Hive_CloudFront.q:
     annotations:
       linguist: HiveQL
+      linguist-heuristics: HiveQL
       vote: HiveQL
   github.com/prabirshrestha/asyncomplete.vim/db3ab51ef6d42ac410afaea53fc0513afd0d5e25/autoload/asyncomplete/utils/_on_change/timer.vim:
     annotations:
       linguist: Vim script
+      linguist-extension: Vim script
       vote: Vim script
   github.com/pragmagic/karax/1911a1cfe0db08d840fcfd245e541342f6289836/karax/autocomplete.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/prelegalwonder/qpid_fabric/3ed23c6cd0ff855d9fbd01311c3cfb00c8e9a99d/lenses/qpid.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
       vote: Augeas
   github.com/prertik/test-repo-lfe/266560fc26a62f5a746ca981467ccd9c521ffcc8/example-ring.lfe:
     annotations:
       linguist: LFE
+      linguist-extension: LFE
       vote: LFE
   github.com/pret/pokeyellow/533578e602ad2a9deee5d3c74201c342c9895a7f/data/mapObjects/museum2f.asm:
     annotations:
@@ -12919,49 +15888,60 @@ files:
   github.com/prior-art-archive/uspto-query-parser/c2e63c20b7f09c3771264ab05a52aec8a9f96375/grammar/uspto.ne:
     annotations:
       linguist: Nearley
+      linguist-extension: Nearley
       vote: Nearley
   github.com/prisma/graphcool-framework/dc274418ba663caad8c157a8d8690127e64e6541/server/backend-api-subscriptions-websocket/src/main/scala/cool/graph/websockets/services/WebsocketServices.scala:
     annotations:
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/prisma/prisma/c7be9f75b91c9e2fd53a42dd9a5e2aeddcf26b94/server/servers/deploy/src/main/scala/com/prisma/deploy/schema/fields/DeleteProjectField.scala:
     annotations:
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/probcomp/Gen/164b60ffa4f5ce980979a2200b64c90c0009497d/test/selection.jl:
     annotations:
       linguist: Julia
+      linguist-extension: Julia
       vote: Julia
   github.com/probe-scope/Probe-Scope-PCB/f5a3add610575115ad71bc815e6f6577f5d11894/Project Outputs for Probe-Scope v1.0/Probe-Scope v1.0.G4:
     annotations:
       human-ajnavarro: Unknown
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: Unknown
   github.com/procaconsul/sociologic/dcec734783f92ad04d118376131f162fddf55670/experiments/narrow-passage-one-person.las:
     annotations:
       human-smola: Unknown
       linguist: Lasso
+      linguist-extension: Lasso
       vote: Unknown
   github.com/processone/ejabberd/bb26d7c379f65fa3c6363a43a8f821a7f38b371d/src/mod_mam_mnesia.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
       vote: Erlang
   github.com/processone/tsung/4094df6054727f39fc45f999d719433f0047a5a8/src/tsung/ts_stats.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
       vote: Erlang
   github.com/proctur/test/efdb7b99476efb614a5098be7dcb6b4c70881ed6/onent15.opal:
     annotations:
       linguist: Opal
+      linguist-extension: Opal
       vote: Opal
   github.com/prof7bit/TorChat/a58d1fc4ad4c9eb97386cba5707d35d676a7616b/src/core/tc_prot_version.pas:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/progranism/Open-Source-FPGA-Bitcoin-Miner/fd76bc932ae04be2b27be769871105c4678af9dc/projects/KC705_experimental/KC705_experimental.srcs/sources_1/ip/golden_ticket_fifo/fifo_generator_v10_0/fifo16_patch/fifo_generator_v10_0_fifo16_patch.vhd:
     annotations:
       human-ajnavarro: Unknown
       linguist: VHDL
+      linguist-extension: VHDL
       vote: Unknown
   github.com/proofcert/fpccheck/6de59990bfb7762f869e0d3a4c5d0fad453a86c2/fpc/lprolog/pair.mod:
     annotations:
@@ -12976,117 +15956,147 @@ files:
   github.com/protocolbuffers/protobuf/0150f7f5325a83d4804fcd89f29c72f574da8043/src/google/protobuf/arenastring.h:
     annotations:
       linguist: C++
+      linguist-heuristics: C++
       vote: C++
   github.com/protz/ocaml-installer/c28f789ead872c28bbce273dfe5a59dbd9e8a13b/ReplaceInFile.nsh:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/prs-de/ffidl/07b30ffeaab09083c2b4a6d682ecadfb6518f48d/tclconfig/pkg.m4:
     annotations:
       linguist: M4
-      vote: M4
+      linguist-modeline: M4Sugar
+      vote: Unknown
   github.com/prusa3d/Original-Prusa-i3/b5e22772bbc42ec3159206ebde95317c29ff4765/Printed-Parts/scad/x-end.scad:
     annotations:
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/psake/psake/404f3876ae9a58cdae5df975bc0f49df0dcefb7f/specs/SharedTaskModules/TaskModuleB/0.2.0/TaskModuleB.psd1:
     annotations:
       human-smola: PowerShell
       linguist: PowerShell
+      linguist-extension: PowerShell
       vote: PowerShell
   github.com/psaris/funq/2a10568e9c491db643931aa9229cfc4643b082f8/hiragana.q:
     annotations:
       linguist: q
+      linguist-heuristics: q
       vote: q
   github.com/psifidotos/Latte-Dock/122e6a9616d2c5f7ead97de6629514a0ec31611b/containment/package/contents/ui/VisibilityManager.qml:
     annotations:
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/psonia/Rexx/771dd4dea28f57670096ff2873e16eafbcac527d/Rexx_Hello.rexx:
     annotations:
       linguist: REXX
+      linguist-extension: REXX
       vote: REXX
   github.com/public-apis/public-apis/cd2299b46036f9c9f3d99b717b2827e939105b15/build/validate_links.py:
     annotations:
       linguist: Python
+      linguist-extension: Python
+      linguist-shebang: Python
       vote: Python
   github.com/puffnfresh/iridium/2dc438475962b62f6ca8d00f0dff3add87418dec/src/IR/StackSet.idr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/pulp-platform/ariane/b45617315465be743d964d767abc53e9e93cdb9d/src/cache_subsystem/std_cache_subsystem.sv:
     annotations:
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/pulp-platform/fpnew/da5fd4f0140c45f652c4a82a193f017484e3c72e/src/fpnew_opgroup_block.sv:
     annotations:
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/pulp-platform/riscv/aa13a06b4ca5bacdc59a92fd7aff75adb140cd7f/tb/dm/tb_test_env.sv:
     annotations:
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/pure-c/purec/7cac5ea8db3db11123ce8c151f35127010bd675a/upstream/tests/purs/passing/DuplicateProperties.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/pure-data/deken/24d1de4d95f7841874133b24559bcb4c67c8c171/developer/deken.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
+      linguist-shebang: Hy
       vote: Hy
   github.com/pureqml/qmlcore/cca410b7fdf8d869bbc8a7631eb8477ea3ee928b/core/WheelMixin.qml:
     annotations:
       human-smola: QML
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/purescript-contrib/pulp/e09129b32a42e1275ac19f1225cf4d3d61084967/src/Pulp/Init.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/purescript-contrib/purescript-aff/78916a9c7e6d203f1d9f441c8eaa257d6475e978/test/Test/Bench.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/purescript-contrib/purescript-react/4bf5a5a46ceb485f6941820f717f4507cc030674/src/React/SyntheticEvent.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/purescript-hyper/hyper/c3498d2e2d41e1bb86a1aaeae64058fd6ffe4c2d/src/Hyper/Node/FileServer.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/purescript/purescript/432accc3ea69cb4555e2b3305fae8a29e4e17dde/src/Language/PureScript/Sugar/Names.hs:
     annotations:
       human-smola: Haskell
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/pvanhoof/dir-examples/523cab5edaff99acba037218d5b95227cb2487a9/qmake-example/src/libs/qmake-example/qmake-example.pro:
     annotations:
       linguist: QMake
+      linguist-heuristics: QMake
       vote: QMake
   github.com/pyenv/pyenv/49bf595266866958501d4567fd2e76cfe538a51a/pyenv.d/rehash/source.bash:
     annotations:
       linguist: Shell
+      linguist-extension: Shell
       vote: Shell
   github.com/pymc-devs/pymc/c6e530210bff4c0d7189b35b2c971bc53f93f7cd/lapack/double/dlacon.f:
     annotations:
       linguist: Fortran
+      linguist-heuristics: Fortran
       vote: Fortran
   github.com/pyqt/python-qt5/c9ed180c56f6fd3521ffe5fb70904bc5d3f50e5f/PyQt5/qml/QtQuick/Controls.2/Popup.qml:
     annotations:
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/pytorch/pytorch/bc91e198617ef92d9abd739c49ad5b0393a43a78/caffe2/operators/normalize_op.cc:
     annotations:
       linguist: C++
+      linguist-extension: C++
       vote: C++
   github.com/pyx/hymn/d2257bdf3ac6121500665104e0abb6e52a2124dd/hymn/mixins.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
       vote: Hy
   github.com/qiemem/SmoothLife/db802d4165b9cfe3dca5cca582ecea7f0cb852af/SmoothLife.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/qinwf/awesome-R/e6c83d49289d184658d59f9487c0933b5944a15a/misc/trending_repo.R:
     annotations:
@@ -13095,166 +16105,207 @@ files:
   github.com/qmlbook/qmlbook/e05f0d5b7588807062b501fc103f15d874cb6597/make.bat:
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/qqueue/ANSICHAN/29505cf0f867bdd7526e8967e63628c8db38bf95/ansichan.ls:
     annotations:
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/qqueue/fountain/d91bec238b9efae3cc15bbc682c4a11cbb101866/clients/client.ls:
     annotations:
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/quag/io-json/32e9c0eefba0a746b3dee2515c719bffb78d94fb/json.io:
     annotations:
       linguist: Io
+      linguist-extension: Io
       vote: Io
   github.com/quag/iospec2/32f1899cdefdb85121b83ea36a7e6fd3266f6cf8/iospec:
     annotations:
       linguist: Io
+      linguist-shebang: Io
       vote: Io
   github.com/quanhinh9/H2P/b5458c1026cd1d55ea2172742582742c47d42678/h2geo_v1.1.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/quantixed/CellMigration/f7e9c8c0d7633af8d7f8c06ce67f4376f2a70660/CellMigration.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/quasarframework/quasar/43dcdd6145f3a0896f3553c986b0a50c9da95c3a/ui/src/components/btn-toggle/QBtnToggle.js:
     annotations:
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/quelpa/quelpa/144b71e0f514b96cf19c39853cf08b2d957a8ed5/test/quelpa-test.el:
     annotations:
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/quil/quil/a8106218bfbc53ab2ac746f97c66b85e93cc6216/src/cljc/quil/snippets/shape/loading_and_displaying.cljc:
     annotations:
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/quillford/config/9e482da34d4dc835d34305db773e82752cc26925/.i3:
     annotations:
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Modula-3
   github.com/quintesse/ceylon-tako-sdk/d0890c2599fe63af499908452452b7786d8f4c23/test/test/options/test.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/r-lib/devtools/568ac2a11b67cf780972c11122edce7d65f6fddb/R/utils.R:
     annotations:
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/rabbitmq/rabbitmq-server/151ad8dd013766554ecae8ef143dc63f44f8d3ab/src/rabbit_mirror_queue_mode_nodes.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
       vote: Erlang
   github.com/rabix/cwl-ts/4cc33e96e50932692cf10bd458bf540521593091/src/tests/cli-conformance/v1.0/bwa-mem-tool.cwl:
     annotations:
       linguist: Common Workflow Language
+      linguist-extension: Common Workflow Language
+      linguist-shebang: Common Workflow Language
       vote: Common Workflow Language
   github.com/racket/racket/0c6f50d57d1de42cf70e2c31069fb04ae43a5f55/racket/collects/planet/private/prefix-dispatcher.rkt:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/racket/redex/9ed2787d3bafb4ffb83ba789ac20483ec4129297/redex-examples/redex/examples/delim-cont/randomized-tests.rkt:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/racket/scribble/b67f265b93e74a2a525173449c6febc02c04d57a/scribble-doc/scribblings/scribble/tag.scrbl:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/radiganm/shen-dev/0816137200699b9dcadf214f0d80731ac5193e5e/functions_and_types/functions-and-types.shen:
     annotations:
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/radiganm/shen-modulesys/0e816f8768a562ebb3648e02c884816f29b6de0e/modulesys.shen:
     annotations:
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/radovanbauer/eulerFantom/91edadae4759cab36635fbc09ad53b789c669ded/fan/Problem88.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/rafael-trevisan/apex-plugin-ig_simple_checkbox/050e4bb73c06d37fb03fd11fe75d15313746454e/ig_simple_checkbox.sql:
     annotations:
       human-smola: PL/SQL
       linguist: SQLPL
+      linguist-heuristics: SQL
       vote: PL/SQL
   github.com/rafaelcn/louv1.1x/a52dc99fde7d1f5e4ddcc99babda251bc74f4fce/Second week/primes.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/rails-oceania/roro/e497c5ee0e608810e79518288dba5b217f84c497/2019/06/201906-rorosyd.md:
     annotations:
       linguist: Markdown
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/rails/rails/803c6ba7b3ae06f602e33c15b4d9ea8ae3602a82/activerecord/lib/active_record/connection_adapters/postgresql/oid/point.rb:
     annotations:
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/rain-1/single_cream/f8989fde4bfcffe0af7f6ed5916885446bf40124/t/tarot/compiler.scm:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
       vote: Scheme
   github.com/raine/ramda-cli/76d30c5c8a8d7bb1e920c78494e69d00907333ed/src/main.ls:
     annotations:
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/raksheshekhar1/las2Witsml/4220649cf672da893f9e4902d56ffa5e6ec65e3e/dt2.las:
     annotations:
       linguist: Lasso
+      linguist-extension: Lasso
       vote: Lasso
   github.com/rakudo/star/139ba6333a8b7497b5349a6ed9fde963ea7a90e7/tools/star/analyze_module_dependencies.p6:
     annotations:
       human-smola: Raku
       linguist: Raku
+      linguist-extension: Raku
       vote: Raku
   github.com/ramonsaraiva/cfg/41a14360bb7bda3f1689a90ea2c109059796116f/.i3:
     annotations:
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Modula-3
   github.com/rampelstinskin/ParserGenerator/7eabf20f45f1dc47525fcc158653a6d363b981d3/N2/Boot.N2.Runtime/Internal/ExtensionPostfixBase.n:
     annotations:
       linguist: Nemerle
+      linguist-heuristics: Nemerle
       vote: Nemerle
   github.com/randolfgeist/oracle_scripts/bfd37b1b880093fb90aa0f279291dbf0c1265d34/io_benchmark/max_write_throughput_benchmark_harness.sql:
     annotations:
       linguist: SQLPL
-      vote: SQLPL
+      linguist-heuristics: SQL
+      vote: Unknown
   github.com/raphink/config-augeas-validator/ee8aeffb9753fcb260e6227b2ef6b785bdca77c8/lenses/tests/test_fai_diskconfig.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
       vote: Augeas
   github.com/raphink/puppet-cups/d7eea48de85d2bfc7681aedd1be3a5967072839c/files/lenses/test_cups.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
       vote: Augeas
   github.com/rapidsai/cudf/3d9da9e5da2e731d3d63a066a6d44fe3465cbb5a/cpp/custrings/strings/substr.cu:
     annotations:
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/rasmusbergpalm/DeepLearnToolbox/5df2801f2196a2afddb7a87f800e63e153c34995/tests/test_example_CNN.m:
     annotations:
       human-smola: MATLAB
       linguist: MATLAB
+      linguist-heuristics: MATLAB
       vote: MATLAB
   github.com/raum-dellamorte/RaumEngine/8d60f8007fea69f61cfb3e4a3e246ff1dc22d102/src/main/java/org/dellamorte/raum/toolbox/fontMeshCreator/FontType.mirah:
     annotations:
       linguist: Mirah
+      linguist-extension: Mirah
       vote: Mirah
   github.com/ravichugh/sketch-n-sketch/a5c6f7a8a91195a813320f22fef3ab003862b6f1/src/Deuce.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/ray-dino/SpaceGame/6e47c3e0144ba3b3d66e100dac62ef27e574629f/Main.eq:
     annotations:
       linguist: EQ
+      linguist-extension: EQ
       vote: EQ
   github.com/raywenderlich/swift-algorithm-club/055cb6834c59e02624297925b54aa13204e3fb76/Array2D/Array2D.playground/Contents.swift:
     annotations:
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/raziele/Nigun/ca39bc6bcccc8e650b19e515c2dcc3f4da53a3e3/Footprints/graphics/nigun_logo_sm.kicad.mod:
     annotations:
@@ -13264,48 +16315,59 @@ files:
   github.com/razuna/razuna/45caa4fc47bfd1528c40697aad2a5b3cee0715b7/global/host/dam/views/ajaxparts/dsp_groups_list_users.cfm:
     annotations:
       linguist: ColdFusion
+      linguist-extension: ColdFusion
       vote: ColdFusion
   github.com/rbenv/rbenv/c46a970595036718f1b6d3ed8f38833820df709e/test/whence.bats:
     annotations:
       linguist: Shell
+      linguist-extension: Shell
       vote: Shell
   github.com/rbgirshick/rcnn/43b0334e96e9e910bc45c94902a093b5a6f35d0a/experiments/rcnn_run_pool5_explorer.m:
     annotations:
       human-smola: MATLAB
       linguist: MATLAB
+      linguist-heuristics: MATLAB
       vote: MATLAB
   github.com/rbgirshick/voc-dpm/c0b88564bd668bcc6216bbffe96cb061613be768/train/subarray.m:
     annotations:
       human-smola: MATLAB
       linguist: MATLAB
+      linguist-heuristics: MATLAB
       vote: MATLAB
   github.com/rbtnn/vimconsole.vim/ad4fe23165e24ddc79607e2f09c4609fc4bc3fbf/autoload/vital/_vimconsole.vim:
     annotations:
       linguist: Vim script
+      linguist-extension: Vim script
       vote: Vim script
   github.com/rcdmk/aspJSON/a169daa6b903d574703b37cf08c1275c2cbcd471/test.asp:
     annotations:
       linguist: Classic ASP
+      linguist-extension: Classic ASP
       vote: Classic ASP
   github.com/rcmaehl/NotCPUCores/ef4983b6781e0c7e3be3ff797bf36325c57b2292/Includes/_ModeSelect.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/rcqls/red-gtk/5899b14b48ecb4bcbb1c967bc53bec550617c6ce/063/gtk3/modules/view/backends/gtk3/font.reds:
     annotations:
       linguist: Red
+      linguist-extension: Red
       vote: Red
   github.com/react-native-community/lottie-react-native/3f6870447e007d09261503cfbe5b77e16c7382f7/example/android/app/src/main/java/com/example/DoubleTapRecognizer.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/react-native-community/react-native-camera/4eb67c7b63b9dee8522ba0cedcb8832fbe5becc6/android/src/general/java/org/reactnative/facedetector/tasks/FileFaceDetectionAsyncTask.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/react-native-community/react-native-maps/f8b255e40bef3a68fe3134c08a5219d7ffa173f9/lib/ios/AirGoogleMaps/AIRGoogleMapWMSTileManager.m:
     annotations:
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/reactiveui/refit/56715f8098d10df2d1333a2d7907d66044ef2f1e/Refit.Tests/HttpClientFactoryExtensionsTests.cs:
     annotations:
@@ -13314,11 +16376,13 @@ files:
   github.com/reactphp/reactphp/a13fd22dc66fc79e8d40d21341a659cb0edb060b/tests/bootstrap.php:
     annotations:
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/readevalprintlove/black/6fcc28bdb078502e0b467358d888a038be95fdf2/black-with-delta.scm:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
       vote: Scheme
   github.com/realm/realm-cocoa/6da0d3baebbed932c103d2465c62e72016e6b307/Realm/Tests/MigrationTests.mm:
     annotations:
@@ -13327,11 +16391,13 @@ files:
   github.com/realpython/python-guide/5b959c94153e3bd680181d150a81ad3c33a6cd36/make.bat:
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/reasonml-community/reason-react-hacker-news/8ba4b7855e7c40cd5f2d575beb9a381c8f8ff7e5/src/StoryListItem.re:
     annotations:
       linguist: OCaml
-      vote: OCaml
+      linguist-heuristics: Reason
+      vote: Unknown
   github.com/reasonml/reason-react/8017a5f556176744c245350cbeb5c600abebb8f8/src/ReasonReactRouter.re:
     annotations:
       linguist: OCaml
@@ -13339,51 +16405,63 @@ files:
   github.com/rebolek/gitara/fbec2c695a6f9e5ab2e6e2d8a98a44cec51f779f/json.red:
     annotations:
       linguist: Red
+      linguist-extension: Red
       vote: Red
   github.com/rebolek/gritter/927930504ca7bb580fe17d6f2b92ca562f4b0a84/mockup.red:
     annotations:
       linguist: Red
+      linguist-extension: Red
       vote: Red
   github.com/rebolek/lest/ce7fd205d802bbda100e0b1c39544d177c4de0ba/styletalk.reb:
     annotations:
       human-smola: Rebol
       linguist: Rebol
+      linguist-extension: Rebol
       vote: Rebol
   github.com/rebolek/red-tools/21618dcee44dad7ac28250b4f3b1d81767e31d6c/apis/github-v3.red:
     annotations:
       linguist: Red
+      linguist-extension: Red
       vote: Red
   github.com/rebolsource/rebol-syntax/4ff11396312d0ccd8490191571206f628be79e8e/syntax.r:
     annotations:
       linguist: Rebol
+      linguist-heuristics: Rebol
       vote: Rebol
   github.com/red-gate/honeycomb/df19e64933c3b394ac096ed44aec5bba18f2823b/src/ui/library/elements/type.hb:
     annotations:
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Harbour
   github.com/red/code/749f4662320068da6d5bc5531ac25ea0282215d9/Library/Steam/SteamAPI/Steam-MatchmakingServers.reds:
     annotations:
       linguist: Red
+      linguist-extension: Red
       vote: Red
   github.com/red/community/e2e1db22941fcc555e4012dab23e0674a388b360/mezz/_-while.red:
     annotations:
       linguist: Red
+      linguist-extension: Red
       vote: Red
   github.com/red/red/1d32938a2c39286c14173a4ff78f21dd3c17d905/tests/shield.red:
     annotations:
       linguist: Red
+      linguist-extension: Red
       vote: Red
   github.com/red/wallet/e185143c76ec215bc781f849a95b415d5259279d/utils/extract-tokens.red:
     annotations:
       linguist: Red
+      linguist-extension: Red
       vote: Red
   github.com/redhat-openstack/ansible-role-tripleo-collect-logs/65abb9b2b48d34930540fa4b7b7b07cddb473554/scripts/doc_extrapolation.awk:
     annotations:
       linguist: Awk
+      linguist-extension: Awk
       vote: Awk
   github.com/redjumper/geo2addresslist/4667d3f39fd80a8dc2dc874ac1520e0a68ab6854/freedom-addresslist.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/redline-smalltalk/redline-smalltalk/14d92a2cac8311837810b87e2dd434436430108d/src/main/smalltalk/st/redline/kernel/Transcript.st:
     annotations:
@@ -13392,128 +16470,160 @@ files:
   github.com/redox-os/redox/e39b0bdf77c9c2ad927fbaf7e38e45849bcf143c/mk/prefix.mk:
     annotations:
       linguist: Makefile
+      linguist-extension: Makefile
       vote: Makefile
   github.com/redox-os/tfs/dd2fe205c0255f568a33909a7560201d2d564dbf/core/src/error.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/reduxjs/redux/f1fc7ce8bfa2fd83159c25d2a1b90046f0143790/test/bindActionCreators.spec.ts:
     annotations:
       linguist: TypeScript
+      linguist-heuristics: TypeScript
       vote: TypeScript
   github.com/refi64/hyskell/ed88f8dc557b4392bae37ef2404cd5d2e7cbaa76/hyskell.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
       vote: Hy
   github.com/reflex-frp/reflex-platform/8f4b8973a06f78c7aaf1a222f8f8443cd934569f/haskell-overlays/any-head.nix:
     annotations:
       linguist: Nix
+      linguist-extension: Nix
       vote: Nix
   github.com/regakakobigman/Tutorial-Projects/3f0a77cb5101b359f93d736642de4fb1d40a9c01/How to Use Delta/MovingSprite.gd:
     annotations:
       human-smola: GDScript
       linguist: GAP
+      linguist-heuristics: GAP
       vote: GDScript
   github.com/rehnd/MoS2-band-structure/56a90b1384cccb63bc4cfe6747077c38cc3526cc/espresso/electron/4-plotbands/MoS2-2H.bands.dat.gnu:
     annotations:
       human-smola: Unknown
       linguist: Gnuplot
+      linguist-extension: Gnuplot
       vote: Unknown
   github.com/reid47/gracedoc/f21ab16e2e1e3b52a95bb8303608c5a7aa58c777/gracedoc.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/rektide/compfuzor/9db4309ee245ffdbea1aeea85b49cc5fbc77c6c9/awesome-copycats.pb:
     annotations:
       human-smola: YAML
       linguist: PureBasic
+      linguist-extension: PureBasic
       vote: YAML
   github.com/relrod/Potato/0784257e66ec3cdc7ff68518783e4d8467d78daf/main.io:
     annotations:
       linguist: Io
+      linguist-extension: Io
+      linguist-shebang: Io
       vote: Io
   github.com/remkes/calculus1/1c31e0f45b9bc77ebb642df30840536cf010a3a8/asy/figure07.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/remkes/linearalgebra/1feb9ee4ca170b74bc30eeb7317336724393290d/asy/figure9.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/remko/waforth/5d2a92abcf73ee33ea25be2f5b47a6d83cd6e672/tests/benchmarks/sieve-vanilla.wat:
     annotations:
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/remobjects/calendar/ba057051128e5ba993de69e4bbebc82b98abb4c1/RemObjects.Calendar.oxygene:
     annotations:
       linguist: Oxygene
+      linguist-extension: Oxygene
+      linguist-xml: XML
       vote: Oxygene
   github.com/renaudhager/puppet-agent-smtp-docker-builder/62fa1e31ffff72406dc2d453b848c0dd59775685/centos/6.6/files/postfix_main.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
       vote: Augeas
   github.com/renefloor/flutter_cached_network_image/23cf3f4c4acd36de6fe8ff2b1b4ee51e516d9dfd/lib/src/cached_network_image_provider.dart:
     annotations:
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/reprah/ischeme/8d94dd1288841c9abfaf1ae0a9a28434e89316d8/lib/ischeme/utils.ik:
     annotations:
       linguist: Ioke
+      linguist-extension: Ioke
       vote: Ioke
   github.com/resume/resume.github.com/f5990756495bfd6d86495733bfb238c96771cbbf/js/githubresume.js:
     annotations:
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/revarbat/snappy-reprap/6f06297fe2cdeaf7bfb595e402420ff1bcab714d/bridge_brace_parts.scad:
     annotations:
       linguist: OpenSCAD
+      linguist-extension: OpenSCAD
       vote: OpenSCAD
   github.com/revault/help.rebol.org/e0da3d82018ba1bd64516c26e905674eb53c38c5/qm/support/mashup/gravatar.r:
     annotations:
       human-smola: Rebol
       linguist: Rebol
+      linguist-heuristics: Rebol
       vote: Rebol
   github.com/revery-ui/revery/4a37510cc8ca436e69fc8e77e9930126ca633b33/src/Draw/FontShader.re:
     annotations:
       human-smola: Reason
       linguist: OCaml
+      linguist-heuristics: Reason
       vote: Reason
   github.com/revl-ca/query-parser/91c5644e3aab220c469ab0903de2ba8812de9fd3/query-parser.ne:
     annotations:
       linguist: Nearley
+      linguist-extension: Nearley
       vote: Nearley
   github.com/rexim/fantom2048/958a85d9d063287b1beeafb81d0c40d716092d25/src/fan/Board.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/rfinnie/hlulsl/0b101d531c7c3070bf6b61a2d61237d7f8086673/hlulsl.nsi:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/rfordatascience/tidytuesday/3c584b2270918b9b33b4e8caa259dda89b028183/data/2019/2019-01-22/example_code.R:
     annotations:
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/rformoso/bytes-x-strings/272801b204997e513ba7a577553d213577935d3d/correios_pac_error.zpl:
     annotations:
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Zimpl
   github.com/rgchris/Scripts/7ec511b62606b10b9840f4224bddea28ecc1d141/r3-alpha/httpd.r3:
     annotations:
       human-smola: Rebol
       linguist: Rebol
+      linguist-extension: Rebol
       vote: Rebol
   github.com/rgoulter/cdecl/eeb267492e3c3f19ac1245d5dda807d51d6f7767/src/main/antlr4/cdecl/C.g4:
     annotations:
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: ANTLR
   github.com/rhysd/8cc.vim/228bea2f983dc4e68e716093d89b76e2b83dcc71/autoload/eightcc/command.vim:
     annotations:
       linguist: Vim script
+      linguist-extension: Vim script
       vote: Vim script
   github.com/richard-roberts/GraceLibrary/c2018498bdd6a4b06d07b4d413fd2e6a22a44a00/Benchmarks/PyStone.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/richardeoin/thermocouple/02e168926a972fc747047461dd8dcb07e82eb3d9/nist/type_b.tab.rs:
     annotations:
@@ -13524,162 +16634,201 @@ files:
     annotations:
       human-smola: SQL
       linguist: PL/pgSQL
+      linguist-heuristics: SQL
       vote: SQL
   github.com/riemann/riemann/a1bbfc301078da62de4980c27bbfc421451546be/test/riemann/query_test.clj:
     annotations:
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/rien/Project-ProgrammingLanguages/e1e6b8849f00f81d7915c60f69c03df104ac55a6/List_vs_Tuple.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/rikkarikka/nn_math_solver/6e7a9b0e1f845c8c3fba02d264f30c6f6106366c/data/val.eq:
     annotations:
       linguist: EQ
+      linguist-extension: EQ
       vote: EQ
   github.com/ring-lang/ring/ae6232bd6a068291ac1591b037b1d1ed2cd5512a/developers/Arabic/Mahmoud/test103.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/ringpackages/dotsandboxes/e514060384083beec35bd237bc93dd9182e1b404/applications/dotsandboxes/CalmoSoftDotsAndBoxes.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/ringpackages/game2048/d97f8e866cdfa01fd10cc55b4e0f9623173eaf7d/applications/game2048/CalmoSoft2048Game.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/ringpackages/gameoflife/d0298086a396a0b3e1b7541988cc4492d964d70c/applications/gameoflife/AA-GameOfLife.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/ringpackages/geanyeditorextension/332737032ab7ee07f778f50af9e97f45bcb7194d/package.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/ringpackages/memorygame/d3bcfc7f01747efb0ced65030c61ad32b2824c06/applications/memorygame/CalmoSoftMemoryGame.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/ringpackages/ringbeep/985009381f0ecbb2a1ed1bcc0e67026c784832c9/package.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/ringpackages/ringhelpchm/dbc590c549c11f0b58e35b1845a8585d552df0b9/package.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/ringpackages/sample3dmanycubes/1a53b0eff0e210847cf0c0872e64a80bd3be1eeb/package.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/ringpackages/snake/c03869f12d69230eca864f1404b48f92c4c43884/applications/snake/snake.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/ringpackages/sokoban/46bc7df7e58d8214d1f2bc508118bd1ed02c6c3e/applications/sokoban/sokoban_v2.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/ringpackages/stdlib/da18bdf464c5f2fbae197d66bcef071520e55390/ringlibs/stdlib/stdinternet.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/ringpackages/tictactoe/6bdee9162d9181a7cd670768de229c76e9d89770/applications/tictactoe/TicTacToe.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/ringpackages/visualizesortsample/011425eeaec7c787c368b9668e73bf8dd84356c0/package.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/ringpackages/weblibtools/84deb8c1bd333d62ce2edf6529cfc0de6149f39c/package.ring:
     annotations:
       linguist: Ring
+      linguist-extension: Ring
       vote: Ring
   github.com/riot/riot/fc0cc802ab67baf10196dcd1433e6597ccb5b723/src/core/component.js:
     annotations:
       human-smola: JavaScript
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/riscy/shx-for-emacs/298f96e68068d6891d20e6188e918ab55ac56b30/shx.el:
     annotations:
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/rjbs/Data-UUID/732deecacb22562c88e9957c42a4559482f120e5/UUID.xs:
     annotations:
       linguist: XS
+      linguist-extension: XS
       vote: XS
   github.com/rkh/sinatra.fy/2dd8170fafd8d59cdc289f339a8a59be57c1a7d1/lib/sinatra.fy:
     annotations:
       linguist: Fancy
+      linguist-extension: Fancy
       vote: Fancy
   github.com/rkoeninger/ShenPrelude/28b0daf9e803ab784d4a623f26cc792c721d4f0d/memo.shen:
     annotations:
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/rkoeninger/euler/bb6f4e2fdfc3b47198afd0949ff47cda6e706f4e/src/euler6/euler6.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/rkruppe/rvv-llvm/5dd2e94b266274638dc508c002126eab3ed84ff1/test/CodeGen/ARM/neon_ld1.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/rmartyna/LOLCODE-examples/b6eba27d1e60a14ca9f5457b0bbe857bbfc488fc/src/hello_func.lol:
     annotations:
       linguist: LOLCODE
+      linguist-extension: LOLCODE
       vote: LOLCODE
   github.com/robbyrussell/oh-my-zsh/8b6b2ea07e7e18129757195731a3df5d57465807/plugins/rbfu/rbfu.plugin.zsh:
     annotations:
       linguist: Shell
+      linguist-extension: Shell
       vote: Shell
   github.com/robertzhouxh/dotfiles/9172b17cbbc89c45a3d4d15a3f405a5b63b66b7e/.emacs.d/snippets/dix-mode/pardef:
     annotations:
       linguist: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/robinhouston/PadWalker/53372956f9d11021319035edec700599482ec9e6/PadWalker.xs:
     annotations:
       linguist: XS
+      linguist-extension: XS
       vote: XS
   github.com/robinhouston/wdg-html-validator/9694889302d12e6bb1a78f65e145af4d2ccd3ec8/root/usr/local/share/sgml/declaration/xml1n.dcl:
     annotations:
       human-smola: Unknown
       linguist: Clean
+      linguist-extension: Clean
       vote: Unknown
   github.com/robsimmons/c0testing/f5e29b4b4ae8176af809038902db970310ca2b7e/testspec.ne:
     annotations:
       linguist: Nearley
+      linguist-extension: Nearley
       vote: Nearley
   github.com/robwhitby/xray/82379fef28971583767c616399826280f4cfdbc4/src/assertions.xqy:
     annotations:
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/rocketnia/penknife/8d710c8c6ec06e080a74b93931cf217699a3f4f4/pk-util.arc:
     annotations:
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/rocky/elisp-bytecode/9bc3be3e04cdcad863b04cc8b038fe7cd81d8dce/byte-pretty-22.el:
     annotations:
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/rocky/emacs-load-relative/dbcd7cbcca6503ef93f4b8d19bf7a9efd7f6bf9b/test/load-file2.el:
     annotations:
       human-smola: Emacs Lisp
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/rodjek/puppet-haproxy/c95446aa111fee4e4b0d0e31b4817952f2640c60/files/usr/share/augeas/lenses/haproxy.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
       vote: Augeas
   github.com/rodrigocaldeira/tictactoelolcode/f6b3b1eed5e982ea473f7cc7c5460e6891bb8dce/tictactoe.lol:
     annotations:
       linguist: LOLCODE
+      linguist-extension: LOLCODE
       vote: LOLCODE
   github.com/rodrigogribeiro/agda-software-foundations/db41971ac28d18ba304e202d9c92e77f34afac80/SfLib.lagda:
     annotations:
       linguist: Agda
-      vote: Agda
+      linguist-extension: Literate Agda
+      vote: Unknown
   github.com/roelandjansen/pcmos386v501/406365a0919f6fb48fd5de1bddfdf157e80892e3/SOURCES/src/latest/MOSKBSF.ASM:
     annotations:
       linguist: Assembly
@@ -13687,28 +16836,34 @@ files:
   github.com/rogera24/Programming_Projects/977284258a50587ec9bcb1018ac707c927117272/School Work/Multi-Agent_Modeling/Telemarketer/Telemarketer 2x Reserve with neighboor.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/rogrush/grace-dictionary/f22c3f8233dc57d2e762c50ed5cdf15d1ec4ab84/gUnit.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/rokudev/SceneGraphDeveloperExtensions/e12d03ccea23b0674a8412b5fbd856abfe334b48/extensions/SGDEX/Handlers/ContentHandler.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/rokudev/samples/e03a191760ce4a740cc23deb6dd81b8680c49d7c/ux components/text/ScrollableTextExample/source/main.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/rolledback/regionadjacency/42e3bbdb38ea3f194ad11b0e2d89b5fde3b63336/test.boo:
     annotations:
       human-smola: Unknown
       linguist: Boo
+      linguist-extension: Boo
       vote: Unknown
   github.com/ronascentes/sqltoolbox/ae810d41c5c54277c5eaf03750e3a2450dd2853c/usp_index_defrag/usp_index_defrag.sql:
     annotations:
       linguist: SQLPL
-      vote: SQLPL
+      linguist-heuristics: TSQL
+      vote: Unknown
   github.com/ronsaldo/lowtalk/ed169388a9f4799b296b92ea2b0d5e7e9e59a5b8/tonel/Lowtalk-Core/LowtalkBObject.class.st:
     annotations:
       linguist: Smalltalk
@@ -13716,63 +16871,79 @@ files:
   github.com/rorydavidson/SNOMED-CT-Database/c2b75bbd8d56ff95d3d357b6cb58aaa59302deb4/PostgreSQL/load-postgresql.sql:
     annotations:
       linguist: SQLPL
-      vote: SQLPL
+      linguist-heuristics: SQL
+      vote: Unknown
   github.com/ros-simulation/gazebo_ros_demos/64e9200749567aab9ca2289563eea987fea8cf50/gazebo_tutorials/CMakeLists.txt:
     annotations:
       linguist: CMake
+      linguist-filename: CMake
+      linguist-heuristics: Text
       vote: CMake
   github.com/rossgray/rossgray.github.io/5006ee1e608f039a11bdad8235399b248f700d4d/source/kit/index.kit:
     annotations:
       linguist: Kit
+      linguist-extension: Kit
       vote: Kit
   github.com/rowanthorpe/taskwrangle/6c50120b6ed258feac8136f8aff86e6748dd424c/lib/libtaskwrangle.l:
     annotations:
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
       vote: PicoLisp
   github.com/rpolley/chapel-geometry-raytracing-library/3b87fe6914d98ea383f1aaf5b0f6be0b45bf4fe4/geometry.chpl:
     annotations:
       linguist: Chapel
+      linguist-extension: Chapel
       vote: Chapel
   github.com/rradclif/mortgagesample/dd650c4d701bff7a12026e69530b87ca663c0037/MortgageApplication/copybook/epsmortf.cpy:
     annotations:
       linguist: COBOL
+      linguist-extension: COBOL
       vote: COBOL
   github.com/rricharz/Tek4010/0efbc2e783efe4f88375f07af6172c3cb437045b/pltfiles/More_pltfiles/msdusa.plt:
     annotations:
       human-smola: Unknown
       linguist: Gnuplot
+      linguist-extension: Gnuplot
       vote: Unknown
   github.com/rritoch/PikeVM/e4664e95c99412d264ceddd89aec096a14f83b45/lib/mudlib/object/m_move.pike:
     annotations:
       linguist: Pike
+      linguist-extension: Pike
       vote: Pike
   github.com/rrrene/credo/da1d94013da1e8b699f4d5701c4f665e8ff19464/test/credo/config_file_test.exs:
     annotations:
       linguist: Elixir
+      linguist-extension: Elixir
       vote: Elixir
   github.com/rsayers/anonchat/655b339d08fc1c7f9d9224fda00724803b800c9a/chat.arc:
     annotations:
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/rschiang/material/db866cd2134c54485e807874111b7470c4b3bfcd/qml/material/PaperShadow.qml:
     annotations:
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/rsdn/Hql/14958db4b928f5546b3df4c7b8da018f904c3177/TypingSupport/ProjectSupport.n:
     annotations:
       linguist: Nemerle
+      linguist-heuristics: Nemerle
       vote: Nemerle
   github.com/rsdn/Nitra-Mini-C/7251c21796adff1a938f3557db7f35e95d01679d/Nitra-Mini-C/Properties/AssemblyInfo.n:
     annotations:
       linguist: Nemerle
+      linguist-heuristics: Nemerle
       vote: Nemerle
   github.com/rsdn/nemerle/f7ebf8f2cff477c3d9b8abdb6470e7b8d80f51ce/snippets/Nemerle.Async/Nemerle.Async.Macros/Syntax.n:
     annotations:
       linguist: Nemerle
+      linguist-heuristics: Nemerle
       vote: Nemerle
   github.com/rsdn/nitra/e331fffdd8981835a3b1e55893495fcdfa3d3ae7/Nitra/Nitra.Compiler/Generation/Parser/ParseMethodEmitter/CompileList.n:
     annotations:
       linguist: Nemerle
+      linguist-heuristics: Nemerle
       vote: Nemerle
   github.com/rsoesemann/salesforce-plantuml/e5bec0113cdb8e9fadb626a8ad20520cd253e96c/sfdx-source/main/default/classes/CodeMetrics.cls:
     annotations:
@@ -13781,55 +16952,69 @@ files:
   github.com/rspeer/wiki2text/1859b9e336c8cdbb698b6b1a24cb077e18c094e5/wiki2text.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/rstudio/bookdown/c58cac7fda077bc84740f18945f442dfe04cfd81/R/word.R:
     annotations:
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/rstudio/shiny/32f93a2be109ab8e38931afa7a6232ba8359442f/R/server-input-handlers.R:
     annotations:
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/rstudio/tensorflow/9d7f1abcca71ec294d07e453cc8a5a2fbab367ad/R/compat.R:
     annotations:
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/rswarbrick/giplayer/064a738e8a8c2d5ec067cd2631fbb148024ce8dc/search-box/search-box-tests.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/rtfeldman/elm-css/eebd494c1a8bc4dceded3473a75294434ebef5ee/src/Css/Structure.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/rtfeldman/elm-spa-example/17a3398623f9e538f14f5b0d039fd62b3beae934/src/Loading.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/rtfeldman/node-test-runner/0ff9ce1dfee2de565c20449b485127e0f0543233/fixtures/elm-home/0.19.0/package/elm-explorations/test/1.2.1/tests/src/Test/Html/Query/CustomNodeTests.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/rubinius/rapa/38a6950939258dd3e751ef0571f6730dfb639a44/machines/pack.rl:
     annotations:
       linguist: Ragel
+      linguist-extension: Ragel
+      linguist-modeline: Ragel
       vote: Ragel
   github.com/rubygeeks/mirah_book/477c7f2497a71a74297294bca6ab318af5f88035/cookbook/code/mirah/code_which_does_not_work_in_mirah.mirah:
     annotations:
       human-smola: Mirah
       linguist: Mirah
+      linguist-extension: Mirah
       vote: Mirah
   github.com/rubygeeks/msl/257393b3853e035469f289a046f0d21516f77d8c/mirah.mirah:
     annotations:
       linguist: Mirah
+      linguist-extension: Mirah
       vote: Mirah
   github.com/rukano/scprivatepool/bb5dbf275ba8dc9775eb22919bcf51d4c79decd5/projects/sc_tron/_synths.scd:
     annotations:
       linguist: SuperCollider
+      linguist-extension: SuperCollider
       vote: SuperCollider
   github.com/rundeck/rundeck/03287bc79cab9994f1f7dc757942b615d8b12859/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy:
     annotations:
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/ruoru/leetcode-rust/0736a26e0c9f8ac2e8a5f60e7ae8bb1eb9e9b445/Algorithms/0684.redundant_connection/redundant_connection_test.rs:
     annotations:
@@ -13839,144 +17024,181 @@ files:
   github.com/ruslo/hunter/eacae658ad6ebb63d79acf1c2f62564b5b7afce9/cmake/projects/Qt/qttools/hunter.cmake:
     annotations:
       linguist: CMake
+      linguist-extension: CMake
       vote: CMake
   github.com/russellallen/flow/dec9cc74748dde5791f95321c2fda8a27a565766/objects/flow.self:
     annotations:
       linguist: Self
+      linguist-extension: Self
       vote: Self
   github.com/russellallen/self-webserver/3b931c9740f53f2f7fac7427e052eaaecd4eec75/objects/webserver.self:
     annotations:
       linguist: Self
+      linguist-extension: Self
       vote: Self
   github.com/russellallen/self/2bcf2c4cab23f52bf68ac4f617020e748699a548/objects/applications/cecil/interp/methodCache.self:
     annotations:
       linguist: Self
+      linguist-extension: Self
       vote: Self
   github.com/rust-lang-nursery/futures-rs/0c7fa20ae07b59af4c04487817f33a830561b7e9/futures-executor/src/lib.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/rust-lang/rust/e8b190ac4ad79e58d21ee1d573529ff74d8eedaa/src/test/ui/numbers-arithmetic/integer-literal-suffix-inference.rs:
     annotations:
       human-smola: Rust
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/rust-lang/rustfmt/e4a50da529e7a6eb7b58a75b0b43f7938aab8e66/tests/target/cfg_if/detect/arch/x86.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/rust-lang/www.rust-lang.org/e770231372604486abd995fcf1532e28b5ea0611/locales/pt-BR/licenses.ftl:
     annotations:
       linguist: FreeMarker
+      linguist-extension: FreeMarker
       vote: FreeMarker
   github.com/rust-unofficial/awesome-rust/b945661634e8a2d345c0e55c71d33024b9d44820/cleanup.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/rustwasm/wasm-bindgen/d51f539d1a1625e9f2fe7d48d2ae8bdeb98041ff/publish.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/rustymyers/scripts/37f2737b6d00d8760a7d17da0a2b5ad74a0c56ae/Xojo/PrefTest/macoslib/ImageKit & ImageCapture/ICCameraItem.xojo_code:
     annotations:
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/ruz/HTML-Gumbo/b4447afa57f522e4faea2dd6b7d7d000c877aea6/lib/HTML/Gumbo.xs:
     annotations:
       linguist: XS
+      linguist-extension: XS
       vote: XS
   github.com/rverstappen/AMX/f51a7770e767a8c77b4dead77314c410f23e125f/NetLinx/RelayConfig.axi:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/rvjansen/rexx-repository/f14c3a8a00270e5a97a34200a58e0f1cca3f0851/Object_Rexx/windows/oodialog/userGuide/exercises/Exercise07/Product/ProductListView.rex:
     annotations:
       linguist: REXX
+      linguist-extension: REXX
       vote: REXX
   github.com/ryanjdew/XQuery-XML-Memory-Operations/8fa6a98efa9525f4dda53ed94fd65353f0a694e6/memory-operations.xqy:
     annotations:
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/ryanoasis/powerline-extra-symbols/ae05de7c51f6609479f4f1a4a0f6f65631731c1b/src/uniE0D3_lego_block_facing_WIP-3d-good.eps:
     annotations:
       linguist: PostScript
+      linguist-extension: PostScript
       vote: PostScript
   github.com/ryantking/ats-portaudio/9c3a4517bbfd5bd3d0bbf70448fcb6bca9a6e8cc/portaudio.sats:
     annotations:
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/rycee/home-manager/450571056552c9311fcb2894328696b535265593/modules/services/redshift.nix:
     annotations:
       linguist: Nix
+      linguist-extension: Nix
       vote: Nix
   github.com/ryotako/igor-CommandPanel/13e16fc7746a5af207cff126666db17c6a9c80b8/CommandPanel Test.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/ryotako/igor-MinTest/e81451965c3ca38fde270574cfb60109fe7e1e9c/MinTest.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/ryotako/igor-glob/b02ebfb0c6c621a1f97d1bd38c5aafab089658a5/glob.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/ryuji/epona/4462ddfa408eaed6a94015259a4a3f8220d5cf75/lib/arc/code.arc:
     annotations:
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/s-ol/csgo-vscripts/a377d403e48a8ec866cf129f769e39452e79b471/nadetraining.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/sachac/.emacs.d/bc1f7f870a3140b95168cb36a93c319d3291ba16/snippets/org-mode/links:
     annotations:
       linguist: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/sadmac7000/org.americanteeth.ceylon_llvm/50ab1fb43336749677492f63180d537b064a9a30/source/org/americanteeth/ceylon_llvm/cso/ParameterListData.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/sagishahar-zz/lpeworkshop/923357f2d6869ad154116c8b71915b5e4c28de67/lpe_windows_setup.bat:
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/sait/vfpjson/7eb5c77d369b655f0b7919b3cdcf4eb6b8ca5982/json.prg:
     annotations:
       linguist: xBase
+      linguist-extension: xBase
       vote: xBase
   github.com/sakamitz/Quizer/a3d8b8f7badae4ad440d26bb8ab46a75945c0a49/main.lsp:
     annotations:
       human-ajnavarro: NewLisp
       linguist: NewLisp
+      linguist-heuristics: NewLisp
+      linguist-shebang: NewLisp
       vote: NewLisp
   github.com/sakra/cotire/391bf6b7609e14f5976bd5247b68d63cbf8d4d12/src/CMakeLists.txt:
     annotations:
       linguist: CMake
+      linguist-filename: CMake
+      linguist-heuristics: Text
       vote: CMake
   github.com/saltybytes/3ds-max-tools/9498c78267136182d8152560ce5f5cb97defadb6/Tentacles/Tentacles.ms:
     annotations:
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: MAXScript
   github.com/samawati/j1eforth/49ea12b33191929dd166becb2905e498dec93774/j1.4th:
     annotations:
       linguist: Forth
+      linguist-extension: Forth
       vote: Forth
   github.com/samisalreadytaken/vs_library/792ccd7e50b8f4238a3b44963560c0c95208dc53/vs_library.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/sampayo/Alfred-WorkFlows/59230ab2fbac70af4920fd105d1c691738887a62/Audio Switch/input.applescript:
     annotations:
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/samratashok/nishang/d332b7b85b5d70b17aed15cb4afd930736fcbad9/Client/Out-SCF.ps1:
     annotations:
       linguist: PowerShell
+      linguist-extension: PowerShell
       vote: PowerShell
   github.com/samuelgruetter/dot-calculus/5226123cf638f8e967f3294578ca3ecb7379cf96/ln/tlc/LibMap.v:
     annotations:
       linguist: Coq
+      linguist-heuristics: Coq
       vote: Coq
   github.com/samuelpmish/RLUtilities/7c645db1c7450ee793510c3acbb8bc61f8825b74/extras/analysis/jumping/jumping.nb:
     annotations:
@@ -13986,10 +17208,12 @@ files:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/sandogeorge/webtalk/eee039beb36565fb7a20b4f64d37c9e770ae1ae3/core/blueprint/static/static.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/sandroandrade/ifba-foss-experience/71e4ca81f61eff14a7a709aebe64aca3e5e00cba/ifba-foss-experience.pro:
     annotations:
@@ -13999,58 +17223,73 @@ files:
     annotations:
       human-smola: C
       linguist: eC
+      linguist-extension: eC
       vote: C
   github.com/santi6291/felix-the-cli/99c3f25e187ca56a944ff6e0a24095540c653113/assets/templates/scss/main/_variables.hb:
     annotations:
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Harbour
   github.com/saphanaacademy/PAL/2e15de442f440a77624b8b1e176e4590d458159f/Code Snippets/PAL 91 Exception Handling.sql:
     annotations:
       linguist: SQLPL
-      vote: SQLPL
+      linguist-heuristics: SQL
+      vote: Unknown
   github.com/sarabander/sicp-pdf/5b3a5b2165c414a689873fd316a7293bc587b1c7/src/texi-to-latex.pl:
     annotations:
       linguist: Perl
+      linguist-heuristics: Perl
       vote: Perl
   github.com/sarahBuisson/kotlin-parser/427719a0e62783ea3e8d9d28133db0abe3257b12/src/main/antlr4/com/github/sarahbuisson/kotlinparser/KotlinLexer.g4:
     annotations:
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: ANTLR
   github.com/sascommunities/sas-global-forum-2019/18a43149b36130c11d5bf5e49d6dca2b9447cf8c/2991-2019-DelGobbo/Files/Exercise3.sas:
     annotations:
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/sassoftware/enlighten-apply/7ad42e11b3d59b7ccbcee5fdd6ef2571f69a5821/SAS_UE_TidyData/tidy2.sas:
     annotations:
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/sassoftware/sas-prog-for-r-users/b7bc35cdd7743dc2bc53cc6c0b701b167e136b22/code/SP4R07d08.sas:
     annotations:
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/savatoxa/Time-line-nav/bde40908e158a14db7853ed04991694fdda77632/timeLineNavigator.ms:
     annotations:
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: MAXScript
   github.com/savnon/test/8dde0e4479377ca88d272717ccd572a720fc27e5/apache/manual/programs/apxs.html.fr:
     annotations:
       linguist: Frege
+      linguist-heuristics: Frege
+      linguist-xml: XML
       vote: Frege
   github.com/savonet/liquidsoap/cb66ff1bcc19ce1756478012fe1633d47a13db9e/src/encoder_formats/vorbis_format.ml:
     annotations:
       linguist: OCaml
+      linguist-heuristics: OCaml
       vote: OCaml
   github.com/sayon/forthress/6e0f96ec63e9c97e0233bcbd3175ca36a760bb03/stdlib.frt:
     annotations:
       linguist: Forth
+      linguist-extension: Forth
       vote: Forth
   github.com/sblendorio/gorilla-cpm/a10cb1cb6445e4c7f6e84e7f2e3c8d731badbae9/source/xterm.mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/sbolel/imp-nrf24/611dcf0790294a5f7ce1027041b7f4c593f0e256/rf24_imp.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/sbragagnolo/taskit/3b78424adde348ce6daeeda2cf38f8af481e237f/TaskIt-Tests/TKTWorkerMemoryLeakTests.class.st:
     annotations:
@@ -14063,18 +17302,23 @@ files:
   github.com/scala/scala/673cfec756c350b3bdca1d031f63624bb618148b/test/files/jvm/duration-tck.scala:
     annotations:
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/schacon/git-scribe/41424bb312975cc49ed9716a932e216485ebf2d3/docbook-xsl/fo/docbook.xsl:
     annotations:
       linguist: XSLT
+      linguist-extension: XSLT
+      linguist-xml: XML
       vote: XSLT
   github.com/schmx/sdl-forth/b1ea86d17be0e13bc6bef0f83279db1f3bd37513/sdl-error.fs:
     annotations:
       linguist: Forth
+      linguist-heuristics: Forth
       vote: Forth
   github.com/schneiderandre/popping/6237b8c0392aa13e9e8227a756f864c244269c91/Popping/ModalViewController.m:
     annotations:
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/sciguy14/Eagle-Tutorial-Series/2683c0f2b7aaacc525c2180436f6940eb952dfe4/02 Layout/blinky.pro:
     annotations:
@@ -14083,38 +17327,48 @@ files:
   github.com/scilab/scilab/0068b70ee75ebbfd7f0201abec7a5e56df5469b0/scilab/modules/xcos/tests/nonreg_tests/bug_11821.tst:
     annotations:
       linguist: Scilab
+      linguist-heuristics: Scilab
       vote: Scilab
   github.com/scmu/foundations-harper/63f170677b07f78ce19cee228e98fc9abbdb19e7/08.LNumStr->/Membership.agda:
     annotations:
       linguist: Agda
+      linguist-extension: Agda
       vote: Agda
   github.com/scotchi/Chuckery/012be4a4670984bf61e88b3aedb44d2855f128a4/include/MidiValues.ck:
     annotations:
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/scottbass/SAS/efc2d3bd959f1c3565dfa8ec585faeb2a5536953/Macro/create_directory.sas:
     annotations:
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/scottprahl/iad/0c7f834b02ab0bb53bf6da6d7eff3a0ad93cda1b/src/ad_cone_test.w:
     annotations:
       linguist: CWeb
+      linguist-heuristics: CWeb
       vote: CWeb
   github.com/scottprahl/mie/c6f6d14b51d3457ebaf270b40ff81c25aebe2806/src/mie_cylinder.w:
     annotations:
       linguist: CWeb
+      linguist-heuristics: CWeb
       vote: CWeb
   github.com/scrapy/scrapy/98caf055b5a343ff663f2c1150b301a3f4546a16/tests/test_middleware.py:
     annotations:
       linguist: Python
+      linguist-extension: Python
       vote: Python
   github.com/screx/cwl-tutorial/ae08e989af8634697b93dc565049370907381f90/cl-tools/grep/grep.cwl:
     annotations:
       linguist: Common Workflow Language
+      linguist-extension: Common Workflow Language
+      linguist-shebang: Common Workflow Language
       vote: Common Workflow Language
   github.com/scriptin/jmdict-simplified/07b869c62e5b5ae50f3fba06e99de70182d32e66/src/jmnedict/convert-entries-range.xq:
     annotations:
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/sctb/lumen/2d272b2cc78b23b0b23a69a08fc625240e545ebc/main.l:
     annotations:
@@ -14124,26 +17378,33 @@ files:
   github.com/scurty-labs/weel/45598a5a7318de6692e26c84f441af8cf78dba1c/project.monkey2:
     annotations:
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/se38/zJSON/41472d1c5e06011ccca714d4945407aaea521220/src/zcx_json_document.clas.abap:
     annotations:
       linguist: ABAP
+      linguist-extension: ABAP
       vote: ABAP
   github.com/seata/seata/4f286878ed5690ecdca4df5d695053259fd5c646/core/src/main/java/io/seata/core/rpc/ClientType.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/sebastianbergmann/diff/2ce6675fe77612cce2a49d0cecb4e7afead64323/tests/Output/Integration/UnifiedDiffOutputBuilderIntegrationTest.php:
     annotations:
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/sebastianbergmann/php-token-stream/5bc2030589cad93e6c73ce3ccee3f5e960604a0d/tests/Token/ClassTest.php:
     annotations:
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/sebgod/skat/6b6c10a6e381c9a0fe703618a2592ced1f69fa59/src/suit.m:
     annotations:
       linguist: Mercury
+      linguist-heuristics: Mercury
+      linguist-modeline: Mercury
       vote: Mercury
   github.com/sebh/HLSL-Spherical-Harmonics/7d6c4550b8f762c5372a1258b633f7a196d8bba3/sh2.nb:
     annotations:
@@ -14152,14 +17413,17 @@ files:
   github.com/sebkirche/pbnilist/233e080985bdfdc4f2b78394d911e5ec73d9f5c1/pb_src/115/listdemo.sra:
     annotations:
       linguist: PowerBuilder
+      linguist-extension: PowerBuilder
       vote: PowerBuilder
   github.com/sebkirche/pbniregex/f61cb31163ac83cacfcd0fb8bd88e405272dcc63/pb_src/115/u_splitbar_horizontal.sru:
     annotations:
       linguist: PowerBuilder
+      linguist-extension: PowerBuilder
       vote: PowerBuilder
   github.com/sebnil/RealtimePlotter/f7b90526a54a9e8d36eac1597e12ce573196fa74/BasicRealtimePlotter/GraphClass.pde:
     annotations:
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/sebschub/FontPro/165b4a7d11ad34b64d7457ee6d51af4875e0bf14/fontinst/MyriadPro/MnSymbolF5.pl:
     annotations:
@@ -14168,6 +17432,7 @@ files:
   github.com/sentry07/netlinx-libJSON/cf09cc6798e5d141d49b47bf4aeb206fd971b0be/libJSON.axi:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/seoeun25/data-ex/9507410fa1518c2bb4ba61f056cdc7092110fc4c/hive/ddl/wikiticker.q:
     annotations:
@@ -14176,70 +17441,87 @@ files:
   github.com/sephiroth74/purePDF/5a409634412fa1032b1e9937a347b344d3ccc63e/purepdf/src/org/purepdf/pdf/PdfFormXObject.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/sergiocorreia/ftools/ecd992ef82f9d9c2cfd7bd096411a00d64318920/src/ftools_main.mata:
     annotations:
       linguist: Stata
+      linguist-extension: Stata
       vote: Stata
   github.com/sergiocorreia/reghdfe/fe46317f6923f1834ddb9edfcdc8c7c5b9ca7319/src/reghdfe_class.mata:
     annotations:
       linguist: Stata
+      linguist-extension: Stata
       vote: Stata
   github.com/sergoslav/magento-to-zephir/4d88a4c6b318ab2ccf78fff00bbe88e5f5432a90/varien/vobject.zep:
     annotations:
       linguist: Zephir
+      linguist-extension: Zephir
       vote: Zephir
   github.com/serhii-londar/open-source-mac-os-apps/73c599eed4e83c9bae2d49acedbf74903e1402b3/.github/main.swift:
     annotations:
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/servo/servo/8abc272d27edf06840b23db79f76a4c3a6a8ed41/components/style/stylesheets/viewport_rule.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/seven1m/30-days-of-elixir/9aff3e5f492ff19f9c549dd42f103f0d27a47186/07-fibonacci.exs:
     annotations:
       linguist: Elixir
+      linguist-extension: Elixir
       vote: Elixir
   github.com/sgebbie/pony-graphs/04299a58e77d655914004b25b9726e2f43ed1592/dominators.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/shabiel/KIDS-VC/fc062d90bd6b3ebe0502fadb6cafffd16b594201/XPD_8P0_11310.KID:
     annotations:
       linguist: Genshi
+      linguist-extension: Genshi
       vote: Genshi
   github.com/shabiel/rpms-immunizations/2b6f920ef7d092dcfafc9d02da887a98174884b0/kids/VISTA-Port/BIV_0P8-BI-PATIENT.KID:
     annotations:
       linguist: Genshi
+      linguist-extension: Genshi
       vote: Genshi
   github.com/shabiel/vistalink-gtm-mtl-support/00de443555ff81e65ec67461fdc4291dd9df787a/KBAN_VL_GTM_SUPPORT_0P1.KID:
     annotations:
       linguist: Genshi
+      linguist-extension: Genshi
       vote: Genshi
   github.com/shadowsocks/ShadowsocksX-NG/3fa0945116a77ac230119e9178868016bde1f191/ShadowsocksX-NG/PreferencesWindowController.swift:
     annotations:
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/shadowsocks/shadowsocks-android/4e23960088432e59164ced4847be5b7e722fa894/core/src/main/java/com/github/shadowsocks/plugin/PluginManager.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/shadowsocks/shadowsocks-gui/069dd20c00d9f188bd1994b4c4b4f6aa177b8492/src/args.coffee:
     annotations:
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/shadowsocks/shadowsocks-windows/3759305d6a54177e100687eb2debd93a2ec41863/shadowsocks-csharp/Controller/Strategy/StatisticsStrategy.cs:
     annotations:
       linguist: C#
+      linguist-heuristics: C#
       vote: C#
   github.com/shajra/example-nix/cca6a75b10456a726598d8bcc8a11f44910da117/pkgs-make/python/overrides/scikit-multilearn/default.nix:
     annotations:
       linguist: Nix
+      linguist-extension: Nix
       vote: Nix
   github.com/shamblett/CtoDart/bf869938bef84a57ff07d6f5825d07ddb6ce43ed/Txl/CtoDart.Txl:
     annotations:
       linguist: TXL
+      linguist-extension: TXL
       vote: TXL
   github.com/shanhuio/smlos/9f7de31d7ba9a97dad1ecb54583c8d3702663165/sync/join.g:
     annotations:
@@ -14249,56 +17531,69 @@ files:
   github.com/shanlusun/blockchain/e536a43a6fe341a948bd3973aedb10e2cd6327dd/eos/08/docker/hello/hello.wast:
     annotations:
       linguist: WebAssembly
+      linguist-extension: WebAssembly
       vote: WebAssembly
   github.com/sharkdp/bat/3d23daa7b463e1dee5bd7eead6767bb25b5a4b55/src/bin/bat/app.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/sharkdp/cube-composer/eba26feccb82a9c9033f37f398280b3df42871bb/src/Types.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/sharkdp/fd/c14a00436704097f5e3effab1c5084c60944d011/src/exec/input.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/sharkdp/insect/c94fa6481e402b2659bc0903da515478be4c0424/src/Insect/Format.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/sharkdp/pastel/4ec67197b9595f07b157baaee514ab6eb12fb660/src/cli/commands/pick.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/sharkdp/purescript-flare/2e93a11322850fb82ecae77d5b8297379056b47a/test/Main.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   "github.com/sharoue/chinawareblock/b334468623fac087a13c9f76427c4486633dd938/\u4E00\u952E\u5C4F\u853D\u8F6F\u4EF6/\u817E\u8BAF/~\u4E00\u952E\u62C9\u9ED1.bat":
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/sharplispers/cormanlisp/6ff68633ed730dbd1500f06639dd093513b4278e/Sys/auto-update.lisp:
     annotations:
       human-ajnavarro: Common Lisp
       linguist: Common Lisp
+      linguist-heuristics: Common Lisp
       vote: Common Lisp
   github.com/sheganinans/pfpl-shen/26bc29a573038e6e2171cd22b10438bc0d4b9766/pfpl-4.shen:
     annotations:
       human-smola: Shen
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/shelajev/fantom-http-server/cde37922e18ff29ee6e2a92908bde32b98831176/fan/HttpServer.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/shepheb/pony-playground/c6a30f64ec712895d0ed383c44de72b27714cc1a/main.pony:
     annotations:
       linguist: Pony
+      linguist-extension: Pony
       vote: Pony
   github.com/shiffman/LearningProcessing/7c3e3c532f6bcc84abd7136ca3986c5697da6052/chp17_strings/exercise_17_05_display_coordinates/Ball.pde:
     annotations:
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/shihyu/MyTool/541771d9bc10d32a54baa48eb62992b4bcb9353f/mybin/se/macros/ctviews.e:
     annotations:
@@ -14312,77 +17607,94 @@ files:
   github.com/shlevy/elvysh-filedes/730738cf3acd9292004b32bbad980c9cdb95b30c/src/partially-initialized-array.dats:
     annotations:
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/shlevy/elvysh-main/f40fe21d1d3281d27cab45a94f07cb43a5003d8d/include/elvysh/posix-main.hats:
     annotations:
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/shreevatsa/knuth-literate-programs/9b46afe7e66cb1493592a6bf08adacada165fc58/programs-orig/spgraph.w:
     annotations:
       linguist: CWeb
+      linguist-heuristics: CWeb
       vote: CWeb
   github.com/shsdev/arc2warc-hadoop/96e624592deaa1cf355a27772032bd0206dc6ce5/src/test/resources/arc-dedup/2-metadata-1.arc:
     annotations:
       human-smola: Unknown
       linguist: Arc
+      linguist-extension: Arc
       vote: Unknown
   github.com/siddontang/tlaplus-example/65df94e273d5e31b88b924d440aa5ed6a2f7fe3b/raft.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/signalfx/signalflow-grammar/940e2fe4b707d5316499672dd8dfe9845149f0fd/python/grammar/newline.g4:
     annotations:
       human-smola: ANTLR
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: ANTLR
   github.com/sihorton/appjs-deskshell/5d820d8b3e84d4eeb8916785d395561a37719ea2/sys-apps/win-exe-compiler/NSIS/Examples/languages.nsi:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/sile-typesetter/sile/447535ea927687345d93567737b16ab6531947d9/lua-libraries/lunamark/writer/dzslides.lua:
     annotations:
       human-smola: Lua
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/simlun/simlun-rpms/c004c82b60c821f2d2493e3daffe93e4eb24e69b/Dockerfile.i3:
     annotations:
       human-smola: Dockerfile
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Dockerfile
   github.com/siraben/zkeme80/ef2ae421ad56d1d3668a8cd17ae08f34171be8c6/src/util.scm:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
       vote: Scheme
   github.com/sitaramc/gitolite/2cb621498b963f7ff2df49015b5ac9c7a8892398/contrib/utils/ipa_groups.pl:
     annotations:
       linguist: Perl
+      linguist-heuristics: Perl
       vote: Perl
   github.com/sj26/mailcatcher/626a7b7a651151dd4222962d0d8d7b12c619be3c/lib/mail_catcher/web/application.rb:
     annotations:
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/skidvision/wolfram-language/6ad074c5c593b3280745f22bd495310606be7f8b/tools/test.wl:
     annotations:
       human-smola: Wolfram Language
       linguist: Wolfram Language
+      linguist-extension: Wolfram Language
       vote: Wolfram Language
   github.com/skilion/onedrive/945251f7f2e95ae85001efb6eab85d6176bac75e/src/itemdb.d:
     annotations:
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/skn3/qrcode/4eba37d31756f2c47d572e013959bc5a61176156/qrcode.monkey:
     annotations:
       human-smola: Monkey
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/skn3/xml/88ec9e0700788e9485faf388d636420869717d5d/xml.monkey:
     annotations:
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/skywind3000/kcp/4c58607c917c2a82bf116489c3eb89e4e9aa696d/ikcp.c:
     annotations:
       linguist: C
+      linguist-extension: C
       vote: C
   github.com/sl4m/gnu_smalltalk_koans/1b52dcdc9dd6f6e61706d0fa68d2c30ae9da6f47/src/koans/TestMessage.st:
     annotations:
@@ -14391,19 +17703,23 @@ files:
   github.com/slackhq/hack-sql-fake/e35f696bdc73b23f83ab7ec7b350402a060e0350/src/Expressions/CaseOperatorExpression.php:
     annotations:
       linguist: Hack
+      linguist-heuristics: Hack
       vote: Hack
   github.com/slamdata/purescript-halogen/115b48959afae35bdfebfac87221ba0ac61b5367/src/Halogen/Aff/Driver/State.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/slashiee/cemu_graphic_packs/3a4e7ab73442a016374c85dfa3d31eb03c2d477a/Enhancements/TwilightPrincessHD_Bicubic/output.glsl:
     annotations:
       linguist: GLSL
+      linguist-extension: GLSL
       vote: GLSL
   github.com/slime/slime/2b9feb2fef764c6713ce433a6318cc412127172d/swank/clisp.lisp:
     annotations:
       human-ajnavarro: Common Lisp
       linguist: Common Lisp
+      linguist-heuristics: Common Lisp
       vote: Common Lisp
   github.com/smkplus/ShaderMan/f2501540e3f0ef8da4abaf8a05c98f5cb4cfa022/Assets/Shaders/Examples/Voronoi.shader:
     annotations:
@@ -14412,18 +17728,22 @@ files:
   github.com/smmankad/float/c20b44e342dee91736e4f1cfd076bb85a13a0e8b/src/Ribbons/botao.pde:
     annotations:
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/smurphy8/ats-0.3.11-my-examples/a9605fad318dcd490b686cea53f53d13b287a14e/src/dataviews.dats:
     annotations:
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/smyru/XTemplate-for-Pike/3785e1d5376ef429285e8c061bee7a8ffb94274a/XTemplate.pike:
     annotations:
       linguist: Pike
+      linguist-extension: Pike
       vote: Pike
   github.com/sncn-hub/imu_demo/988975866194bf46d9396e5f1931ee10c842596c/lib_i2c/src/i2c_slave.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/snj33v/ofqmake/40c7591c831087cce523fe42f8c9210774d91227/openFrameworks.pro:
     annotations:
@@ -14433,152 +17753,190 @@ files:
   github.com/snosov1/dot-emacs/1dcc17066d740bcfc5595a75187c6a0f957bf0fe/.yasnippets/c++-mode/eulerangles:
     annotations:
       linguist: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/snyded/dbdatabases/f2e09ddd8ac45a3e3ebc23f8a297fd02fc0ea118/dbdatabases.ec:
     annotations:
       human-smola: C
       linguist: eC
+      linguist-extension: eC
       vote: C
   github.com/snyded/dbrowlock/bd3a3ac7f6dc16e111a59299f8582b366f5c0aba/dbrowlock.ec:
     annotations:
       human-smola: C
       linguist: eC
+      linguist-extension: eC
       vote: C
   github.com/so-fancy/diff-so-fancy/05e2a1aca01746ed5de24e27f1ca7832393dc216/lib/DiffHighlight.pm:
     annotations:
       linguist: Perl
+      linguist-heuristics: Perl
       vote: Perl
   github.com/soapyigu/Swift-30-Projects/70fa254298352558220fc250c268b1b9e5128321/Project 12 - Tumblr/Tumblr/TransitionManager.swift:
     annotations:
       linguist: Swift
+      linguist-extension: Swift
       vote: Swift
   github.com/socketio/socket.io/47161a65d40c2587535de750ac4c7d448e5842ba/lib/index.js:
     annotations:
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/sofakid/Skoarcery/e4fece84792e1979bdac8abaeb76a117ad8f3965/SuperCollider/Skoar/toker.sc:
     annotations:
       linguist: SuperCollider
+      linguist-heuristics: SuperCollider
       vote: SuperCollider
   github.com/softvelocity/clariontouch/645b9cca9569002220699ea7d9a5dcc1eb40a806/Media Player/MPlayer001.clw:
     annotations:
       linguist: Clarion
+      linguist-extension: Clarion
       vote: Clarion
   github.com/softwaresaved/build_and_test_examples/93ceaf4e9f96ef5673a5a5358a91fffdbfd58904/fortran/fruit/fruit.f90:
     annotations:
       linguist: Fortran
+      linguist-extension: Fortran
       vote: Fortran
   github.com/soimort/translate-shell/0115103a9289ade50c2e184b70cecae8a07a9739/include/Translators/BingTranslator.awk:
     annotations:
       linguist: Awk
+      linguist-extension: Awk
       vote: Awk
   github.com/solidityj/solidity-antlr4/50cf6acb3f14d5b317636f4c162562410f2c58d3/Solidity.g4:
     annotations:
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: ANTLR
   github.com/solidsnack/GraphpostgresQL/8756fce0f8a9fddb49e7258bbe78de048c643725/fb/schema.sql:
     annotations:
       linguist: PL/pgSQL
+      linguist-heuristics: PL/pgSQL
       vote: PL/pgSQL
   github.com/soloworks/netlinx-global-code/8b12a1dbd41330869d0df61c6403a5b84813d8ea/ModulesNetlinx/mSim2Projector.axs:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/solson/rust-nightly-nix/7081bacc88037d9e218f62767892102c96b0a321/default.nix:
     annotations:
       linguist: Nix
+      linguist-extension: Nix
       vote: Nix
   github.com/solus-project/budgie-desktop/e6433d87974e735296e72cf5b9d2a25466d5fe7a/src/applets/places-indicator/MountHelper.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/soolar/CONSUME.ash/4c2cce867e13695ae188e5e1c7c85807285d56be/RELEASE/scripts/CONSUME/INFO.ash:
     annotations:
       linguist: AGS Script
+      linguist-extension: AGS Script
       vote: AGS Script
   github.com/sooqua/js-react-redux-yasnippets/70785d126a28ffcb314fb4b354319418586e06b1/snippets/js-mode/rpcp:
     annotations:
       linguist: YASnippet
+      linguist-modeline: YASnippet
       vote: YASnippet
   github.com/source-foundry/Hack/3e7343e1a244c253ce84f0b75516cc42ea8d136b/build-woff2.sh:
     annotations:
       linguist: Shell
+      linguist-extension: Shell
+      linguist-shebang: Shell
       vote: Shell
   github.com/sovathkoeun/HTML/2fe6dab6e1c8074b1648d8429eef7b84d8c8c3cf/OrganiZen/All-in-One 08-05-2019/Microsoft Project Pro 2013 x64/admin/zh-cn/onent15.opal:
     annotations:
       linguist: Opal
+      linguist-extension: Opal
       vote: Opal
   github.com/spacejam/tla-rust/45e7a16c111dc2af2f36b9a4cbc1757002585475/pcal_intro.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/sparanoid/chinese-copywriting-guidelines/ea01f1bc27e61ca32b109e3c9e26a1c693de116d/Gruntfile.coffee:
     annotations:
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/spark-jobserver/spark-jobserver/1e0504a118dbbe820eb15953bb634eae663d85d5/job-server/src/test/scala/spark/jobserver/JobSpecBase.scala:
     annotations:
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/sparkfun/Wimp_Weather_Station/8fb4f8052ee94b945a8d5a44dab230c936724fdf/device.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/sparklinlabs/superpowers-asset-packs/e8674a03ab4456802f71f848c4df79eccca23f7a/3d-character/character/animation/walk/Walk0FS.glsl:
     annotations:
       linguist: GLSL
+      linguist-extension: GLSL
       vote: GLSL
   github.com/sparverius/ats-acc/2d49f4e76d0fe1f857ceb70deba4aed13c306dcb/DATS/tokenize.dats:
     annotations:
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/sparverius/ats-macos/032c8008669c5b002faffb486a5535c3eccfecce/src/eight_queens.dats:
     annotations:
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/spdegabrielle/gasTank/de9f2f41362cfd5dff132be181fc55237e93ac4b/idealGas.self:
     annotations:
       linguist: Self
+      linguist-extension: Self
       vote: Self
   github.com/speeeee/language-random/16a215d39254e057ff175520f89e99e3e419d376/computational-ling.ijs:
     annotations:
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/spire/spire/3d67f137ee9423b7e6f8593634583998cd692353/formalization/agda/Spire/DarkwingDuck/Derived.agda:
     annotations:
       linguist: Agda
+      linguist-extension: Agda
       vote: Agda
   github.com/spluta/LiveModularInstrument/790d86a20426464ca1a29e359920157f0f41873e/modules/buchlaOLDControllers.scd:
     annotations:
       linguist: SuperCollider
+      linguist-extension: SuperCollider
       vote: SuperCollider
   github.com/spockframework/spock-example/7d231048200fe4164e4e857da7be0988d6af2424/src/test/groovy/OrderedInteractionsSpec.groovy:
     annotations:
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/spree/spree/0f1bfd3e4d3dde93ee21dacd56bdac1e86675597/core/db/migrate/20150317174308_remove_duplicated_indexes_from_multi_columns.rb:
     annotations:
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/spring-projects/spring-boot/684d7cfe38cdb264d58ab3e746edcaa62bcff06e/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-custom-layout/src/main/java/smoketest/layout/SampleLayout.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/sqrlab/ARC/8ba61ff3b1404b0419381c998881d374ce80ff80/src/_txl/ASM_V.Txl:
     annotations:
       linguist: TXL
+      linguist-extension: TXL
       vote: TXL
   github.com/sqrlab/ccmetrics/845ef71a9834804e32308066c1eea8a1b441b154/src/CCMetrics.Txl:
     annotations:
       linguist: TXL
+      linguist-extension: TXL
       vote: TXL
   github.com/square/leakcanary/1f6c971caba4d5cf78ac561b0cec006a2c482a1b/leakcanary-object-watcher/src/main/java/leakcanary/GcTrigger.kt:
     annotations:
       linguist: Kotlin
+      linguist-extension: Kotlin
       vote: Kotlin
   github.com/square/retrofit/669d371db28e803bed4144667c8f83191c4cf443/retrofit/src/main/java/retrofit2/CompletableFutureCallAdapterFactory.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/sredmond/stanford-karel/0cd5e64cbc9cd5930bddaacaf8bc0b175fd3e26c/worlds/StoneMasonSmall.w:
     annotations:
@@ -14589,78 +17947,96 @@ files:
     annotations:
       human-smola: Unknown
       linguist: NewLisp
+      linguist-heuristics: NewLisp
       vote: Unknown
   github.com/sryza/aas/a5fad93f169e71811db7cb3457a0cf076412b12b/ch03-recommender/src/main/scala/com/cloudera/datascience/recommender/RunRecommender.scala:
     annotations:
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/ss13-daedalus/daedalus/18b19f32ff48863cdc638a7782c144d875f9f374/code/obj/machinery/smart_fridge.dm:
     annotations:
       linguist: DM
+      linguist-extension: DM
       vote: DM
   github.com/st33d/red-rogue/5fef5ef7ac1cc5229411b625d8c9eed67abd5a09/src/com/robotacid/util/XorRandom.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/stanaka/dash-at-point/4d795a23a8428c421d5107f1b005c9d8e0d1816c/dash-at-point.el:
     annotations:
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/stanislaw/awesome-safety-critical/cdf3fc56dd773bd0657bfdf62e0109dd2c163319/Makefile:
     annotations:
       linguist: Makefile
+      linguist-filename: Makefile
       vote: Makefile
   github.com/stascorp/rdpwrap/a5c64a43319e4e375b391ad42c41504bcb349b4a/src-x86-binarymaster/LiteINI.pas:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/statebox/idris-ct/9eb218b365eebedab1227823b8e0cd304462a610/src/Monoid/MonoidMorphismAsFunctor.lidr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/statickidz/TemarioDAW/8597a388be0cc661b97d06e9adf4226c96477369/BBDD/tareas/BD_Tarea6_Actividad 1.sql:
     annotations:
       human-smola: PL/SQL
       linguist: PL/SQL
+      linguist-heuristics: SQL
       vote: PL/SQL
   github.com/status-im/nimbus/c734e959c70ab74de88f1384877a92815443fe1f/nimbus/vm_types.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/staylward/esoteric-fun/3a6b290329f5642b62d647adabb5a5d7f69a046d/lolcode/baseConverter.lol:
     annotations:
       linguist: LOLCODE
+      linguist-extension: LOLCODE
       vote: LOLCODE
   github.com/stcarrez/ada-util/a6961727e90edb96d2205034323d15c9d1149996/src/sys/http/util-http-rest-rest_get_vector.ads:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/stcarrez/etherscope/d53e55c0dc52d0fce500dc7df91274320d183038/src/etherscope-analyzer-ethernet.ads:
     annotations:
       human-smola: Ada
       linguist: Ada
+      linguist-extension: Ada
       vote: Ada
   github.com/stefanos1316/Rosetta-Code-Research/de36e40041021ba47eabd84ecd1796cf01607514/Scripts/Task/universal-turing-machine/rexx/universal-turing-machine-4.rexx:
     annotations:
       linguist: REXX
+      linguist-extension: REXX
       vote: REXX
   github.com/steinwaywhw/ats-redis/78096ca66c397d73ce73005545193538529e89a7/redis.hats:
     annotations:
       human-ajnavarro: ATS
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/steinwaywhw/ats-session-playground/c7979e0f9baf0de2b6520ac80cf11e6123a660f3/dependent/tests/simple.dats:
     annotations:
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/step-/JSON.awk/b0a85162b5639d95684e96e43ec2ae24978dfceb/callbacks.awk:
     annotations:
       linguist: Awk
+      linguist-extension: Awk
       vote: Awk
   github.com/stepan-mitkin/drakon_editor/f52e727640cb2fd14d25008969abe8d61054b61a/unittest/model_test.tcl:
     annotations:
       linguist: Tcl
+      linguist-extension: Tcl
       vote: Tcl
   github.com/steveicarus/ivtest/7923eb3d764d25ebc4f694247c3e5549369e8f15/ivltests/pr2937417c.v:
     annotations:
@@ -14669,10 +18045,12 @@ files:
   github.com/stevenharradine/winipcfg/106b1fdaef4ab24e1672a3c7d44c3f759c9420d4/winipcfg.t:
     annotations:
       linguist: Turing
+      linguist-heuristics: Turing
       vote: Turing
   github.com/stevepiercy/rackspace_cloud/135f41c8254f4ff4ce6349a72d508ae5dc228bc8/rackspace_cloud.lasso:
     annotations:
       linguist: Lasso
+      linguist-extension: Lasso
       vote: Lasso
   github.com/stewartsmith/libeatmydata/df7ddeb0345104f25b5b7bb154bc6a008c8c8404/m4/acx_pthread.m4:
     annotations:
@@ -14681,14 +18059,18 @@ files:
   github.com/stewbeef/beefy_questing/b6d075ec1c11776d9ed9e21e87ad1a4ca1ad152b/scripts/questing/beefy_quests.ash:
     annotations:
       linguist: AGS Script
+      linguist-extension: AGS Script
       vote: AGS Script
   github.com/sticker0ne/RubiusTest/9acc68546ba2d4475b5bd4941fb388f5043352a7/DB/musicServiceLogic.txl:
     annotations:
       linguist: TXL
+      linguist-extension: TXL
+      linguist-xml: XML
       vote: TXL
   github.com/stiggy87/ZynqBTC/6dbd2734de82510afc9268630ebf58cde75ca9b7/hls/ip/hdl/vhdl/sha256_top.vhd:
     annotations:
       linguist: VHDL
+      linguist-extension: VHDL
       vote: VHDL
   github.com/stipub/stixfonts/73d7c426993abacea44288aded4e81b568d57ed1/archive/STIXv2.0.0/Type1/fonts/source/public/stix2/stix2-mathrm.pl:
     annotations:
@@ -14698,34 +18080,41 @@ files:
   github.com/stisti/jenkins-app/df19f7a254c792868a7069fc0c74cdfe755a5be7/main.applescript:
     annotations:
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/storrgie/predict410/c35ee31fbd4553ab4a15d7d4b27b331d020bf7e0/assignment/6/assignment6.sas:
     annotations:
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/storybookjs/storybook/5770c8e6357910f489a942a87cc579a3188db136/lib/cli/test/fixtures/angular-cli-v6/src/polyfills.ts:
     annotations:
       human-smola: TypeScript
       linguist: TypeScript
+      linguist-heuristics: TypeScript
       vote: TypeScript
   github.com/strangeloop/StrangeLoop2014/0176d1dcb090cba2ec1b19dda50eadf73d034b21/slides/sessions/Hendricks-ProductionProlog.pl:
     annotations:
       human-smola: Prolog
       linguist: Prolog
+      linguist-heuristics: Prolog
       vote: Prolog
   github.com/streetster/perch/aa5bfa73e887d5f106bafc9815ca9db786265437/code/kdb/procs/stp/stp_init.q:
     annotations:
       linguist: q
+      linguist-heuristics: q
       vote: q
   github.com/strongself/generamba-catalog/f5ab7c7b23f2c2a667c26096cbc20fa00ec36809/adkrviper_controller/Code/View/view_input.h.liquid:
     annotations:
       human-smola: Liquid
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/stsdc/monitor/81c10e6f2f9c40b5799880d8353a6aea458dc0a3/vapi/libgtop-2.0.vapi:
     annotations:
       human-smola: Vala
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/studio/studio/b653144046b775ea8bddc391a4ba29625936e282/frontend/Studio-RaptorJIT/RJITBlIRFragment.class.st:
     annotations:
@@ -14734,14 +18123,17 @@ files:
   github.com/submersibletoaster/povray-planets-build/25e266f8ed0641dd13a42f477f7dcbe9a8ad5cf0/share/povray/cm/cm_camera.inc:
     annotations:
       linguist: POV-Ray SDL
+      linguist-heuristics: POV-Ray SDL
       vote: POV-Ray SDL
   github.com/subsetpark/aoc-2018/4b0c8ee3709537369f16822393a9738b43acea2f/lfe/src/aoc_2.lfe:
     annotations:
       linguist: LFE
+      linguist-extension: LFE
       vote: LFE
   github.com/sullivan-USA/Grace/a60063c4d1862754b2e00de0fa173343e2b8f92c/Album_Collection/Track_Object_Tests.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/sullo/nikto/3c2c484e054425a842fd6d67f134949f219409f5/program/replay.pl:
     annotations:
@@ -14750,10 +18142,12 @@ files:
   github.com/sunakane/graduate/f84f1aa5d9e60919222a00a6905a243b1ab41f22/CollresMDfor1.0.ec:
     annotations:
       linguist: eC
+      linguist-extension: eC
       vote: eC
   github.com/sund/tempbug/6a0cd6072759d5fb71135c1be174caa954e86988/tempbug.device.nut:
     annotations:
       linguist: Squirrel
+      linguist-extension: Squirrel
       vote: Squirrel
   github.com/sunyaoGitHub/CassTimeCode/dbd874c4f506575c6ade294c74b5125b2b2b7033/conf/BMW Map.e:
     annotations:
@@ -14767,10 +18161,12 @@ files:
     annotations:
       human-smola: Unknown
       linguist: Augeas
+      linguist-extension: Augeas
       vote: Unknown
   github.com/surrim/osmod/1843f4b1885482361af92c6984c2488209bc3df3/MOON-C/scripts/Units/Supplier.ec:
     annotations:
       linguist: eC
+      linguist-extension: eC
       vote: eC
   github.com/svenvc/ston/049da2fad16df1a470da5fd8c4f748562250b7f5/repository/STON-Tests.package/STONTestDomainObject.class/class/dummy.st:
     annotations:
@@ -14779,204 +18175,253 @@ files:
   github.com/sverrirs/XboxBigButton/7135144f8374bd6cc4e6504eeb8556415782c598/XboxBigButton_WinUsbDriver/installer/setup.nsi:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/svetlyak40wt/arc-crawler/764b950a92de93fc1b56a0581dbe54567e3ee080/crawler.arc:
     annotations:
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/svetlyak40wt/python-processor/9126a021d603030899897803ab9973250e5b16f6/tests/outputs.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
       vote: Hy
   github.com/svlsResearch/ha-mikrotik/36153605d2f311ba715688be593f58e86ee9cb0e/HA_init.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/swannodette/mori/46c9194b3c4bc93fc4b402925b9417add3b0a3ba/project.clj:
     annotations:
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/sweetalert2/sweetalert2/2292d146178082cbd4e289230390c71ca538b698/test/qunit/params/image.js:
     annotations:
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/swirldev/swirl/466dddc617cc73b373d9558f0e1d3b1e4f0ebe83/R/answerTests2.R:
     annotations:
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/swirldev/swirl_courses/ed63fe67f8eb1f13414607bae2355d518c62427c/R_Programming/Functions/scripts/remainder-correct.R:
     annotations:
       human-smola: R
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/symfony/symfony/ba1ba971d67a982223a794f7f780d3cd975a0485/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php:
     annotations:
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/synopse/mORMot/e8e797cbd6cec374a3ead17442bc37f94ec55d7b/SynDBDataset/SynDBUniDAC.pas:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/syntacore/scr1/9bc6cbbbd3670040720d8e39e7f569b3f2796df6/src/top/scr1_dmem_ahb.sv:
     annotations:
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/t-martin/qmail/6c7edb4d7f4159767baae9096624bfec1d4c8352/q/qmail.q:
     annotations:
       linguist: q
+      linguist-heuristics: q
       vote: q
   github.com/t3h2mas/pc-hy/ad9d3e83a66efce9c81206ed296bdc71058c6c1a/db.hy:
     annotations:
       linguist: Hy
+      linguist-extension: Hy
       vote: Hy
   github.com/tabacof/adversarial/dcacc594a9b185733a4955c379c95b40e5d50f86/lbfgsb/linpack.f:
     annotations:
       linguist: Fortran
+      linguist-heuristics: Fortran
       vote: Fortran
   github.com/tahamohkawy/titianicDataAnalysis_Hive/d399399c36b8625b87fc5d52b7550cb0ce4f89fa/TitianicDataAnalysis_Hive.q:
     annotations:
       human-smola: HiveQL
       linguist: HiveQL
+      linguist-heuristics: HiveQL
       vote: HiveQL
   github.com/taigaio/taiga-front/7e2e0b7cf9ac7559fd701536275819a6cd408b37/app/modules/history/comments/comments.controller.spec.coffee:
     annotations:
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/taij33n/picolisp/ddc994b4697fd88b0596fb90a4b5e80ea94e5d82/lib/term.l:
     annotations:
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
       vote: PicoLisp
   github.com/tajmone/name-that-color/5b6c58e82a3d4032b3d84f6ca3c3cd714a7291b1/NTC.pbp:
     annotations:
       linguist: PureBasic
-      vote: PureBasic
+      linguist-xml: XML
+      vote: Unknown
   github.com/tak-oda/201904_DisneyReview/b831fd9020ba4f23bd44e41891191f991012b388/Codes/Q1.q:
     annotations:
       linguist: HiveQL
+      linguist-heuristics: HiveQL
       vote: HiveQL
   github.com/taka-no-me/android-cmake/556cc14296c226f753a3778d99d8b60778b7df4f/AndroidNdkGdb.cmake:
     annotations:
       linguist: CMake
+      linguist-extension: CMake
       vote: CMake
   github.com/takano32/selfevaluck/db001a1dfc5ac041c85d13d8467b0ff02cbd9d41/hello.ms:
     annotations:
       human-smola: Unknown
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: Unknown
   github.com/takikawa/racket-clojure/6a65b4348770dee984bd6fe8d0e33445887fff17/clojure/reader/parse-afl.rkt:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/tangentstorm/syndir/9dbc98590f22aaaf63421437d4c619bc483cfab1/unify.ijs:
     annotations:
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/target/lorri/363cd2db3584572b5e35d26140755a1b811c1314/src/logged-evaluation.nix:
     annotations:
       linguist: Nix
+      linguist-extension: Nix
       vote: Nix
   github.com/tarreislam/TeenyScript/49ee38d195c0861a85468be8dd4b28eb44472089/TeenyScript/GuiOpt.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/tbmihailov/kb-computer-classifier/852aa784d2d978131ec60a1aa491d7afa0486678/ComputerClassifier.clp:
     annotations:
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: CLIPS
   github.com/tcolar/camAxonPlugin/52f8c5119cbb001ed4a333949c2042e747d62274/fan/AxonPlugin.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/tcolar/camembert/0e38e8bcaf0295e5e4522a32082e86cddc2f8814/plugins/fantom/build.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/tcolar/fantomide/b6aff94f009b675d152e9f7b9cb44dbd0fc6930e/presentations/fantom/examples/hello/fan/examples/Functions.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/teachop/xcore_neopixel_buffered/37bbce485d28b4eadbd57adbbbf6e8c0aa8d8d68/module_neopixel/src/neopixel.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/technomancy/atreus/6e5aa64bcde0f7c1ca33101b087dbbf3133b4a98/case/deck.rkt:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/technomancy/leiningen/d30da96058ead9126c833b474c350c0437683c74/test/leiningen/test/new.clj:
     annotations:
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/teckerpro/MikroTik-pptpBan/63e7cfb668a2805fc0419d571916b8acb87e00b0/pptpBan.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/tedhagos/android-mirah/d0d976d8ee5226cb1771ce98e1cc523a12fd392e/call-activity/src/com/thelogbox/MainActivity.mirah:
     annotations:
       linguist: Mirah
+      linguist-extension: Mirah
       vote: Mirah
   github.com/teejee2008/timeshift/f395760b3f4c31d104af669bf6f8a196b6b7082a/src/Gtk/RestoreDeviceBox.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/tekartik/sqflite/89a5e73a4a383246c5a4ba26918997e8b3022e84/sqflite/example/lib/todo_test_page.dart:
     annotations:
       linguist: Dart
+      linguist-extension: Dart
       vote: Dart
   github.com/tempelmann/custom-editfield/3e9b6909f141dd3b883410663b7c93e8ef757c2d/cef/CustomEditField/SyntaxHighlightEngine/LineHighlighter.rbbas:
     annotations:
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/tempelmann/rb-tcmportmapper/50bd46be1cc60457795b124bf1bc2c43a7766aaf/TCMPortMapper Lib/From MacOSLib/CoreFoundation/CFType.rbbas:
     annotations:
       linguist: REALbasic
+      linguist-extension: REALbasic
       vote: REALbasic
   github.com/ten24/slatwall/3b566784ae126a5713481fd8d8fdd83ca4eb7295/admin/views/entity/preprocessgiftcard_redeemtoaccount.cfm:
     annotations:
       linguist: ColdFusion
+      linguist-extension: ColdFusion
       vote: ColdFusion
   github.com/tensorflow/models/948333240864dbf2f55bfb8c5d213d8d1cc55465/research/ptn/nets/im2vox_factory.py:
     annotations:
       linguist: Python
+      linguist-extension: Python
       vote: Python
   github.com/tensorflow/playground/b8f91b111c2d2058c547a1ab779ff96a70162004/src/dataset.ts:
     annotations:
       human-smola: TypeScript
       linguist: TypeScript
+      linguist-heuristics: TypeScript
       vote: TypeScript
   github.com/tensorflow/tensorflow/f3c0673ad7079deda3c6bdbdbae59be323b326ed/tensorflow/core/grappler/utils.cc:
     annotations:
       linguist: C++
+      linguist-extension: C++
       vote: C++
   "github.com/testsecer/WebShell/2c768372c746837b14e096d5dbd8908717c6b27c/aspx/\u661F\u5916\u63D0\u6743aspx\u5927\u9A6C(\u53BB\u540E\u95E8\u7248).aspx":
     annotations:
       linguist: ASP.NET
+      linguist-extension: ASP.NET
       vote: ASP.NET
   github.com/texmacs/texmacs/106de6e055fd0b3054e7a1246fef42535680ec51/TeXmacs/doc/main/text/man-structure.zh.tm:
     annotations:
       human-ajnavarro: Unknown
       linguist: Tcl
+      linguist-extension: Tcl
       vote: Unknown
   github.com/tfaoliveira/libjc/b28765f6b6099c12764de16fd2e911f978a21aa9/proof/crypto_hash/keccak1600/EclibExtra.ec:
     annotations:
       human-smola: Coq
       linguist: eC
+      linguist-extension: eC
       vote: Coq
   github.com/tfausak/fr2048/d29fb24f44ae10e7d8c460b65db68e4d6556b89b/fr2048/Renderer.fr:
     annotations:
       linguist: Frege
+      linguist-heuristics: Frege
       vote: Frege
   github.com/tfogo/BitmapAPL/4eb35dceb6b1cee81075e7c985eeb1ccf5bd4dc5/bitmap.dyalog:
     annotations:
       linguist: APL
+      linguist-extension: APL
       vote: APL
   github.com/tgstation/tgstation/5d05c8689f41b5143f921570372316f43b665b83/code/modules/jobs/job_types/quartermaster.dm:
     annotations:
       linguist: DM
+      linguist-extension: DM
       vote: DM
   github.com/thakurab/shiva/6d930b637244535e8c0f1f6d40270354e26444b8/3d-octahedron.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/thalerjonathan/phd/4b17ed00d30e1b922bcd35301ef8f9e680d625da/writing/papers/unpublished/PFEFullPaper/results/step2_yampa/STEP_2_YAMPA_DYNAMICS_100agents_01dt.m:
     annotations:
@@ -14986,109 +18431,135 @@ files:
   github.com/thalesmg/project-euler/7d4da19622e151e16eb4d6f8611157a75d8a1ad1/p1/ats/main.dats:
     annotations:
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/thash/ctmcp/15bf399ee12f42de9e4348a57e7ce59687aec7d2/sec6/q/q6-3.oz:
     annotations:
       linguist: Oz
+      linguist-extension: Oz
       vote: Oz
   github.com/that-tinsin-guy/Badger/75fc718435dd067558668fe4bf4d49f2c0162953/scripts/Badger.ash:
     annotations:
       linguist: AGS Script
+      linguist-extension: AGS Script
       vote: AGS Script
   github.com/the-couch/slater/d1a295f90a39fb59438243ef70c9fc217976064f/packages/sync/test/theme/templates/page.contact.liquid:
     annotations:
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/the-little-typer/pie/a698d4cacd6823b5161221596d34bd17ce5282b8/interactive-editing.rkt:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/the-set-of-sets/lp_draw/cc1233bbbc72171525a970df80da0446a4a1cdd4/lp_draw.asy:
     annotations:
       linguist: Asymptote
+      linguist-heuristics: Asymptote
       vote: Asymptote
   github.com/theaplroom/apl-sound-wave/8fc750befcf0f29e60ccbe7e57bbd67a11d0e8bd/src/SoundFX.dyalog:
     annotations:
       linguist: APL
+      linguist-extension: APL
       vote: APL
   github.com/theos/theos/badb4240cbde4a0788e0961d6c6d1d2cfbbd4562/makefiles/instance/subproject.mk:
     annotations:
       linguist: Makefile
+      linguist-extension: Makefile
       vote: Makefile
   github.com/theseanco/awesome-synthdefs/918ab60ee9332db76e682b87f5dc6c234e42c893/co34pt/SynthDefs/co34pt_synthdefs.scd:
     annotations:
       linguist: SuperCollider
+      linguist-extension: SuperCollider
       vote: SuperCollider
   github.com/theseanco/howto_co34pt_liveCode/87db22c54e6c8db1176beeb647e95ea558954bcd/Setup/Setup.scd:
     annotations:
       linguist: SuperCollider
+      linguist-extension: SuperCollider
       vote: SuperCollider
   github.com/thetrime/trimeplay/0137e444ff7c8a756367aee3cafa223b1b920dc3/source/mac.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/theturtle32/AS3WebSocket/0b5a7c69b316cec02a8c5f06182a0e9973d8002f/AS3WebSocket/src/com/hurlant/crypto/tests/ECBModeTest.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/thibaultimbert/graphicscorelib/85afe4b73491aa4494311d54db7a46d61ebe5879/src/com/adobe/utils/macro/VariableExpression.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/thingdom/node-neo4j/26ee50da12d5c926242ce4c44475e952293da8b0/test/misc._coffee:
     annotations:
       human-smola: CoffeeScript
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/thinkingserious/omnifocus-applescripts/1d2f91833467af12e690f19d4eeefe64474712ba/Prepare task completion report.scpt:
     annotations:
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/thinknlive/picolisp-fibonacci-coding/12434640bb028a4ee3d83b79bef631583dfdf64d/fib.l:
     annotations:
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
       vote: PicoLisp
   github.com/thomashoneyman/purescript-halogen-realworld/4581af1e04044a129d1c7fea15e99d75ecfbe3e2/src/Data/Username.purs:
     annotations:
       linguist: PureScript
+      linguist-extension: PureScript
       vote: PureScript
   github.com/thommcgrath/ArtisanKit/f33c2e4d255525f27f0d9cde2ed71051bb3f06ec/Project/ArtisanKit/Control.xojo_code:
     annotations:
       human-smola: Xojo
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/thommcgrath/Beacon/b7b35c079b209ed894d7df21389dbc3161e3adec/Project/Modules/NotificationKit/Invocation.xojo_code:
     annotations:
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/thormagnusson/ixilang/58334bd92ed069b295104f781874d0a4e2e7cdbc/XiiLangRecord.sc:
     annotations:
       linguist: SuperCollider
+      linguist-heuristics: SuperCollider
       vote: SuperCollider
   "github.com/ti-cortex-m4/devices/01001b79425c7d6e4d99d4429d674ac5b5a60f61/nzif/\u043F\u0440\u043E\u0433\u0440\u0430\u043C\u043C\u044B/WTune/repiter/CONTRO2.TU":
     annotations:
       human-smola: Unknown
       linguist: Turing
+      linguist-extension: Turing
       vote: Unknown
   github.com/tianyicui/yixin/7b8aa1816566397d69910d36fba2ba67c1186152/src/controller.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/tidyverse/dplyr/44cc2c15849e184f9366ca346719c0b947031e14/R/distinct.R:
     annotations:
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/tidyverse/ggplot2/48580251e5cb006863edf102376815c379ae1fcf/R/annotation-logticks.r:
     annotations:
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/tidyverse/purrr/a8ec9032058e81c20f688523cbf129e0aaf22efd/R/map.R:
     annotations:
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/tidyverse/rvest/c820e48c01b04b93cad73d47af8336af603b65d6/R/form.R:
     annotations:
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/tildedave/universal-react-without-node/834af1bcfe71d80ff7324664c70cd780820f4017/m4/ax_pkg_swig.m4:
     annotations:
@@ -15097,24 +18568,29 @@ files:
   github.com/timaeudg/CSSE403-PLP-JTracer/2b9f78f01598673739f68e8dd08a5f33e4ffb431/run.ijs:
     annotations:
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/timdietrich/luna/55d4de56941446ff6a1f200ac7b270c8d2767609/Luna Project Files/App.xojo_code:
     annotations:
       human-smola: Xojo
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/timjs/3cows-teaching/8055d0a5f72d3de2bd44edd576a94fa422f6ba8e/4-meeting-date/Main.icl:
     annotations:
       human-smola: Clean
       linguist: Clean
+      linguist-extension: Clean
       vote: Clean
   github.com/timmvt/VistA_tt/05694e3a98c026f682f99ca9eb701bdd1e82af28/Packages/Kernel/Patches/XU_8.0_614/XU-8_SEQ-497_PAT-614.KID:
     annotations:
       linguist: Genshi
+      linguist-extension: Genshi
       vote: Genshi
   github.com/timothyhalim/Maxscript/6c561064970ef9de2f5054f90b7be7bff2e2039f/TextureLister/timo.ink - Texture Lister.ms:
     annotations:
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: MAXScript
   github.com/tioui/Eiffel_Game2/7220b2bbf74c98e8955853f2ee28571fbd64915e/game_image_file/img_image_cpf.e:
     annotations:
@@ -15127,76 +18603,95 @@ files:
   github.com/titon/framework/cbf44729173d3a83b91a2b0a217c6b3827512e44/src/Titon/Context/Definition.hh:
     annotations:
       linguist: Hack
+      linguist-heuristics: Hack
       vote: Hack
   github.com/tizoc/shen-scheme/8c857c9d3a83a4231ac6d7cfc8458cb27359167c/scripts/run-compiler-tests.shen:
     annotations:
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/tj/git-extras/a6a17540938971685cab13e55a996b39a689d135/bin/git-info:
     annotations:
       linguist: Shell
+      linguist-shebang: Shell
       vote: Shell
   github.com/tj/n/80b8d69d04d74dc91f99a6d038fadab0aca1156d/test/tests/uninstall.bats:
     annotations:
       linguist: Shell
+      linguist-extension: Shell
       vote: Shell
   github.com/tkashkin/GameHub/4bb1b7f6779b8498e15c4a5a02b20a1377dd70b1/src/ui/dialogs/ImportEmulatedGamesDialog.vala:
     annotations:
       linguist: Vala
+      linguist-extension: Vala
       vote: Vala
   github.com/tkf/emacs-request/6d170649ae9ef1c7c3d545517f896c03ca12062c/tests/request-testing.el:
     annotations:
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/tklepzig/ilp/9bffac63ea47f39b55cb232741e5bfee8dd567e2/trial-day.zpl:
     annotations:
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Zimpl
   github.com/tlaplus/CommunityModules/cf55dc33a4c300dd842ee9e46c784026b03e407f/tests/BitwiseTests.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/tlaplus/DrTLAPlus/167a6b3eb2afd8412967021137828347e9852ffc/Paxos/Paxos.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/tlaplus/Examples/c9bb2d41aca970a6eb64d7a721148483c111bfb8/specifications/SpecifyingSystems/Standard/ProtoReals.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/tlhumphrey2/ML_Miscellaneous/9fc452a2d6997b842a28ac3ad65985240be3e4a5/RandomForestContinuousExample.ecl:
     annotations:
       linguist: ECL
+      linguist-heuristics: ECL
       vote: ECL
   github.com/tluczyns/quizMatPharm/c7df3975cc63ee07dce3c25e684f653f59bbbd80/bin/data/contentGarbageSegregation.ne:
     annotations:
       human-smola: XML
       linguist: Nearley
+      linguist-extension: Nearley
+      linguist-xml: XML
       vote: XML
   github.com/tobyink/p5-type-tiny-xs/ca90f2ff9e42d85af77d50ba92ea138f5b51e6be/XS.xs:
     annotations:
       human-smola: XS
       linguist: XS
+      linguist-extension: XS
       vote: XS
   github.com/toeb/cmakepp/b96fd0578e614b3212c71f57ae0b1feb8f32c183/cmake/package/require_package_binary.cmake:
     annotations:
       linguist: CMake
+      linguist-extension: CMake
       vote: CMake
   github.com/tohojo/bufferbloat-net/52d4ad9ccb72760d5010a00071cb50e4584d61f6/content/attachments/111021191850_txqueuelen37_vs1000_really_works.ps:
     annotations:
       linguist: PostScript
+      linguist-extension: PostScript
       vote: PostScript
   github.com/tomas-abrahamsson/gpb/7679db004e6717b0490da72f204d3cdfd5ea77da/test/gpb_lib_tests.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
       vote: Erlang
   github.com/tomasraphael/ai-challenge/2ae5b42138f2100f420f3b2664651b774050e9bb/challenge/dataset/REXX/heronian-triangles-1.rexx:
     annotations:
       linguist: REXX
+      linguist-extension: REXX
       vote: REXX
   github.com/tomchentw/gulp-livescript/3b536669f5ab493537d553379cb21423402e3a9a/test/main.ls:
     annotations:
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/tommybennett/slickc/e53694b21f15d0695b2b6e1e37dd2a0931936bb8/cpp/make_func.e:
     annotations:
@@ -15206,71 +18701,90 @@ files:
   github.com/tomsoftware/VI-Explorer-VI/dbcf88ffbf8c653839f99a92e73c12e29884ce38/vi-File-Explorer.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/toniajuliejackson/Teach-Cliste-Home-Control/85a34f9799be2f9769f2831c71d54a53b0059f33/FYP SkyReceiver.axi:
     annotations:
       linguist: NetLinx
+      linguist-extension: NetLinx
       vote: NetLinx
   github.com/toninguyen/GraceDesignPattern/67e21561227095acb5b7000eb990778d12771e1f/03_BehaviouralPatterns/CommandPatternDemo.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/toninguyen/GraceHotdraw-/57e53ca48277d1aaf6b79e3629ca72e17ba6bb2d/01_Model/Handle.grace:
     annotations:
       human-smola: Grace
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/tonsky/FiraCode/5ee2653d58fba7d25b4f0a82929e4b42146badaa/clojure/regen_calt.clj:
     annotations:
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/tonybeltramelli/pix2code/94f651f00c686abee4fc633c7b6e4394c2cd3df5/compiler/classes/Node.py:
     annotations:
       linguist: Python
+      linguist-extension: Python
+      linguist-shebang: Python
       vote: Python
   github.com/tonyg/syndicate/a3380ea403d6ed03c821f6c747a61e4e6781d010/racket/syndicate/examples/actor/firewall-demo.rkt:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/toonetown/codekit-starter/8ed22b80fd9b641db9094829bc8fc8f3aefb1eea/src/kit/index.kit:
     annotations:
       linguist: Kit
+      linguist-extension: Kit
       vote: Kit
   github.com/tootsuite/mastodon/42d9ca21de298e1d51b87723745f2b17e4169894/spec/controllers/settings/migrations_controller_spec.rb:
     annotations:
       linguist: Ruby
+      linguist-extension: Ruby
       vote: Ruby
   github.com/topjohnwu/Magisk/46447f7cfd966da458e83f33b6205a89196fe598/native/jni/utils/include/blocking_queue.h:
     annotations:
       linguist: C++
+      linguist-heuristics: C++
       vote: C++
   github.com/torchnet/torchnet/c87fa3cf9ad9a4d99ce6c9ce93b5f0603a8ce91e/dataset/paralleldatasetiterator.lua:
     annotations:
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/tosrevive/ShrineTextMode/5db8e502956c13c08e758e4cba091c8df93f6ea0/Kernel/KExcept.HC:
     annotations:
       linguist: HolyC
+      linguist-extension: HolyC
       vote: HolyC
   github.com/toursprung/iOS-Screenshot-Automator/0a628891fffe0e71fee9e0e4c241afdf537807f1/run:
     annotations:
       linguist: AppleScript
+      linguist-shebang: AppleScript
       vote: AppleScript
   github.com/toyakon/clock-v/f06783ca1f65aa2930333d7ddb53f9b20d9fdb30/main.v:
     annotations:
       linguist: V
+      linguist-heuristics: V
       vote: V
   github.com/tpdunpaz-2019-sc/hector-game-gonzaunpaz/0ace9d214b48e006787f7cfa1179a556881e2c95/src/personajes.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/tpoindex/tsp/ca75604c4bdb999c8aa7467df0c9a7a4154f179f/tsp-generate-control.tcl:
     annotations:
       linguist: Tcl
+      linguist-extension: Tcl
       vote: Tcl
   github.com/tpope/vim-endwise/996f6bdba06bdd497306df042637d5b3e352d08b/plugin/endwise.vim:
     annotations:
       linguist: Vim script
+      linguist-extension: Vim script
       vote: Vim script
   github.com/trailheadapps/purealoe/f9495bd08b1f486915f01f9c7ec8cbbb6c03e30d/force-app/main/default/classes/Einstein_Dataset.cls:
     annotations:
@@ -15281,71 +18795,94 @@ files:
     annotations:
       human-smola: Unknown
       linguist: Modula-3
+      linguist-extension: Modula-3
       vote: Unknown
   github.com/transhumandesign/kag-base/fdb0f3977ea8dce1f50eba6c2e49e33a0898d311/Rules/CommonScripts/ColoredNameToggleCommon.as:
     annotations:
       linguist: AngelScript
+      linguist-heuristics: AngelScript
       vote: AngelScript
   github.com/transmission-remote-gui/transgui/3fb1d339f600d9d973aa9b923b548a369bd3adbf/synapse/source/lib/pop3send.pas:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/transpect/calabash-frontend/040b8a801480228c8caeefbdf81e498cb4d31e8f/extensions/calabash/library-1.0.xpl:
     annotations:
       linguist: XProc
+      linguist-extension: XProc
+      linguist-xml: XML
       vote: XProc
   github.com/transpect/cascade/018dc6b64f0c5f5e911524ff758ab68a25f19471/xpl/get-clades-from-dirs.xpl:
     annotations:
       linguist: XProc
+      linguist-extension: XProc
+      linguist-xml: XML
       vote: XProc
   github.com/transpect/epubcheck-idpf/d95cf8712b01f0d73f146501b65d68fa6111165b/xpl/epubcheck-command-line.xpl:
     annotations:
       linguist: XProc
+      linguist-extension: XProc
+      linguist-xml: XML
       vote: XProc
   github.com/transpect/html2xlsx/1943f4e7767caa024c6c387f47ea43246eb74ae4/xpl/html2xlsx.xpl:
     annotations:
       linguist: XProc
+      linguist-extension: XProc
+      linguist-xml: XML
       vote: XProc
   github.com/transpect/pdf2fxl/31df7cea1320b92235b45a25134c9a3227f815f3/xpl/pdf2fxl.xpl:
     annotations:
       linguist: XProc
+      linguist-extension: XProc
+      linguist-xml: XML
       vote: XProc
   github.com/transpect/pygmentize-xpl/5c7035c14a1536b8e70d30710258069523d335c7/xpl/pygmentize.xpl:
     annotations:
       linguist: XProc
+      linguist-extension: XProc
+      linguist-xml: XML
       vote: XProc
   github.com/traviscarrigan/VAWTMesh/716f4fdaa9ecfe68d74143d5f1f5301e0d3d41e3/VAWTMesh.glf:
     annotations:
       linguist: Glyph
+      linguist-extension: Glyph
       vote: Glyph
   github.com/trekhleb/javascript-algorithms/dc1047df725117c411959692a1ab538f65342b2e/src/algorithms/string/levenshtein-distance/__test__/levenshteinDistance.test.js:
     annotations:
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/trello/victor/713bc42814736e02e0764427cf45b4b31eddeb39/victor/src/test/groovy/com/trello/victor/ConverterTests.groovy:
     annotations:
       linguist: Groovy
+      linguist-extension: Groovy
       vote: Groovy
   github.com/trivialmips/nontrivial-mips/f18d2bbd8216dd1783044fb677471172e2355dba/src/cpu/mmu/tlb.sv:
     annotations:
       human-smola: SystemVerilog
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/trizen/youtube-viewer/343a6083969dd79c3bb5b83baf70fd8974040dc7/lib/WWW/YoutubeViewer/ParseJSON.pm:
     annotations:
       linguist: Perl
+      linguist-heuristics: Perl
       vote: Perl
   github.com/trothr/znetboot/6675a27a42055c927cff74a3474f7fc80a532d91/curl.rexx:
     annotations:
       linguist: REXX
+      linguist-extension: REXX
       vote: REXX
   github.com/troyp/asoc.el/4a3309a9f250656da6f4a9d34feedf4f5666b17a/test/asoc-test.el:
     annotations:
       linguist: Emacs Lisp
+      linguist-extension: Emacs Lisp
       vote: Emacs Lisp
   github.com/truongdam/echat/9bb0e0285d84e125a1f2949da5043d41225ee80a/src/main/java/com/springsource/petclinic/domain/Pet_Roo_ToString.aj:
     annotations:
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/tsaarni/cpp-subprocess/2e91c3945df3894648ecdcdbd1c197eedb22e63a/m4/boost.m4:
     annotations:
@@ -15354,20 +18891,24 @@ files:
   github.com/tsloughter/OpaDo/2562d8905dbe2f26c31a9bbfbe158935406cebb7/src/main.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/tsloughter/todomvc_opa/d552fbb0de45b3f6061330fc60432e7c4ad9322e/src/view.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/tsulej/GenerateMe/50666b8ebe3491c3259be41f75b60ca6dd68cb59/ultimateSort/ultimateSort.pde:
     annotations:
       human-smola: Processing
       linguist: Processing
+      linguist-extension: Processing
       vote: Processing
   github.com/tsuna/boost.m4/b52682291fa9d1a26507ab9ac19cb199524fbdcd/configure.ac:
     annotations:
       linguist: M4
-      vote: M4
+      linguist-filename: M4Sugar
+      vote: Unknown
   github.com/ttencate/aoc2017/94a9618ef1617b74144e7c98b5d446d592db5307/18_eiffel/18a/state.e:
     annotations:
       linguist: Eiffel
@@ -15375,6 +18916,7 @@ files:
   github.com/ttroy50/cmake-examples/a62b62eee4ae554fe1ee94627b2063c47ded22fd/04-static-analysis/cppcheck/cmake/analysis.cmake:
     annotations:
       linguist: CMake
+      linguist-extension: CMake
       vote: CMake
   github.com/tudortimi/vscale_tb-e/8828954570cb8c7d085c517675339f810b894307/tests/test_mem.e:
     annotations:
@@ -15387,6 +18929,7 @@ files:
   github.com/turbopape/docker-picolisp-image/3c885796f62e2a2542d32b0f89893c3b2f065b6e/picoLisp/test/src/flow.l:
     annotations:
       linguist: PicoLisp
+      linguist-heuristics: PicoLisp
       vote: PicoLisp
   github.com/tushar-97/Convex-Hull/2cbb53ed5b687793b593d7c0a959ece86896a15b/Test Cases/Test Case 5/hull_5.ch:
     annotations:
@@ -15396,146 +18939,184 @@ files:
     annotations:
       human-smola: JavaScript
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/tweag/asterius/beb0b82786de8ce2daaad4aed3c594065a6311db/ghc-toolkit/boot-libs/text/Data/Text/Internal/IO.hs:
     annotations:
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/twigphp/Twig/d073fed7f1979689a25d161423c90ecccaf87c4f/src/Test/NodeTestCase.php:
     annotations:
       linguist: PHP
+      linguist-heuristics: PHP
       vote: PHP
   github.com/twitter/AnomalyDetection/1f5deaa1609f8f1964c1e905c7a8ad2d1d0dc718/tests/testthat/test-edge.R:
     annotations:
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/twitter/diffy/d0976b6f2c63406f152e4852498c903d4c96cd05/src/test/scala/com/twitter/diffy/ParentSpec.scala:
     annotations:
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/twitter/finagle/9e48c7d63cb9306edca65808ae2a51946eef20fd/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ByteBufConversionTest.scala:
     annotations:
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/twostraws/ShaderKit/b7f92e51f32329226475cd50d924520063db3170/Shaders/SHKLightGrid.fsh:
     annotations:
       linguist: GLSL
+      linguist-extension: GLSL
       vote: GLSL
   github.com/tyaan/ChucK-compositions/10f4517c5419267bfead657ad1ec24ca4df3260e/Singh_4 CMPO281 assignment 4.ck:
     annotations:
       linguist: ChucK
+      linguist-extension: ChucK
       vote: ChucK
   github.com/tyler/iota/4df0b145f0bbba5c0e47d4465ed4fbf0d2220af9/app/controllers/admin.io:
     annotations:
       linguist: Io
+      linguist-extension: Io
       vote: Io
   github.com/typeable/stackage2nix/86f11b89ccaa77cfd94cb2601ed22fd263f81c45/nix/haskell-packages/configuration-packages.nix:
     annotations:
       linguist: Nix
+      linguist-extension: Nix
       vote: Nix
   github.com/typedefs/typedefs/100f47e16a5e67119d5d94e2ebf124128cf24862/src/Typedefs/Test/ReasonMLTests.idr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/typicode/json-server/72e5f95c025e9ae5d6b7bb9ca977debc9b8c4d8f/src/server/defaults.js:
     annotations:
       linguist: JavaScript
+      linguist-extension: JavaScript
       vote: JavaScript
   github.com/tyrchen/unchained/84c87162eb5aec4536cfcaf2d3933933894e432a/Makefile:
     annotations:
       linguist: Makefile
+      linguist-filename: Makefile
       vote: Makefile
   github.com/tyru/eskk.vim/207d05cd50d126a84271aca7f02b3f839dab27c3/plugin/eskk.vim:
     annotations:
       linguist: Vim script
+      linguist-extension: Vim script
       vote: Vim script
   github.com/uC137/uCreative/9c1083e40f9b034af78501f6dda5fffda9ab1d2a/Obsidian___0.icl:
     annotations:
       human-smola: XML
       linguist: Clean
+      linguist-extension: Clean
+      linguist-xml: XML
       vote: XML
   github.com/ualberta-smr/Android-Update-Analysis/541c23bd0fc814ecbc23a573717e896933f1bac4/sourcerercc/parser/java/txl/cs-rename-consistent-functions.txl:
     annotations:
       linguist: TXL
+      linguist-extension: TXL
       vote: TXL
   github.com/uber/NEAL/7789fcef09f05c2aff1df7622b8ebed2bfbdb881/src/providers/swift/swift_provider.ml:
     annotations:
       human-smola: OCaml
       linguist: OCaml
+      linguist-heuristics: OCaml
       vote: OCaml
   github.com/ubports/unity8/2af5f2c29908fa9017ac4fb88ed8918d36833371/tests/utils/modules/Unity/Test/UnityTestCase.qml:
     annotations:
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/ucb-bar/fpga-zynq/726eb97185a74014ef3af059458db56d9ca25755/zc706/src/tcl/zc706_bd.tcl:
     annotations:
       linguist: Tcl
+      linguist-extension: Tcl
       vote: Tcl
   github.com/uclnlp/ntp/23687f5ccbb089ed78b4bcef5d055091408ee8d2/data/nations/dev.nl:
     annotations:
       human-smola: Prolog
       linguist: NewLisp
+      linguist-heuristics: NewLisp
       vote: Prolog
   github.com/udacity/cs344/ea71271181fa8ae71ae461f3655fc653408ff826/Problem Sets/Problem Set 2/student_func.cu:
     annotations:
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/ueberauth/guardian/957f006a35beb0d569b19150f1302431f92c8ff7/lib/guardian/plug/pipeline.ex:
     annotations:
       linguist: Elixir
+      linguist-extension: Elixir
       vote: Elixir
   github.com/ufologist/onekey-decompile-apk/efd54a34d0d065f97cba45f714a740483cf44450/onekey-decompile-apk/_tools/dex2jar/dex2jar.bat:
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/ufrisk/pcileech-fpga/ecb487b80634b3d68db3ffea7c2ad3b6a676e83d/pciescreamer/src/pcileech_header.svh:
     annotations:
       human-smola: SystemVerilog
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/ugetdm/uget-integrator/94a13a7c10e88ea6860cf4866038ca90d38c9091/install/windows/uget-integrator.nsi:
     annotations:
       linguist: NSIS
+      linguist-extension: NSIS
       vote: NSIS
   github.com/uglide/RedisDesktopManager/56f7ddd48585933887a5156e20a8af07832c206a/src/app/models/treeoperations.cpp:
     annotations:
       linguist: C++
+      linguist-extension: C++
       vote: C++
   github.com/ultralight-ux/Ultralight/d724e7f2a915687ebc4c2307c8b69692cec99e37/Deps.cmake:
     annotations:
       linguist: CMake
+      linguist-extension: CMake
       vote: CMake
   github.com/unamfi/Xcode-Jess/4d7a0edb60e58f650b0554846c9b9e1843cda88b/bin/BLOQUESJ.CLP:
     annotations:
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: CLIPS
   github.com/unchartedworks/HaskellRed/37ff889b5b2bc21de04fb8e424a2c11979f2739d/control-monad.red:
     annotations:
       linguist: Red
+      linguist-extension: Red
       vote: Red
   github.com/underscorediscovery/luxe/66bed0cf1a38e58355c65497f8b97de5732467c5/luxe/components/physics/deflect/three/BoxCollider.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/unforswearing/applescript/7ecc04d1b2fc1192259e1f1f65abc9c59b02cb4a/Application Services/AppWatcher.applescript:
     annotations:
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/unipsycho/Graph-Extensions-LabVIEW/d73bd49b43126c6f5a68c368c07d732930b10aef/LV2014/Graph Extensions.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/unipsycho/LabVIEWdotNetDataGrid/9f11bf46bdc7bf6acf248aa1c0b56be0c89d574e/source/DataGrid.lvproj:
     annotations:
       linguist: LabVIEW
+      linguist-extension: LabVIEW
+      linguist-xml: XML
       vote: LabVIEW
   github.com/uniremington/POAJava/9b3b3b65f2aff1a5f17ea555bb8398ed0bc93e5d/src/com/remington/ejercicios/BaseDeDatos.aj:
     annotations:
       linguist: AspectJ
+      linguist-extension: AspectJ
       vote: AspectJ
   github.com/unstacked/level/0a2cbae151869c2d9b79b3bfb388f5d00739ae12/assets/elm/src/Page/Help.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/uobdv/Design-Verification/6acb2241f659912aace4f507fe96e91ba4cfe04d/SN-CPU-Tutorial/cpu/e/gold/cpu_instr.e:
     annotations:
@@ -15544,27 +19125,33 @@ files:
   github.com/urlysses/1991/b1f03d4e4175658606153cdb66d41df1075525ba/1991.fs:
     annotations:
       linguist: Forth
+      linguist-heuristics: Forth
       vote: Forth
   github.com/usakhelo/batchcam/cb9592398f46da5f3ab39182baba31db816da400/BatchCameraRender-functions-setters.ms:
     annotations:
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: MAXScript
   github.com/useflashpunk/FlashPunk/46faa60129749725054226a30acd11d97afece6c/net/flashpunk/utils/Draw.as:
     annotations:
       linguist: ActionScript
+      linguist-heuristics: ActionScript
       vote: ActionScript
   github.com/ustc-zzzz/HOCON-CN-Translation/466afe929a09be9b47ad4b8bfb1ca557ab79c690/HOCON.md:
     annotations:
       linguist: Markdown
+      linguist-heuristics: Markdown
       vote: Markdown
   github.com/utPLSQL/utPLSQL/b08ede3342d37dc7d0d66cecff7653f75eb3ad69/source/create_synonyms.sql:
     annotations:
       human-smola: PL/SQL
       linguist: PL/SQL
+      linguist-heuristics: SQL
       vote: PL/SQL
   github.com/utk3995/Automotive-Expert-System/8ee8345362859fe6fd52171539d0d0fe7c767b95/automotive_expert_system.clp:
     annotations:
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: CLIPS
   github.com/utoh/pygmy-forth/21d555e1592ed266f3156d2a62e75a553cdbf9bf/ed.scr:
     annotations:
@@ -15573,40 +19160,50 @@ files:
   github.com/uty/haproxy-augeas-lens/b4ff3dc2e5d7f2ab9499e9507788575927797124/test_haproxy.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
       vote: Augeas
   github.com/utylee/dotfiles-hc/44723b028851b7a9451842efa8d5d80be699f15c/.vimrc.hc:
     annotations:
       human-smola: Vim script
       linguist: HolyC
+      linguist-extension: HolyC
       vote: Vim script
   github.com/utylee/dotfiles-odroid/60393e840e0512ecb2554fc78c7c49b10ef925dc/.bashrc.hc:
     annotations:
       human-smola: Shell
       linguist: HolyC
+      linguist-extension: HolyC
       vote: Shell
   github.com/uwegeercken/awk_scripts/63c58f975c618ec32464fdaf42130615d8cfd6ed/field_highlow.awk:
     annotations:
       linguist: Awk
+      linguist-extension: Awk
+      linguist-shebang: Awk
       vote: Awk
   github.com/uwol/proleap-cobol-parser/5406fe5d5c794c02a4be433aa5ec1c708a6f6662/src/test/resources/gov/nist/SM102A.CBL:
     annotations:
       linguist: COBOL
+      linguist-extension: COBOL
       vote: COBOL
   github.com/uwplse/herbie/377c45e087b9d9207a5279d4c987ebea92fedee5/src/syntax/rules.rkt:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/uwplse/memsynth/8eb53fb9c6c0ff8268f3fcc4f5a53c7a3db10a1f/case-studies/performance/verification/alloy/ppc/tests/safe124.als:
     annotations:
       linguist: Alloy
+      linguist-extension: Alloy
       vote: Alloy
   github.com/uwplse/verdi/2b94f5529eb7b8d28ef7e596383b4eec1d8343c5/core/TotalMapSimulations.v:
     annotations:
       linguist: Coq
+      linguist-heuristics: Coq
       vote: Coq
   github.com/v-community/faker/a855efb4e53b7249a7ed7126985a7f0710420242/main.v:
     annotations:
       linguist: V
+      linguist-heuristics: V
       vote: V
   github.com/v-community/v_by_example/5c0602c3ba900749a98e5d52e05e726036b1530f/code/hello_world/hello.v:
     annotations:
@@ -15616,42 +19213,53 @@ files:
   github.com/vacancy/PreciseRoIPooling/8ee2a646d096f63c15b75680361d712802391ed1/src/prroi_pooling_gpu_impl.cu:
     annotations:
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/vahidzolf/Demand_Response/15c51938a8fe1189317bfbdca552339260bc4d84/demand.zpl:
     annotations:
       linguist: Zimpl
+      linguist-extension: Zimpl
       vote: Zimpl
   github.com/valexey/bigbench/8fef6599bffa9f1fb327cd7d5fa9f3a5e70993dd/elektrybalt/merge_rs/merge_rsx.mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/vangberg/iodis/2044ed8f9b6a7e8d7df6738f54e9b8f63ed20773/tests/IodisTest.io:
     annotations:
       linguist: Io
+      linguist-extension: Io
       vote: Io
   github.com/vangelisv/thea/bac0924cdf4232c3d0fb5952fa57d057a07165cd/owlgres/owlgres_sql_schema.pl:
     annotations:
       linguist: Prolog
+      linguist-heuristics: Prolog
       vote: Prolog
   github.com/varda/aule-test/a99ab183f966fefc7009281289fb06e331c7dacb/templates/data_sources.hb:
     annotations:
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Harbour
   github.com/varda/aule/1111ad7cf5f20bffde187a3c895639e4aadcc86b/templates/application.hb:
     annotations:
       linguist: Harbour
+      linguist-extension: Harbour
       vote: Harbour
   github.com/vasil-sd/shen-libs/6512ba4fad752158470a92766b55e30591eae12f/utils/defpackage.shen:
     annotations:
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/vboxme/Portable-VirtualBox/2fd9eb1c83a4fd2e3fc7207bc2b7d7a1051baec2/source/FileConstants.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/veeenu/LiveSplit.NotesViewer/e5504e968d9a7bfe95bf92322fa535468e0158f3/test.lsl:
     annotations:
       linguist: LSL
+      linguist-extension: LSL
+      linguist-xml: XML
       vote: LSL
   github.com/veekxt/BrainFuck/7c27fae7461ad54ac02eb7dfd60b3c911be699fa/test_bf_file/xietao.bf:
     annotations:
@@ -15660,63 +19268,78 @@ files:
   github.com/veelenga/awesome-crystal/b92198f7d6c6a55dfe6bc4970290f884c99da4d8/spec/readme_spec.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/vendethiel/trying.apl/ec8b8aadc6bf62d4eaa49e7c8558f89793e712ce/rank.apl:
     annotations:
       linguist: APL
+      linguist-extension: APL
       vote: APL
   github.com/vernemq/vernemq/3f52f1870e2db5ca662ca342cf826b5711ee17e9/apps/vmq_server/src/vmq_cowboy_websocket_h.erl:
     annotations:
       linguist: Erlang
+      linguist-extension: Erlang
       vote: Erlang
   github.com/vgstation-coders/vgstation13/ecaf4fec264939ccc8b2a0a34a5100e6b5254703/code/ATMOSPHERICS/components/unary/thermal_plate.dm:
     annotations:
       linguist: DM
+      linguist-extension: DM
       vote: DM
   github.com/vibe-d/vibe.d/fa079e4438bf03c6e12f8b307b6a148d43ac41ba/tests/vibe.web.rest.1230/source/app.d:
     annotations:
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/vidalvanbergen/ViMediaManager/fbc64c5564e0e8e0ff18607df469311122490709/ViMM/Source/Modules/macoslib/CoreFoundation/CFMutableAttributedString.xojo_code:
     annotations:
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/vietj/ceylon-cayla/c1bd417a5d9162968c7f7a7ccde65b42ab5bb6e7/source/io/cayla/web/Application.ceylon:
     annotations:
       linguist: Ceylon
+      linguist-extension: Ceylon
       vote: Ceylon
   github.com/vikjam/mostly-harmless-replication/f9c10053dd1d51c866bc2575c61992af2b1e2ffc/06 Getting a Little Jumpy/Figure 6-1-1.do:
     annotations:
       linguist: Stata
+      linguist-extension: Stata
       vote: Stata
   github.com/viktorgino/headunit-desktop/3c6f754dd591c38a18cdbb7121e386a2c373162d/modules/android-auto/aaVideo.qml:
     annotations:
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/vilbur/MAXSCRIPT-viltools2/e6f3531ab05a5ba3ab8abf4ce742ba5a54d63a1d/_Exporter/UnityExportNode/UnityExportNode.ms:
     annotations:
       linguist: MAXScript
+      linguist-heuristics: MAXScript
       vote: MAXScript
   github.com/vim-scripts/indentpython.vim/6aaddfde21fe9e7acbe448b92b3cbb67f2fe1fc1/indent/python.vim:
     annotations:
       linguist: Vim script
+      linguist-extension: Vim script
       vote: Vim script
   github.com/virtix/cfmongodb/214c58592d402bb4a31fb9cbf125e2d53360482c/core/MapReduceResult.cfc:
     annotations:
       human-smola: ColdFusion CFC
       linguist: ColdFusion
+      linguist-extension: ColdFusion CFC
       vote: ColdFusion CFC
   github.com/vishaps/voc/760e14bbe197b8a7edb984c2ca73faf5a6de9cfd/src/runtime/Platformwindows.Mod:
     annotations:
       linguist: Modula-2
+      linguist-heuristics: Modula-2
       vote: Modula-2
   github.com/visualzhou/mongo-repl-tla/7ea53f733112267522f7a72290bdc709fed09b35/RaftMongo.tla:
     annotations:
       linguist: TLA
+      linguist-extension: TLA
       vote: TLA
   github.com/viva64/pvs-studio-qmake-examples/dd493c95b9f79a38a3e2a1dec3430e62fe224b0a/PVS-Studio.pri:
     annotations:
       linguist: QMake
+      linguist-extension: QMake
       vote: QMake
   github.com/vlang/doom/2ca6f30a99c4d90e9a385341515f163b1a053f0e/p_enemy.v:
     annotations:
@@ -15725,39 +19348,48 @@ files:
   github.com/vlang/v/e3ad367b805edb7d44da5bbb150821ee36034369/vlib/crypto/rand/rand_test.v:
     annotations:
       linguist: V
+      linguist-heuristics: V
       vote: V
   github.com/vlang/vid/c0ce3ee6e092c83281b504fe780a36e760ac2fc5/view.v:
     annotations:
       linguist: V
+      linguist-heuristics: V
       vote: V
   github.com/vlang/vorum/9f8998822fc5105eed3c7b384700354199dd62c0/oauth.v:
     annotations:
       linguist: V
+      linguist-heuristics: V
       vote: V
   github.com/vlfeat/matconvnet/1e5ae7b70fc1074bf8a2a5617e698e54072fbb2c/matlab/src/bits/nnbias_cudnn.cu:
     annotations:
       linguist: CUDA
+      linguist-extension: CUDA
       vote: CUDA
   github.com/vmchale/polyglot/30c007c50e127d624959759f36cf4e910bfb6d05/DATS/shared.dats:
     annotations:
       human-ajnavarro: ATS
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/vmchale/recursion/dba6fbdbcc2596ad3568b03aeba02f8b370b9993/test/recursion.dats:
     annotations:
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/vmchale/recursion_schemes/e10780a16028a6f8fe418d8251578a7d1c43ebe8/Data/Functor/Foldable/Exotic.idr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/voc/intro-outro-generator/b1b14c5a4860329837267590f3d126a679822dee/35c3-chaoswest/outro folder/(Footage)/statics/logos/creative commons Logo.eps:
     annotations:
       linguist: PostScript
+      linguist-extension: PostScript
       vote: PostScript
   github.com/vokins/yhosts/731b360e29117f5d19424d0e44446b6914fca464/web/chrome/@CClean.bat:
     annotations:
       linguist: Batchfile
+      linguist-extension: Batchfile
       vote: Batchfile
   github.com/vpervenditti/vgram/bbea3b9ee8d043612571ef77a34da6030ac5fd46/methods.v:
     annotations:
@@ -15771,14 +19403,19 @@ files:
   github.com/vpzomtrrfrt/djs-dson/46a38c7c3c00d7f1a97cb7bd857359a6ccd27634/DSON.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/vsay01/Android-Studio-MVP-Template-Google-Architecture/619808c4df67e3a6da9cdbca04aa39057088a80f/MVPTemplateKotlin/root/src/app_package/layout/activity_layout.xml.ftl:
     annotations:
       linguist: FreeMarker
+      linguist-extension: FreeMarker
+      linguist-xml: XML
       vote: FreeMarker
   github.com/vshn/modsecurity-docker/d53d456274e820a4ac0f40c937587994ab24d2dc/v3.1/transform-alert-message.awk:
     annotations:
       linguist: Awk
+      linguist-extension: Awk
+      linguist-shebang: Awk
       vote: Awk
   github.com/vslavik/diff-pdf/6741ab979342c6a118ef0263bb3049b055cbc8a7/admin/wxwin.m4:
     annotations:
@@ -15787,10 +19424,12 @@ files:
   github.com/vsraptor/producton_system/5678528146ffbcfd37e7e7fa0e92041d25d7dcdc/rules.lgt:
     annotations:
       linguist: Logtalk
+      linguist-extension: Logtalk
       vote: Logtalk
   github.com/vt-elixir/ja_serializer/574afb8d3170fa50e1f0dd918275936e32d06671/test/ja_serializer/param_parser_test.exs:
     annotations:
       linguist: Elixir
+      linguist-extension: Elixir
       vote: Elixir
   github.com/vtapadia/amplExperiments/2d57e9094c4234f476d45d867c838e36410408e8/singleMachineScheduling/tardiness.mod:
     annotations:
@@ -15799,10 +19438,12 @@ files:
   github.com/vuejs/vue-next/f8e7fadaae8177a02f8abd7568d9fb6fbc96f7ee/packages/compiler-dom/src/index.ts:
     annotations:
       linguist: TypeScript
+      linguist-heuristics: TypeScript
       vote: TypeScript
   github.com/vvdleun/audiostreamerscrobbler/1921399a72ba8c692be32e8da12f2707ed990f9c/src/main/golo/include/factories/PlayersControlThreadFactory.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/vygr/ChrysaLisp/96411f662295043fe0dee8e913f8d1c1f6dfc8a9/apps/raymarch/child.lisp:
     annotations:
@@ -15812,22 +19453,28 @@ files:
   github.com/wagtail/wagtail/06fb0764e09eddd52c0793fe909826cdd5045089/wagtail/admin/tests/pages/test_edit_page.py:
     annotations:
       linguist: Python
+      linguist-extension: Python
       vote: Python
   github.com/wallix/PEPS-chat/912db548d84d3fede132e371d6053f0d03fe072b/src/metric.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/wanderingbort/augeas-trafficserver/028ebf15f45d1d7aac2074fc76cb47c5d976dda9/trafficserver_cache.aug:
     annotations:
       linguist: Augeas
+      linguist-extension: Augeas
       vote: Augeas
   github.com/wangp/bower/f8ec279dee723d09ff934b1cbada1f45ebf04605/src/scrollable.m:
     annotations:
       linguist: Mercury
+      linguist-heuristics: Mercury
+      linguist-modeline: Mercury
       vote: Mercury
   github.com/wasdk/wasmbase/7a4db605cfde76f2068e447bda82ae6fe52a50f4/lib/libexports/algorithm.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/wasplang/std/44a681aaca4c1f30287c9a41ecda48ccfff47ac2/strings.w:
     annotations:
@@ -15837,104 +19484,131 @@ files:
   github.com/watabou/TownGeneratorOS/7fbc87a9398cc508af24de93f79cf2ad027f352b/Source/com/watabou/utils/Observable.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/waud/waud/2cd08f91e2de9029653634812ff2a04dd3bec29d/src/WaudUtils.hx:
     annotations:
       linguist: Haxe
+      linguist-extension: Haxe
       vote: Haxe
   github.com/wavebitscientific/functional-fortran/f9baf451a3256c84165c2b9a3fdffd335ba1124e/src/tests/test_head.f90:
     annotations:
       linguist: Fortran
+      linguist-extension: Fortran
       vote: Fortran
   github.com/wbcyclist/merlin_shadowsocks/070d0e80f8aac1bc4450b60bac6a31de0a727107/arm380/shadowsocks/webs/Main_Ss_LoadBlance.asp:
     annotations:
       linguist: Classic ASP
+      linguist-extension: Classic ASP
       vote: Classic ASP
   github.com/wcyn/clips-horticulture-expert-system/0eabdabf91bd76da3dce18b1dbfb83e4ee8c1fea/diagnosis_rules_automated.CLP:
     annotations:
       linguist: CLIPS
+      linguist-extension: CLIPS
       vote: CLIPS
   github.com/weavejester/compojure/bb2fcc7ffdc910555d24ff64a8e7ffacb2c1c478/src/compojure/route.clj:
     annotations:
       linguist: Clojure
+      linguist-extension: Clojure
       vote: Clojure
   github.com/web-dom/web-dom/09eb388a4adfaee8e4ade0c7122486b703164f5c/webidl/UDPSocket.webidl:
     annotations:
       human-smola: WebIDL
       linguist: IDL
+      linguist-extension: WebIDL
+      linguist-modeline: IDL
       vote: WebIDL
   github.com/web3space/web3t/f908e4351037314401ba1448ae3fe06c94396675/plugins/qiwi-rs.ls:
     annotations:
       linguist: LiveScript
+      linguist-heuristics: LiveScript
       vote: LiveScript
   github.com/webyrd/Barliman/b05a04082ccf3989f3df2aa9a96972feb92b1d1a/interpreter_experiments/parse.scm:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
       vote: Scheme
   github.com/welldoer/v_replay/73816826b28d844e4a3bc7b7a108cfb29e02380c/vlib/builtin/map.v:
     annotations:
       linguist: V
+      linguist-heuristics: V
       vote: V
   github.com/wende/elchemy/f4fe9e81bcba8f9298e8c6216ee54f6a7a732bfe/src/Elchemy/Operator.elm:
     annotations:
       linguist: Elm
+      linguist-extension: Elm
       vote: Elm
   github.com/wensir365/pkugcm/aee29d92cbba29d1f2f222ecdb8e5cbde0789651/ppp/N032_surf_0134.sra:
     annotations:
       human-smola: Unknown
       linguist: PowerBuilder
+      linguist-extension: PowerBuilder
       vote: Unknown
   github.com/wernsey/d.awk/853e3a6940f193a72c7b67840bcbf822f1f476c1/wrap.awk:
     annotations:
       linguist: Awk
+      linguist-extension: Awk
+      linguist-shebang: Awk
       vote: Awk
   github.com/westerndigitalcorporation/swerv_eh1/4964714ab673c796edadf08800cdbda977ad0dd8/design/lsu/lsu.sv:
     annotations:
       linguist: SystemVerilog
+      linguist-extension: SystemVerilog
       vote: SystemVerilog
   github.com/wevrem/wry/12c40f95896ad100baea044acf8338d560babd07/references/PHPLexer.g4:
     annotations:
       human-ajnavarro: ANTLR
       human-smola: ANTLR
       linguist: ANTLR
+      linguist-extension: ANTLR
       vote: ANTLR
   github.com/wey-yu/poks-server/220cb9881b6b253bf0ccc2d1a9311deb2120ef08/src/main/golo/main.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/wg/wrk/0896020a2a28b84b1150e9b60933b746fe1dc761/src/stats.c:
     annotations:
       linguist: C
+      linguist-extension: C
       vote: C
   github.com/whymirror/yown/927689a9084b980a88fa0bf93320cdb99aad16fd/yown/webrequest.io:
     annotations:
       linguist: Io
+      linguist-extension: Io
       vote: Io
   github.com/willard-yuan/hashing-baseline-for-image-retrieval/9eaee4b47308fcce07fd538f1322bfdec0ba8e8f/Method-MF/trainMF.m:
     annotations:
       linguist: MATLAB
+      linguist-heuristics: MATLAB
       vote: MATLAB
   github.com/willghatch/racket-rash/dda6688abe0956d285f7ba6b747c9dd15782349d/shell-pipeline/scribblings/shell-pipeline.scrbl:
     annotations:
       linguist: Racket
+      linguist-extension: Racket
       vote: Racket
   github.com/willowtreeapps/ukor/d132534599fc6ffb4cf03b23e3ac07ec7cf2c1db/lib/sample/src/test/source/UnitTestFramework.brs:
     annotations:
       linguist: Brightscript
+      linguist-extension: Brightscript
       vote: Brightscript
   github.com/winbomb/mahjong/a35df26e14669a9c3bff26cd437ee1562660ca88/src/page.opa:
     annotations:
       linguist: Opa
+      linguist-extension: Opa
       vote: Opa
   github.com/winddriver/Delphi-Cross-Socket/8bf60552aa459bb239fa5a99620b8ed8f1a7d2db/Net/Net.CrossSslSocket.MbedTls.pas:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/wingo/fibers/b86405a2f8daaee3c5d2fcd1b6cefd8e9543c703/fibers/psq.scm:
     annotations:
       human-smola: Scheme
       linguist: Scheme
+      linguist-extension: Scheme
+      linguist-shebang: Scheme
       vote: Scheme
   github.com/wintercoder/datamaker/08aae336badbabf8800b6e939973abddb70b5c30/index.php:
     annotations:
@@ -15944,6 +19618,7 @@ files:
   github.com/wireapp/wire-android/0e59fcda5b31e2ccaf9c3f7787eb9453f9487475/wire-android-sync-engine/zmessaging/src/main/scala/com/waz/utils/Serialized.scala:
     annotations:
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/wlandsman/IDLAstro/fa4b3aaf0a1e451b28a21fbbf1ddbb30e38685a7/pro/valid_num.pro:
     annotations:
@@ -15953,14 +19628,17 @@ files:
     annotations:
       human-smola: Visual Basic
       linguist: HiveQL
+      linguist-heuristics: HiveQL
       vote: Visual Basic
   github.com/wo52616111/capslock-plus/60b4ec05d27ad317602f376726aabb905959700f/CapsLock+.ahk:
     annotations:
       linguist: AutoHotkey
+      linguist-extension: AutoHotkey
       vote: AutoHotkey
   github.com/wojtekmach/acme_bank/cee19a490d2b3c04465273b7a6212d7e6a81f736/apps/backoffice/test/views/error_view_test.exs:
     annotations:
       linguist: Elixir
+      linguist-extension: Elixir
       vote: Elixir
   github.com/wolfgangj/okami/7b44509d36d1e61be05935f1e02e22286e79d929/lib/log.ok:
     annotations:
@@ -15969,218 +19647,272 @@ files:
   github.com/wollok/ColeccionesMatrixElElegido/bd200e16787a7f58d3266b6aa3144b439dc819d6/src/matrix.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/wollok/casaDePepeYJulian/4ea344959f41e68ce42665e7943bfcdde64bf90e/src/cosas.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/wollok/coleccionesSinBloquesNaufrago/90d233179fe65f1ee43b57c43a569bf09bcf6cd5/src/naufrago.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/wollok/pepitaGame/7e09e071d53e778ad32e08240dcd723e0a32ac76/src/pepita.wlk:
     annotations:
       linguist: Wollok
+      linguist-extension: Wollok
       vote: Wollok
   github.com/worldbank/SDI-Health/efabe566b0de9739c1b8b4916d6d75c837ad0c5a/scripts/cleaning/Roster-Module2/clean_module2_Madagascar-2016_SDI.do:
     annotations:
       linguist: Stata
+      linguist-extension: Stata
       vote: Stata
   github.com/worldbank/ietoolkit/18b52576fbb0e1261a4ecb7bea589d79b9e1baed/src/help_files/iebaltab.sthlp:
     annotations:
       linguist: Stata
+      linguist-extension: Stata
       vote: Stata
   github.com/wrf-model/WPS/b9cfb7a28342ac8a79ad463fed362f777731b0e9/ungrib/src/file_delete.F:
     annotations:
       linguist: Fortran
+      linguist-heuristics: Fortran
       vote: Fortran
   github.com/wrf-model/WRF/04cb7565605fe1894b4824bef7d0ee71c457f371/chem/module_mosaic_newnuc.F:
     annotations:
       linguist: Fortran
+      linguist-heuristics: Fortran
       vote: Fortran
   github.com/wroberts/fsed/8849facfe665eded230a804977ae293f7270f884/fsed/tests/fsed-testpats.wb.bsd.utf8.sed:
     annotations:
       linguist: sed
+      linguist-extension: sed
       vote: sed
   github.com/wso2-ballerina/module-ethereum/1d76190ec61c140f50688ef1bc761f0c00c4ee92/src/ethereum/tests/test.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/wso2-ballerina/module-github/83a65ab2ce459c2fdc491452ed70f49a3b7c77c8/src/githubwebhook3/github_webhook.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/wso2-ballerina/module-gmail/3a2c99c8d69d67ccfd020fd058b497bd876dcb07/src/gmail/tests/main_test.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/wso2-ballerina/module-sonarqube/0a877c967061633182a63c7884ebc46cd997b12f/src/sonarqube/sonarqube_constants.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/wso2-ballerina/module-twilio/39e8b99475a82b2018d2e8a9057e4f2036807dcd/src/twilio/twilio_endpoint.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/wso2-ballerina/module-twitter/1a5e19e1caebf42a3773a6da47c5f586b96cbb77/src/twitter/twitter_types.bal:
     annotations:
       linguist: Ballerina
+      linguist-extension: Ballerina
       vote: Ballerina
   github.com/wting/hackernews/5a3296417d23d1ecc901447af63dfc27af217f40/arc.arc:
     annotations:
       linguist: Arc
+      linguist-extension: Arc
       vote: Arc
   github.com/wwwscopin/SAS/7572694b302734b6a559f655417bfcbf39008f18/Nested ANOVA.sas:
     annotations:
       linguist: SAS
+      linguist-extension: SAS
       vote: SAS
   github.com/wyc/snippets/cd5cd0fb89892a691b6f7db614c967a622b327fa/j/euler/euler008.ijs:
     annotations:
       linguist: J
+      linguist-extension: J
       vote: J
   github.com/wzyuliyang/StreamOpencvMatDemo/e56de220a5200ef279f7e07ff1cb2f24b0cfb2a6/streamMatClient/deployment.pri:
     annotations:
       linguist: QMake
+      linguist-extension: QMake
       vote: QMake
   github.com/x0rz/EQGRP/0c2354ff1073099b2aa417030b3167ec29d7279c/Linux/bin/electricslide.pl:
     annotations:
       linguist: Perl
+      linguist-heuristics: Perl
       vote: Perl
   github.com/x64dbg/x64dbg/c65f65f3b10e167068ed7b55480d2b9b9a1f91e5/src/dbg/debugger.cpp:
     annotations:
       linguist: C++
+      linguist-extension: C++
       vote: C++
   github.com/x6j8x/factor-machine/d72479da768d6c8eaa26452a49f689dd18c0f0eb/http/machine/machine.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/x6j8x/factor-rdf/c0b94df96a614e3c4f5940c4cdd5968e7346b7fc/rdf/query/query.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/xLinkOut/telegram-udf-autoit/8fc5a9201d58aa4b452e07460f80abb4d1c1677f/include/JSON.au3:
     annotations:
       linguist: AutoIt
+      linguist-extension: AutoIt
       vote: AutoIt
   github.com/xamarin/Xamarin.Forms/6ee5c18011f89ea73fa385d50968116f2b941a06/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs:
     annotations:
       linguist: C#
+      linguist-heuristics: C#
       vote: C#
   github.com/xcore/doc_tips_and_tricks/55e481df3d2cd8c8d6a79b5aa5a898a0053992f8/module_tips_and_tricks/src/emit_p.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/xcore/hw_slicekit_system/2f06dc811e74389dc3a31c3be6ce1ec1a9142856/app_coreboard_chaintest/src/main.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/xcore/sc_adat/204d3d7b5528c2e97a0d87ea9ecbd57c04b217cd/app_adat_tx_direct_example/src/main.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/xcore/sc_canopen/da6e6f6cb3a7c5c59327d94c9203f47a896f3f8f/module_canopen/src/canopen_client.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/xcore/sc_dsp_filters/2b55737d94e1c4c9001d075b7e7becd4f4b900b6/module_fir/src/fir12_par.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/xcore/sc_dsp_transforms/b5c3ec8a5632c6f8f915599a156cd5cb87f92011/app_jpeg_example/src/test.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/xcore/sc_ethernet/f3c3dd14142d063f3f093f27cbf42bf01a92d008/tests/test_smi/src/main.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/xcore/sc_i2c/f011473ac662c7d90a35a0648c34830c51bc8991/app_i2c_single_port_demo/src/main.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/xcore/sc_i2s/9052dd638e5ae3346dfe1c7b3a386a61a88727fe/module_i2s_slave/src/i2s_slave.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/xcore/sc_jtag/f60fa13384118b15a958dc240c3eac67641f134d/module_jtag_otp_access/src/jtag_otp_access.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/xcore/sc_pwm/bcbe51b0847b42eea67f763f54864ff9108d0f5b/module_pwm_multibit_fast/src/pwmProgrammer.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/xcore/sc_spi/195c6bb6e82e6fef775a1ecceec872c264341a7b/app_spi_loopback_demo/src/spi_loopback_demo.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/xcore/sw_audio_analyzer/dd565027da06b4c2a891e2f5c57ce8847ca108ad/module_audio_analyzer/src/analyze_ramp.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/xcore/sw_foc_motor_control/5590594008745f8a5b0593ce5160ae28ce87960d/app_test_adc/src/adc_7265_interface.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/xesscorp/VHDL_Lib/426fa97c0ac16e465ce10f1bb5ad33834b0230f7/audio.vhd:
     annotations:
       linguist: VHDL
+      linguist-extension: VHDL
       vote: VHDL
   github.com/xetorthio/jedis/e7567dacbfefd231695a6765983a3a6d4c598539/src/main/java/redis/clients/jedis/Protocol.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/xi-editor/xi-editor/0b15cfe11c24d0b5f6f4fe74956f7e7308a28fdd/rust/plugin-lib/src/state_cache.rs:
     annotations:
       linguist: Rust
+      linguist-heuristics: Rust
       vote: Rust
   github.com/xianyi/OpenBLAS/4c6a4573582167c21a654076ea58db3c47987448/lapack-netlib/SRC/chegv_2stage.f:
     annotations:
       linguist: Fortran
+      linguist-heuristics: Fortran
       vote: Fortran
   github.com/xilopaint/alfred-things/b0473406bd5f29647385eedf51539fa68cfa5388/src/things.applescript:
     annotations:
       linguist: AppleScript
+      linguist-extension: AppleScript
       vote: AppleScript
   github.com/xizhuoyi/WordGraphing/5b00cbd1a33ba9e3080549eb8b9b59cb68fa9d6b/DATA/Q-words.dats:
     annotations:
       linguist: ATS
+      linguist-extension: ATS
       vote: ATS
   github.com/xlat/pbjson/16b3faaf5e72315812c2f45531a8cbec74f1e004/src/w_jsontest.srw:
     annotations:
       linguist: PowerBuilder
+      linguist-extension: PowerBuilder
       vote: PowerBuilder
   github.com/xmos/lib_mic_array/da2071ecb536d2a2b8d2ed642d7a5af1628fb5d9/tests/measure_phase_delay/src/measure_phase_delay.xc:
     annotations:
       linguist: XC
+      linguist-extension: XC
       vote: XC
   github.com/xnslong/yaml/27c75657c2fe9c7893cf5a98e7a7add2a9cd0723/yaml-awk/get_yaml_value.awk:
     annotations:
       linguist: Awk
+      linguist-extension: Awk
       vote: Awk
   github.com/xojo/XojoDraw/f60dde0aa5c4c26dc7db79f51a588efd2155be67/DrawView.xojo_code:
     annotations:
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/xojo/XojoUnit/cced62d5de26b348834ca8ffd76edb903d624655/Shared Resources/OptionParser/OptionMissingKeyException.xojo_code:
     annotations:
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/xojo/slack/2f2d3c744eb9adbe5664164f4387a1f5ebc5f22e/Slack.xojo_code:
     annotations:
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/xored/f4/b4aba9f9e88a0af5aba7233961152ae57114e32a/com.xored.f4.ui.text/fan/folding/CodeVisitor.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/xored/jsonrpc/f33ea9927a7879da5d64a277e6c367d59e80607b/jsonrpc/fan/core/SyncClient.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/xored/peg/8c99aeb56110d9428a29987dbbbdbdb3031baba4/src/test/GrammarBuilderTest.fan:
     annotations:
       linguist: Fantom
+      linguist-extension: Fantom
       vote: Fantom
   github.com/xorpd/asm_prog_ex/90cd6c43921349330b6b44ae19e162b08524c1c1/4_basic_assembly/0_branching/4_structured_branching/answers/2_write_code/0.asm:
     annotations:
@@ -16189,18 +19921,22 @@ files:
   github.com/xquery/xquerydoc/7ed5fdfe02431c9f7da5af7435559ea8cca83ce1/src/tests/examples/json.xqy:
     annotations:
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/xunhuang1995/AdaIN-style/6d8ac287f35010faf8feece4047bfe86c8c007d0/lib/ImageLoader.lua:
     annotations:
       linguist: Lua
+      linguist-extension: Lua
       vote: Lua
   github.com/xymus/nitcorn/a1c48886bab082caa4ac91d22bd3feffc105c08b/lib/nitcorn/http/auth.nit:
     annotations:
       linguist: Nit
+      linguist-extension: Nit
       vote: Nit
   github.com/y-taka-23/learn-you-a-frege/c5d7a0d7e6a12cd28a20069f2de6896e40887b29/src/main/frege/learnyou/chapter08/AlgebraicDataTypesIntro.fr:
     annotations:
       linguist: Frege
+      linguist-heuristics: Frege
       vote: Frege
   github.com/ya7gisa0/Unity-Raindrops/cb946d95774b2d09eea7be4ebcbcad3d86988191/Raindrop/Assets/Raindrop.shader:
     annotations:
@@ -16209,19 +19945,23 @@ files:
   github.com/yahoo/kafka-manager/a8896d7ff07443261f599b2096bd9c6d2c24be8b/app/models/form/TopicOperation.scala:
     annotations:
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/yahoojapan/hosted-danger/49eed9a1a1241719bd8fe0fec5aaced5d304e599/src/hosted-danger/modules/server_config.cr:
     annotations:
       linguist: Crystal
+      linguist-extension: Crystal
       vote: Crystal
   github.com/yamad/igorutils/6eafc6a246974796f7680e5746b9003b68937e3c/fileutils.ipf:
     annotations:
       linguist: IGOR Pro
+      linguist-extension: IGOR Pro
       vote: IGOR Pro
   github.com/yangchenyun/dbclass-exercises/2a60f4b57cbf12e617ac3acdfd31ffc4f9e40c17/3.xml-exercise/courses-xml/courses-extra.xq:
     annotations:
       human-smola: XQuery
       linguist: XQuery
+      linguist-extension: XQuery
       vote: XQuery
   github.com/yanghaoqin/1-16_RF_PWR_DIV/5316812a7f701bc9aec36a8e75d7528a98e09efb/bestsave.w:
     annotations:
@@ -16231,62 +19971,77 @@ files:
   github.com/yatli/fvim/99357d8bc7331f78ec98b6bcd780095d92eebf3f/Views/PopupMenu.xaml.fs:
     annotations:
       linguist: F#
+      linguist-heuristics: F#
       vote: F#
   github.com/yegor256/blog/9239549407bfc0943e2dc8341b12cb4b0f0f558f/_newsletters/2017/_september.liquid:
     annotations:
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/yglukhov/nimpy/0b5dabcc0be023f4e60c936c719188735446b65d/nimpy/py_types.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/yglukhov/nimx/4e4bffb8c439f8a5eed6697d7878814a48d421d8/nimx/serializers.nim:
     annotations:
       linguist: Nim
+      linguist-extension: Nim
       vote: Nim
   github.com/yi-editor/yi/40c42f7663f9aa531b57e59a0ef17ef8df0bcdaa/yi-language/test/Spec.hs:
     annotations:
       linguist: Haskell
+      linguist-extension: Haskell
       vote: Haskell
   github.com/yihui/knitr/393c62acb269421cb0ee54725919ad6efdc4f5db/R/hooks-rst.R:
     annotations:
       linguist: R
+      linguist-heuristics: R
       vote: R
   github.com/yloiseau/golo-tests/3f4166ba15eb85e24796a5de6e2775a822791cdb/BUGS/326-call-resolution/overloaded/simple/overloaded.golo:
     annotations:
       linguist: Golo
+      linguist-extension: Golo
       vote: Golo
   github.com/ymofen/diocp-v5/6effcce961c94579fecb2a1d7741ea8fca3029d8/source/utils_dvalue.pas:
     annotations:
       linguist: Pascal
+      linguist-extension: Pascal
       vote: Pascal
   github.com/yogiben/meteor-admin/4b20c82aa39addcc2cc5cb9f93b835c56a31e60d/lib/both/utils.coffee:
     annotations:
       linguist: CoffeeScript
+      linguist-extension: CoffeeScript
       vote: CoffeeScript
   github.com/youngerking1985/QML_Learn/eb42e9df6eb74f0a5e5dbcd9da6eb66786305f96/QMLPlugin1/MyPlugin/MyPlugin.pro:
     annotations:
       linguist: QMake
+      linguist-heuristics: QMake
       vote: QMake
   github.com/yrabbit/linkerbk/0ca0fee388a7493550f207ecdddf000877cc2e37/linker.w:
     annotations:
       linguist: CWeb
+      linguist-heuristics: CWeb
       vote: CWeb
   github.com/ytdl-org/youtube-dl/d64ec1242e9dec03ea2aa86b6e913db78c8619e0/youtube_dl/aes.py:
     annotations:
       linguist: Python
+      linguist-extension: Python
       vote: Python
   github.com/yuantiku/YTKNetwork/930c6662d3bb82eb49316b9159be8f81881bd9f4/YTKNetworkDemo/YTKNetworkDemo/RegisterApi.m:
     annotations:
       linguist: Objective-C
+      linguist-heuristics: Objective-C
       vote: Objective-C
   github.com/yuechenglei/VastChallenge2006/2e0c9c175e18133f470fc5ae4943f68a1ce933bf/static/news-processed/1101163520244.txt.p.NE:
     annotations:
       linguist: Nearley
+      linguist-extension: Nearley
       vote: Nearley
   github.com/yuenmichelle/dogescript/4f4d5bef4edbb63a0bb34eaf904a87e47268cca8/dogescript.djs:
     annotations:
       linguist: Dogescript
+      linguist-extension: Dogescript
       vote: Dogescript
   github.com/yuriprym/rusty-spring/c942b9f88f33a1604f66fe78e294122f4eebd6ff/src/tmp/test_units.rs:
     annotations:
@@ -16296,30 +20051,37 @@ files:
   github.com/yuyilei/Word-Ladder/bf0a5025b07ff5551d2a0272568f87d10b7c39f9/WordLadder/WordLadder.pro:
     annotations:
       linguist: QMake
+      linguist-heuristics: QMake
       vote: QMake
   github.com/z-rui/boom/eb59f13c73d27b3a6c9c81befa3a5496bd356936/boom.w:
     annotations:
       linguist: CWeb
+      linguist-heuristics: CWeb
       vote: CWeb
   github.com/z-rui/snake/c676a223f57e8d68f761e37b9a36b1cbb1afff24/snake.w:
     annotations:
       linguist: CWeb
+      linguist-heuristics: CWeb
       vote: CWeb
   github.com/zaatardigital/mqttlib-demo/ba77d11fd22490661a5251c708ce8149cf2b7228/source/MQTTLib/SocketAdapter.xojo_code:
     annotations:
       linguist: Xojo
+      linguist-extension: Xojo
       vote: Xojo
   github.com/zacx-z/Boo2Cs/8590872a412b5c033336566244845482c40ac499/translate.txl:
     annotations:
       linguist: TXL
+      linguist-extension: TXL
       vote: TXL
   github.com/zakhardage/Shopify-Wish-List/63f67b5e151767e7729d3ebba29a85a7d20eb0a0/collection.wishlist.liquid:
     annotations:
       linguist: Liquid
+      linguist-extension: Liquid
       vote: Liquid
   github.com/zapnap/upordown/8d0e61b342d211ac1a97485f50ff9816ba73864c/src/org/zerosum/upordown/StatusActivity.mirah:
     annotations:
       linguist: Mirah
+      linguist-extension: Mirah
       vote: Mirah
   github.com/zaraanry/simple-neural/7d47d832ec3e161934ba768ea758dd753649ff23/mendez.m:
     annotations:
@@ -16329,27 +20091,33 @@ files:
   github.com/zchen09/self-driving-vehicles/0699379227677f9deacd7bb86e248857fc323b03/main.nlogo:
     annotations:
       linguist: NetLogo
+      linguist-extension: NetLogo
       vote: NetLogo
   github.com/zdia/gorilla/18206d30a62f1a9843ba541d73e6c9460ec5fb56/sources/viewhelp.tcl:
     annotations:
       linguist: Tcl
+      linguist-extension: Tcl
       vote: Tcl
   github.com/zdx1989/programming-hive/d64f25d460c884b59c07680f995314e185bd46fe/src/main/scala/chap4/table.q:
     annotations:
       linguist: HiveQL
+      linguist-heuristics: HiveQL
       vote: HiveQL
   github.com/zealic/autorosvpn/3b24921342c96e1d312051dfbc3255311ef7430b/chnroutes-chinanet.rsc:
     annotations:
       linguist: Rascal
+      linguist-extension: Rascal
       vote: Rascal
   github.com/zefhemel/nix-docker/8c176483705d0129f40928761a34d54e41fdac87/nix-docker/modules/config/docker.nix:
     annotations:
       linguist: Nix
+      linguist-extension: Nix
       vote: Nix
   github.com/zendesk/zendesk_jwt_sso_examples/92bb24bf47cc60c48a27ddac512e760a9e068cd5/classic_asp_jwt.asp:
     annotations:
       human-smola: Classic ASP
       linguist: Classic ASP
+      linguist-extension: Classic ASP
       vote: Classic ASP
   github.com/zenware/FizzBuzz/807ab8c4f346c287ca4b2b75cd01c2af5fc0b7ae/brainfuck.bf:
     annotations:
@@ -16358,89 +20126,112 @@ files:
   github.com/zeroflag/punyforth/f0f140b137ac1fdb9c83de52de5c3cfea7794d3f/arch/esp8266/forth/ntp.forth:
     annotations:
       linguist: Forth
+      linguist-extension: Forth
       vote: Forth
   github.com/zeroxthreef/greenit/8fc7229f9392d2a306be25ab0f6362782d51c2d0/src/greenit.pike:
     annotations:
       linguist: Pike
+      linguist-extension: Pike
+      linguist-shebang: Pike
       vote: Pike
   github.com/zetas2015/unicode/edf0d6c4ed3f0bd555a361028d8e597a3c9d534a/unicodesTests.grace:
     annotations:
       linguist: Grace
+      linguist-extension: Grace
       vote: Grace
   github.com/zh-google-styleguide/zh-google-styleguide/f837c554bbdfdd1a32d83df41fb16c091b5551db/Makefile:
     annotations:
       linguist: Makefile
+      linguist-filename: Makefile
       vote: Makefile
   "github.com/zhaoolee/ChromeAppHeroes/0d821c77c2a7b0da4c9df59c08df0470ba9d671a/\u76F8\u5173\u8D44\u6E90/bing/bing.py":
     annotations:
       linguist: Python
+      linguist-extension: Python
       vote: Python
   github.com/zhengtianzuo/QtQuickExamples/9f87989704ba20b054fe2ce3e9763a0d741e3cb0/QmlSign/main.qml:
     annotations:
       linguist: QML
+      linguist-extension: QML
       vote: QML
   github.com/zhousoft/TsingHuaDataStructOj/ed5687fca61fdd6e22cadc2751fd642a26a2722d/BroadCast/deployment.pri:
     annotations:
       linguist: QMake
+      linguist-extension: QMake
       vote: QMake
   github.com/zhuowei/MetalShaderTools/820e4301bc85c472bf5c44ebf2c8660fec0d0f70/sampleshader/out_fragmentShader.air.ll:
     annotations:
       linguist: LLVM
+      linguist-extension: LLVM
       vote: LLVM
   github.com/zhuwenzhen/instance-segmentation/fc395b8f60ae518379bfd5959ff868d2766c8148/src/Utility.wl:
     annotations:
       human-smola: Wolfram Language
       linguist: Wolfram Language
+      linguist-extension: Wolfram Language
       vote: Wolfram Language
   github.com/zick/FactorLisp/9069bbee2358b82707b745263208a9d6842e0b58/lisp.factor:
     annotations:
       linguist: Factor
+      linguist-extension: Factor
       vote: Factor
   github.com/zick/IokeLisp/881e508c968e0c052d8c5db0837edf51331887b3/iokelisp.ik:
     annotations:
       linguist: Ioke
+      linguist-extension: Ioke
       vote: Ioke
   github.com/ziggybcn/harpl-project/059fe0cdf1728432c381c8ff7b4284dfd9fe8b26/harplvm/runtime/stringops.monkey:
     annotations:
       human-smola: Monkey
       linguist: Monkey
+      linguist-extension: Monkey
       vote: Monkey
   github.com/ziman/lightyear/6f56439ea4bdba6a3ad4a11221c6028ed9d74047/Lightyear/Combinators.idr:
     annotations:
       linguist: Idris
+      linguist-extension: Idris
       vote: Idris
   github.com/zio/zio/e50c7c381ef1b922caed54d8b8caa1c7895e7245/test-tests/shared/src/test/scala/zio/test/mock/ExpectationSpecUtils.scala:
     annotations:
       linguist: Scala
+      linguist-extension: Scala
       vote: Scala
   github.com/zk00006/OpenTLD/953e2df96575ba9e3e0720b8f91e936c26c9b2e3/run_TLD.m:
     annotations:
       human-smola: MATLAB
       linguist: MATLAB
+      linguist-heuristics: MATLAB
       vote: MATLAB
   github.com/zlrth/shen-rss/2ccab7bdd82489fe4a16cb7ef3960755242048ec/xml.shen:
     annotations:
       human-smola: Shen
       linguist: Shen
+      linguist-extension: Shen
       vote: Shen
   github.com/zo-chu/pizza_cutter/2953dfa50764c1a17a17a96ee6c488598ff7dbf2/pizza cutter.lol:
     annotations:
       linguist: LOLCODE
+      linguist-extension: LOLCODE
       vote: LOLCODE
   github.com/zv/SICP-guile/edb21a0cd7cecce344aad2912d195d11e935f5c7/sicp4.scm:
     annotations:
       human-smola: Scheme
       linguist: Racket
+      linguist-extension: Scheme
+      linguist-modeline: Scheme
       vote: Scheme
   github.com/zxing/zxing/cfe86846696ad13fa12fc6d426a86a8e63b1647a/core/src/test/java/com/google/zxing/qrcode/decoder/ModeTestCase.java:
     annotations:
       linguist: Java
+      linguist-extension: Java
       vote: Java
   github.com/zyedidia/Literate/e20c5c86713701d4d17fd2881779d758a27a3e5a/lit/tangle/src/parser.d:
     annotations:
       linguist: D
+      linguist-heuristics: D
       vote: D
   github.com/zymme/teststuff/24d706fe0aef2d122c687a9af0f8806a4464caf5/src/main/resources/qby0800-response.dwl:
     annotations:
       linguist: DataWeave
+      linguist-extension: DataWeave
       vote: DataWeave

--- a/data/meta.yml
+++ b/data/meta.yml
@@ -1136,12 +1136,9 @@ languages:
     maps_to:
       linguist:
       - Fortran
+      - Fortran Free Form
       rosetta_code:
       - Fortran
-  Fortran Free Form:
-    maps_to:
-      linguist:
-      - Fortran Free Form
   Fortress:
     maps_to:
       rosetta_code:

--- a/tools/classify_linguist_strategies.py
+++ b/tools/classify_linguist_strategies.py
@@ -1,0 +1,52 @@
+import json
+import logging
+import multiprocessing
+import os
+import subprocess
+
+from .common import *
+
+logger = multiprocessing.log_to_stderr()
+logger.setLevel(logging.DEBUG)
+
+
+def classify_linguist_strategies(path: str, ann):
+    meta = Meta()
+    full_path = os.path.join("data", path)
+    result = subprocess.run(
+        ["ruby", "tools/linguist_wrapper.rb", full_path],
+        shell=False,
+        check=True,
+        capture_output=True,
+    )
+    result = result.stdout.decode("utf-8").strip()
+    result = json.loads(result)
+    for strategy, languages in result.items():
+        if len(languages) != 1:
+            continue
+        language: str = languages[0]
+        language = meta.to_normalized_language(dataset="linguist", lang=language)
+        ann[f"linguist-{strategy}"] = language
+    return ann
+
+
+def _job(args):
+    return (args[0], classify_linguist_strategies(args[0], args[1]))
+
+
+def classify_linguist_strategies_all(dataset):
+    inputs = [(p, d["annotations"]) for p, d in dataset.data["files"].items()]
+    with multiprocessing.Pool() as p:
+        updates = p.map(_job, inputs)
+    for path, ann in updates:
+        dataset.data["files"][path]["annotations"] = ann
+
+
+def main():
+    dataset = Dataset()
+    classify_linguist_strategies_all(dataset)
+    dataset.save()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/gen_meta.py
+++ b/tools/gen_meta.py
@@ -27,6 +27,7 @@ def add_linguist_languages(commit: str, meta: Meta):
 
     norm_langs = {
         "Cuda": "CUDA",
+        "Fortran Free Form": "Fortran",  # TODO: We might want to split this.
         "JSONLD": "JSON-LD",
         "PLSQL": "PL/SQL",
         "PLpgSQL": "PL/pgSQL",

--- a/tools/linguist_wrapper.rb
+++ b/tools/linguist_wrapper.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'linguist'
+
+path = ARGV[0]
+
+blob = Linguist::FileBlob.new(path)
+
+res = {}
+
+res['modeline'] = Linguist::Strategy::Modeline.call(blob, [])
+res['filename'] = Linguist::Strategy::Filename.call(blob, [])
+res['shebang'] = Linguist::Shebang.call(blob, [])
+res['extension'] = Linguist::Strategy::Extension.call(blob, [])
+res['xml'] = Linguist::Strategy::XML.call(blob, [])
+res['manpage'] = Linguist::Strategy::Manpage.call(blob, [])
+res['heuristics'] = Linguist::Heuristics.call(blob, res['extension'])
+#begin
+#    res['classifier-ext'] = Linguist::Classifier.call(blob, res['extension'])
+#rescue
+#    #TODO: https://github.com/github/linguist/issues/4995
+#end
+
+puts JSON.generate(res)


### PR DESCRIPTION
- Add annotations for each individual github/linguist strategy (except
the Bayesian classifier at the moment).

- Readjust voting labels.

- Map linguist's Fortran Free Form to Fortran at the moment.